### PR TITLE
Add inline cell editing to data tables

### DIFF
--- a/backend/app/api/routes/qbsd.py
+++ b/backend/app/api/routes/qbsd.py
@@ -14,11 +14,14 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from app.models.session import VisualizationSession, SessionType, SessionMetadata, FilterSortRequest
 from app.models.qbsd import QBSDConfig, QBSDStatus
 from app.services.qbsd_runner import QBSDRunner
+from app.services.data_editor import DataEditor
 from app.services import websocket_manager, session_manager
 
 router = APIRouter()
 # Create shared QBSD runner instance with shared managers
 qbsd_runner = QBSDRunner(websocket_manager=websocket_manager, session_manager=session_manager)
+# Create data editor instance
+data_editor = DataEditor()
 
 @router.post("/configure", response_model=dict)
 async def configure_qbsd(config: QBSDConfig):
@@ -144,6 +147,26 @@ async def get_qbsd_data_with_filters(
 async def get_qbsd_data(session_id: str, page: int = 0, page_size: int = 50):
     """Get extracted data (backward compatible, no filtering)."""
     return await get_qbsd_data_with_filters(session_id, page, page_size, None)
+
+
+@router.put("/cell/{session_id}")
+async def update_cell(session_id: str, row_name: str, column: str, value: str):
+    """Update a single cell value in the data table."""
+    try:
+        session = session_manager.get_session(session_id)
+        if not session:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        result = await data_editor.update_cell(session_id, row_name, column, value)
+        return result
+
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
 
 @router.post("/stop/{session_id}")
 async def stop_qbsd(session_id: str):

--- a/backend/app/services/data_editor.py
+++ b/backend/app/services/data_editor.py
@@ -1,0 +1,104 @@
+"""
+Service for editing individual cells in data tables.
+Handles updates to JSONL data files for both load and QBSD sessions.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+
+class DataEditor:
+    """Handles cell-level data updates in JSONL data files."""
+
+    def __init__(self, work_dir: str = "./qbsd_work", data_dir: str = "./data"):
+        self.work_dir = Path(work_dir)
+        self.data_dir = Path(data_dir)
+
+    def _find_data_file(self, session_id: str) -> Optional[Path]:
+        """
+        Find the data file for a session.
+        Checks multiple locations in priority order:
+        1. qbsd_work/{session_id}/extracted_data.jsonl
+        2. qbsd_work/{session_id}/data.jsonl
+        3. data/{session_id}/data.jsonl
+        """
+        candidates = [
+            self.work_dir / session_id / "extracted_data.jsonl",
+            self.work_dir / session_id / "data.jsonl",
+            self.data_dir / session_id / "data.jsonl",
+        ]
+        for path in candidates:
+            if path.exists():
+                return path
+        return None
+
+    async def update_cell(
+        self, session_id: str, row_name: str, column: str, value: Any
+    ) -> dict:
+        """
+        Update a specific cell value in the session's data file.
+
+        Args:
+            session_id: The session identifier
+            row_name: The row_name field to identify the row
+            column: The column name to update
+            value: The new value for the cell
+
+        Returns:
+            dict with status and details
+
+        Raises:
+            FileNotFoundError: If no data file exists for the session
+            ValueError: If the row is not found
+        """
+        data_file = self._find_data_file(session_id)
+        if not data_file:
+            raise FileNotFoundError(f"No data file found for session {session_id}")
+
+        # Read all rows
+        rows = []
+        with open(data_file, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    rows.append(json.loads(line))
+
+        # Find and update the target row
+        updated = False
+        for row in rows:
+            current_row_name = row.get("row_name") or row.get("_row_name")
+            if current_row_name == row_name:
+                # Update the cell value
+                if "data" in row and isinstance(row["data"], dict):
+                    # New format with nested 'data' key
+                    if column in row["data"]:
+                        cell_value = row["data"][column]
+                        # Handle QBSD answer format
+                        if isinstance(cell_value, dict) and "answer" in cell_value:
+                            cell_value["answer"] = value
+                        else:
+                            row["data"][column] = value
+                    else:
+                        row["data"][column] = value
+                else:
+                    # Old flat format
+                    row[column] = value
+                updated = True
+                break
+
+        if not updated:
+            raise ValueError(f"Row with row_name '{row_name}' not found")
+
+        # Write back all rows
+        with open(data_file, "w", encoding="utf-8") as f:
+            for row in rows:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+        return {
+            "status": "success",
+            "session_id": session_id,
+            "row_name": row_name,
+            "column": column,
+            "value": value,
+        }
+

--- a/frontend/src/components/DataTable/DataTable.tsx
+++ b/frontend/src/components/DataTable/DataTable.tsx
@@ -39,7 +39,8 @@ import {
 } from '@/components/ui/tooltip';
 
 import { PaginatedData, CellValue, DataRow, ModalContent, QBSDAnswerWithExcerpts } from '../../types';
-import { sessionAPI } from '../../services/api';
+import { sessionAPI, qbsdAPI } from '../../services/api';
+import EditableCell from './EditableCell';
 import {
   formatColumnName,
   isExcerptContent,
@@ -263,7 +264,7 @@ const DataTable: React.FC<DataTableProps> = ({
   );
 
   // Fetch data with pagination, filtering, and sorting (server-side)
-  const { data: fetchedData } = useQuery(
+  const { data: fetchedData, refetch: refetchData } = useQuery(
     [
       'data',
       sessionId,
@@ -289,6 +290,12 @@ const DataTable: React.FC<DataTableProps> = ({
       refetchInterval: sessionType === 'qbsd' ? QBSD_REFRESH_INTERVAL : false,
     }
   );
+
+  // Cell edit handler
+  const handleCellUpdate = useCallback(async (rowName: string, column: string, value: string) => {
+    await qbsdAPI.updateCell(sessionId, rowName, column, value);
+    refetchData();
+  }, [sessionId, refetchData]);
 
   const fetchedOrInitialData = fetchedData ?? initialData ?? EMPTY_DATA;
 
@@ -1225,7 +1232,18 @@ const DataTable: React.FC<DataTableProps> = ({
                         ) : (
                           // Regular frozen column (no spanning)
                           <td className="px-4 py-3 min-w-[150px] max-w-[250px] sticky left-0 bg-background border-r">
-                            {formatCellValue(getFrozenCellValue(), frozenColumn, row)}
+                            {!frozenColumn.startsWith('_') && row.row_name ? (
+                              <EditableCell
+                                value={getFrozenCellValue()}
+                                rowName={row.row_name}
+                                column={frozenColumn}
+                                onSave={handleCellUpdate}
+                              >
+                                {formatCellValue(getFrozenCellValue(), frozenColumn, row)}
+                              </EditableCell>
+                            ) : (
+                              formatCellValue(getFrozenCellValue(), frozenColumn, row)
+                            )}
                           </td>
                         )
                       )}
@@ -1264,9 +1282,23 @@ const DataTable: React.FC<DataTableProps> = ({
                           );
                         }
 
+                        // Determine if cell is editable (not metadata columns, has row_name)
+                        const isEditable = !column.startsWith('_') && !!row.row_name;
+
                         return (
                           <td key={column} className="px-4 py-3 min-w-[120px] sm:min-w-[150px]">
-                            {formatCellValue(cellValue, column, row)}
+                            {isEditable ? (
+                              <EditableCell
+                                value={cellValue}
+                                rowName={row.row_name || ''}
+                                column={column}
+                                onSave={handleCellUpdate}
+                              >
+                                {formatCellValue(cellValue, column, row)}
+                              </EditableCell>
+                            ) : (
+                              formatCellValue(cellValue, column, row)
+                            )}
                           </td>
                         );
                       })}

--- a/frontend/src/components/DataTable/EditableCell.tsx
+++ b/frontend/src/components/DataTable/EditableCell.tsx
@@ -1,0 +1,169 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { Check, X, Pencil } from 'lucide-react';
+import { CellValue } from '../../types';
+
+interface EditableCellProps {
+  value: CellValue;
+  rowName: string;
+  column: string;
+  children: React.ReactNode;
+  onSave: (rowName: string, column: string, value: string) => Promise<void>;
+  disabled?: boolean;
+}
+
+/**
+ * Extracts the editable string value from a CellValue.
+ * Handles QBSD objects with 'answer' field, arrays, etc.
+ */
+function getEditableValue(value: CellValue): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (typeof value === 'object' && 'answer' in value) {
+    return String((value as { answer: unknown }).answer ?? '');
+  }
+  if (Array.isArray(value)) return value.join(', ');
+  return JSON.stringify(value);
+}
+
+/**
+ * A cell wrapper that enables inline editing on double-click.
+ */
+const EditableCell: React.FC<EditableCellProps> = ({
+  value,
+  rowName,
+  column,
+  children,
+  onSave,
+  disabled = false,
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Extract editable value when entering edit mode
+  const startEditing = useCallback(() => {
+    if (disabled) return;
+    setEditValue(getEditableValue(value));
+    setIsEditing(true);
+  }, [value, disabled]);
+
+  // Focus input when entering edit mode
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    if (isSaving) return;
+    const originalValue = getEditableValue(value);
+    if (editValue === originalValue) {
+      setIsEditing(false);
+      return;
+    }
+    setIsSaving(true);
+    setError(null);
+    try {
+      await onSave(rowName, column, editValue);
+      setIsEditing(false);
+    } catch (err) {
+      console.error('Failed to save cell:', err);
+      setError('Failed to save. Please try again.');
+      // Keep editing mode open on error
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setEditValue('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === 'Escape') {
+      handleCancel();
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <div className="flex flex-col gap-1 min-w-[100px]">
+        <div className="flex items-center gap-1">
+          <Input
+            ref={inputRef}
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={() => {
+              // Small delay to allow button clicks to register
+              setTimeout(() => {
+                if (!isSaving) handleCancel();
+              }, 150);
+            }}
+            disabled={isSaving}
+            className={cn("h-7 text-sm py-0 px-2", error && "border-red-500")}
+          />
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={isSaving}
+            className="p-1 hover:bg-green-100 dark:hover:bg-green-900 rounded text-green-600"
+            title="Save (Enter)"
+          >
+            <Check className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={handleCancel}
+            disabled={isSaving}
+            className="p-1 hover:bg-red-100 dark:hover:bg-red-900 rounded text-red-600"
+            title="Cancel (Escape)"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        {error && <span className="text-xs text-red-500">{error}</span>}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "group flex items-start gap-1",
+        !disabled && "cursor-pointer"
+      )}
+      onDoubleClick={startEditing}
+      title={disabled ? undefined : "Double-click to edit"}
+    >
+      {!disabled && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            startEditing();
+          }}
+          className="flex-shrink-0 p-0.5 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-muted rounded mt-0.5"
+          title="Edit"
+        >
+          <Pencil className="h-3 w-3 text-muted-foreground" />
+        </button>
+      )}
+      <div className="flex-1 min-w-0">{children}</div>
+    </div>
+  );
+};
+
+export default EditableCell;
+

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -299,6 +299,18 @@ export const qbsdAPI = {
     link.click();
     window.URL.revokeObjectURL(url);
   },
+
+  updateCell: async (
+    sessionId: string,
+    rowName: string,
+    column: string,
+    value: string
+  ): Promise<{ status: string; session_id: string; row_name: string; column: string; value: string }> => {
+    const response = await api.put(`/qbsd/cell/${sessionId}`, null, {
+      params: { row_name: rowName, column, value }
+    });
+    return response.data;
+  },
 };
 
 // Common session API


### PR DESCRIPTION
Users need to edit table cell values directly in the UI without external tools. This enables quick corrections and data refinement during analysis.

Changes:
- Add EditableCell component with double-click and pencil icon editing
- Create DataEditor service to persist cell updates to JSONL files
- Add PUT /api/qbsd/cell/{session_id} endpoint for cell updates
- Integrate editing into DataTable with proper error handling
- Ensure edited values are included in CSV exports