### PR TITLE
feat: Add concurrency control and multi-user support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ QueryDiscovery/
   - `upload_document_processor.py` - Document processing
   - `session_manager.py` - Session state management
 - `app/core/config.py` - Configuration and environment variables
+- `app/core/exceptions.py` - Custom exceptions (CapacityExceededError)
 - `app/models/` - Pydantic models (session.py, qbsd.py, upload.py)
 - `requirements.txt` - Python dependencies
 - `railway.json` - Railway deployment configuration
@@ -155,6 +156,10 @@ SUPABASE_KEY=your-anon-key
 DEFAULT_MAX_TOKENS=4096
 DEFAULT_TEMPERATURE=0.7
 DEFAULT_RETRIEVAL_K=5
+
+# Concurrency (optional, defaults shown)
+MAX_CONCURRENT_SESSIONS=5      # Max parallel LLM-heavy operations
+QBSD_THREAD_POOL_SIZE=6        # Thread pool workers for blocking calls
 ```
 
 **Frontend (.env):**
@@ -187,6 +192,28 @@ for public/production use. Set `DEVELOPER_MODE=true` to unlock all features.
 2. Resolve the effective value using `DEVELOPER_MODE` (same pattern as `MAX_DOCUMENTS`)
 3. Return it in `/api/config` if the frontend needs it
 4. Update this table
+
+### Concurrency & Multi-User Support
+
+The backend supports multiple concurrent QBSD sessions (target: 5-8 on Railway 8 vCPU / 8 GB RAM). Key architectural decisions:
+
+**Thread Pool**: All blocking LLM/embedding calls from `qbsd-lib` are offloaded via `loop.run_in_executor(qbsd_thread_pool, ...)` using `functools.partial` to avoid closure capture issues. The shared `ThreadPoolExecutor` lives in `app/services/__init__.py`.
+
+**Concurrency Limiter**: A shared `ConcurrencyLimiter` in `app/services/__init__.py` tracks active long-running operations across all services (QBSD creation, reextraction, continue discovery, document processing). Routes call `acquire()` before scheduling work and services call `release()` in `finally` blocks. Exceeding capacity returns HTTP 503 with a friendly message.
+
+**Thread Safety**:
+- `SessionManager` uses `threading.Lock` (accessed from both event loop and thread pool workers)
+- `WebSocketManager` uses `asyncio.Lock` with snapshot-before-broadcast pattern (event-loop only)
+- `QBSDRunner`, `ReextractionService`, `ContinueDiscoveryService`, `SchemaManager`, `UploadDocumentProcessor` all use `threading.Lock` for stop flags and running task dicts (stop flags are read from thread pool workers via `should_stop` callbacks)
+
+**Frontend Capacity Handling**: HTTP 503 from the backend shows an amber "Server Busy" banner in `QBSDMonitor` (not a red error) with a "Try Again" button and 30-second auto-dismiss. Other flows (continue discovery, reextraction, reprocess, document processing) detect 503 and show the backend's friendly message.
+
+**Observability**: All concurrency logs use the `[concurrency]` prefix for easy filtering in Railway. The `/api/config` endpoint returns `active_sessions` and `max_concurrent_sessions`.
+
+| Setting                  | Env Var                    | Default |
+|--------------------------|----------------------------|---------|
+| Max concurrent sessions  | `MAX_CONCURRENT_SESSIONS`  | 5       |
+| Thread pool workers      | `QBSD_THREAD_POOL_SIZE`    | 6       |
 
 ### Using qbsd-lib Directly
 ```bash

--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -21,8 +21,9 @@ from app.models.upload import (
 )
 from app.services.file_parser import FileParser
 from app.services.session_manager import SessionManager
-from app.services import session_manager
+from app.services import session_manager, concurrency_limiter
 from app.storage import get_storage
+from app.core.exceptions import CapacityExceededError
 
 router = APIRouter()
 
@@ -1295,11 +1296,14 @@ async def process_documents(session_id: str, background_tasks: BackgroundTasks, 
         
         session_manager.update_session(session)
         
+        # Reserve a concurrency slot
+        await concurrency_limiter.acquire(session_id, "upload_extraction")
+
         # Start processing in background
         background_tasks.add_task(processor.process_documents, session_id)
-        
+
         print(f"DEBUG: Document processing started in background for session: {session_id}")
-        
+
         return {
             "status": "success",
             "message": "Document processing started",
@@ -1307,10 +1311,15 @@ async def process_documents(session_id: str, background_tasks: BackgroundTasks, 
             "total_documents": len(session.metadata.uploaded_documents),
             "schema_columns": len(session.metadata.extracted_schema['schema'])
         }
-        
+
+    except CapacityExceededError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except RuntimeError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except HTTPException:
         raise
     except Exception as e:
+        await concurrency_limiter.release(session_id)
         print(f"DEBUG: Exception in process_documents: {e}")
         import traceback
         traceback.print_exc()

--- a/backend/app/api/routes/qbsd.py
+++ b/backend/app/api/routes/qbsd.py
@@ -15,8 +15,9 @@ from app.models.session import VisualizationSession, SessionType, SessionMetadat
 from app.models.qbsd import QBSDConfig, QBSDStatus, CostEstimate, CostEstimateRequest, PhaseEstimate, DocumentStats
 from app.services.qbsd_runner import QBSDRunner
 from app.services.data_editor import DataEditor
-from app.services import websocket_manager, session_manager
+from app.services import websocket_manager, session_manager, concurrency_limiter
 from app.core.config import MAX_DOCUMENTS, DEVELOPER_MODE
+from app.core.exceptions import CapacityExceededError
 from app.storage import get_storage
 
 from qbsd.core.cost_estimator import estimate_from_config
@@ -288,13 +289,25 @@ async def run_qbsd(session_id: str, background_tasks: BackgroundTasks):
         session = session_manager.get_session(session_id)
         if not session or session.type != SessionType.QBSD:
             raise HTTPException(status_code=404, detail="QBSD session not found")
-        
-        # Start QBSD in background
+
+        # Reserve a concurrency slot (raises on capacity/duplicate)
+        await concurrency_limiter.acquire(session_id, "qbsd_creation")
+
+        # Start QBSD in background (slot released in run_qbsd's finally block)
         background_tasks.add_task(qbsd_runner.run_qbsd, session_id)
-        
+
         return {"message": "QBSD execution started", "session_id": session_id}
-        
+
+    except CapacityExceededError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except RuntimeError as e:
+        # Duplicate session execution
+        raise HTTPException(status_code=409, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
+        # Release slot if we acquired but failed before scheduling
+        await concurrency_limiter.release(session_id)
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/status/{session_id}", response_model=QBSDStatus)

--- a/backend/app/api/routes/schema.py
+++ b/backend/app/api/routes/schema.py
@@ -18,7 +18,8 @@ from app.services.websocket_manager import WebSocketManager
 from app.services.schema_manager import SchemaManager
 from app.services.reextraction_service import ReextractionService
 from app.services.continue_discovery_service import ContinueDiscoveryService
-from app.services import session_manager, websocket_manager
+from app.services import session_manager, websocket_manager, concurrency_limiter
+from app.core.exceptions import CapacityExceededError
 
 router = APIRouter(tags=["schema"])
 
@@ -410,13 +411,16 @@ async def reprocess_documents(
         session = session_manager.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
-        
+
         # Validate columns if specified
         columns_to_process = reprocess_request.columns or [col.name for col in session.columns]
         for col_name in columns_to_process:
             if not any(col.name == col_name for col in session.columns):
                 raise HTTPException(status_code=404, detail=f"Column '{col_name}' not found")
-        
+
+        # Reserve a concurrency slot
+        await concurrency_limiter.acquire(session_id, "reprocess")
+
         # Schedule reprocessing
         background_tasks.add_task(
             schema_manager.reprocess_documents,
@@ -425,15 +429,22 @@ async def reprocess_documents(
             reprocess_request.incremental,
             reprocess_request.force_reprocess
         )
-        
+
         return {
             "status": "success",
             "message": "Document reprocessing started",
             "columns": columns_to_process,
             "incremental": reprocess_request.incremental
         }
-        
+
+    except CapacityExceededError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except RuntimeError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
+        await concurrency_limiter.release(session_id)
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/reprocessing-status/{session_id}")
@@ -935,17 +946,29 @@ async def start_reextraction(
             has_api_key = 'api_key' in request.llm_config and request.llm_config['api_key']
             print(f"DEBUG: Saved user LLM config for re-extraction: {config_for_log}, api_key={'present' if has_api_key else 'MISSING'}")
 
-        result = await reextraction_service.start_reextraction(
-            session_id,
-            request.columns
-        )
+        # Reserve a concurrency slot
+        await concurrency_limiter.acquire(session_id, "reextraction")
+
+        try:
+            result = await reextraction_service.start_reextraction(
+                session_id,
+                request.columns
+            )
+        except Exception:
+            # Release slot if start_reextraction fails before creating its task
+            await concurrency_limiter.release(session_id)
+            raise
 
         return ReextractionResponse(**result)
 
+    except CapacityExceededError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except RuntimeError as e:
-        raise HTTPException(status_code=503, detail=str(e))
+        raise HTTPException(status_code=409, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -1152,23 +1175,35 @@ async def start_continue_discovery(
         if not request.llm_config:
             raise HTTPException(status_code=400, detail="LLM configuration is required")
 
-        result = await continue_discovery_service.start_continue_discovery(
-            session_id=session_id,
-            document_source=request.document_source,
-            llm_config=request.llm_config,
-            cloud_dataset=request.cloud_dataset,
-            retriever_config=request.retriever_config,
-            max_keys_schema=request.max_keys_schema,
-            documents_batch_size=request.documents_batch_size,
-            bypass_limit=request.bypass_limit
-        )
+        # Reserve a concurrency slot
+        await concurrency_limiter.acquire(session_id, "continue_discovery")
+
+        try:
+            result = await continue_discovery_service.start_continue_discovery(
+                session_id=session_id,
+                document_source=request.document_source,
+                llm_config=request.llm_config,
+                cloud_dataset=request.cloud_dataset,
+                retriever_config=request.retriever_config,
+                max_keys_schema=request.max_keys_schema,
+                documents_batch_size=request.documents_batch_size,
+                bypass_limit=request.bypass_limit
+            )
+        except Exception:
+            # Release slot if start fails before creating its task
+            await concurrency_limiter.release(session_id)
+            raise
 
         return ContinueDiscoveryResponse(**result)
 
+    except CapacityExceededError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except RuntimeError as e:
-        raise HTTPException(status_code=503, detail=str(e))
+        raise HTTPException(status_code=409, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -1224,18 +1259,31 @@ async def confirm_new_columns(
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
 
-        result = await continue_discovery_service.confirm_and_start_extraction(
-            operation_id=operation_id,
-            selected_columns=request.selected_columns,
-            row_selection=request.row_selection,
-            selected_rows=request.selected_rows,
-            llm_config=request.llm_config
-        )
+        # Reserve a concurrency slot for extraction phase
+        await concurrency_limiter.acquire(session_id, "continue_discovery_extraction")
+
+        try:
+            result = await continue_discovery_service.confirm_and_start_extraction(
+                operation_id=operation_id,
+                selected_columns=request.selected_columns,
+                row_selection=request.row_selection,
+                selected_rows=request.selected_rows,
+                llm_config=request.llm_config
+            )
+        except Exception:
+            await concurrency_limiter.release(session_id)
+            raise
 
         return ConfirmColumnsResponse(**result)
 
+    except CapacityExceededError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except RuntimeError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/app/api/routes/websocket.py
+++ b/backend/app/api/routes/websocket.py
@@ -35,7 +35,7 @@ async def websocket_progress(websocket: WebSocket, session_id: str):
 
     try:
         # Add connection to manager
-        websocket_manager.add_connection(session_id, websocket)
+        await websocket_manager.add_connection(session_id, websocket)
         print(f"🔌 WebSocket REGISTERED: {session_id} (total: {websocket_manager.get_connection_count(session_id)})")
 
         # Send initial connection confirmation
@@ -85,7 +85,7 @@ async def websocket_progress(websocket: WebSocket, session_id: str):
             await heartbeat_task
         except asyncio.CancelledError:
             pass
-        websocket_manager.remove_connection(session_id, websocket)
+        await websocket_manager.remove_connection(session_id, websocket)
         print(f"🔌 WebSocket REMOVED: {session_id} (remaining: {websocket_manager.get_connection_count(session_id)})")
 
 
@@ -112,7 +112,7 @@ async def websocket_logs(websocket: WebSocket, session_id: str):
     heartbeat_task = asyncio.create_task(server_heartbeat())
 
     try:
-        websocket_manager.add_log_connection(session_id, websocket)
+        await websocket_manager.add_log_connection(session_id, websocket)
 
         await websocket.send_json({
             "type": "log_connected",
@@ -145,5 +145,5 @@ async def websocket_logs(websocket: WebSocket, session_id: str):
             await heartbeat_task
         except asyncio.CancelledError:
             pass
-        websocket_manager.remove_log_connection(session_id, websocket)
+        await websocket_manager.remove_log_connection(session_id, websocket)
         print(f"🔌 Log WebSocket REMOVED: {session_id}")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -111,6 +111,10 @@ MAX_DOCUMENTS = int(os.environ.get("MAX_DOCUMENTS", str(
     RELEASE_CONFIG["max_documents"] if not DEVELOPER_MODE else 10_000
 )))
 
+# ── Concurrency Configuration ────────────────────────────────────
+MAX_CONCURRENT_SESSIONS = int(os.environ.get("MAX_CONCURRENT_SESSIONS", "5"))
+QBSD_THREAD_POOL_SIZE = int(os.environ.get("QBSD_THREAD_POOL_SIZE", "6"))
+
 # Status Messages
 HEALTH_CHECK_MESSAGE = "healthy"
 API_ROOT_MESSAGE = "QBSD Visualization API"

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -1,0 +1,14 @@
+"""Application-level exceptions."""
+
+
+class CapacityExceededError(Exception):
+    """Raised when the server is at maximum concurrent session capacity."""
+
+    def __init__(self, active_count: int, max_count: int):
+        self.active_count = active_count
+        self.max_count = max_count
+        super().__init__(
+            f"The server is currently busy processing other requests "
+            f"({active_count}/{max_count} active sessions). "
+            f"Please try again in a few minutes."
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,7 +33,8 @@ from app.api.routes.units import router as units_router
 from app.core.config import (
     API_TITLE, API_DESCRIPTION, API_VERSION,
     ALLOWED_ORIGINS, DEFAULT_HOST, DEFAULT_PORT,
-    HEALTH_CHECK_MESSAGE, API_ROOT_MESSAGE
+    HEALTH_CHECK_MESSAGE, API_ROOT_MESSAGE,
+    MAX_CONCURRENT_SESSIONS, QBSD_THREAD_POOL_SIZE,
 )
 
 app = FastAPI(
@@ -98,6 +99,12 @@ app.include_router(cloud_data_router, prefix="/api", tags=["cloud-data"])
 app.include_router(observation_unit_router, prefix="/api/observation-unit", tags=["observation-unit"])
 app.include_router(units_router, prefix="/api/units", tags=["units"])
 
+logger = logging.getLogger(__name__)
+logger.info(
+    "[concurrency] Server starting with MAX_CONCURRENT_SESSIONS=%d, THREAD_POOL_SIZE=%d",
+    MAX_CONCURRENT_SESSIONS, QBSD_THREAD_POOL_SIZE,
+)
+
 @app.get("/", tags=["root"], summary="API Root", description="Returns API information and version")
 async def root():
     """Root endpoint returning API info and version."""
@@ -112,11 +119,14 @@ async def health_check():
 async def get_public_config():
     """Return public configuration for frontend."""
     from app.core.config import MAX_DOCUMENTS, DEVELOPER_MODE, RELEASE_CONFIG, ALLOW_LLM_CONFIG
+    from app.services import concurrency_limiter
     return {
         "max_documents": MAX_DOCUMENTS,
         "developer_mode": DEVELOPER_MODE,
         "release_config": RELEASE_CONFIG,
         "allow_llm_config": ALLOW_LLM_CONFIG,
+        "max_concurrent_sessions": MAX_CONCURRENT_SESSIONS,
+        "active_sessions": await concurrency_limiter.get_active_count(),
     }
 
 if __name__ == "__main__":

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,7 +1,88 @@
 """Shared service instances."""
 
+import asyncio
+import logging
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, Tuple
+
 from .websocket_manager import WebSocketManager
 from .session_manager import SessionManager
+
+from app.core.config import MAX_CONCURRENT_SESSIONS, QBSD_THREAD_POOL_SIZE
+from app.core.exceptions import CapacityExceededError
+
+logger = logging.getLogger(__name__)
+
+# ── Shared thread pool for blocking QBSD operations ──────────────────
+# Bounded pool prevents unbounded thread growth under concurrent load.
+# 6 workers on 8 vCPU leaves headroom for the event loop and OS.
+qbsd_thread_pool = ThreadPoolExecutor(
+    max_workers=QBSD_THREAD_POOL_SIZE,
+    thread_name_prefix="qbsd-worker",
+)
+logger.info("[concurrency] Thread pool initialized: %d workers (QBSD_THREAD_POOL_SIZE)", QBSD_THREAD_POOL_SIZE)
+
+
+# ── Concurrency limiter for long-running operations ──────────────────
+class ConcurrencyLimiter:
+    """Tracks active long-running operations across all services.
+
+    All LLM-heavy operations (QBSD creation, reextraction, continue discovery,
+    document processing) share a single counter so the server never exceeds
+    its capacity.
+    """
+
+    def __init__(self, max_concurrent: int):
+        self._lock = asyncio.Lock()
+        self._max = max_concurrent
+        # session_id -> (operation_type, start_time)
+        self._active: Dict[str, Tuple[str, float]] = {}
+
+    async def acquire(self, session_id: str, operation: str) -> None:
+        """Reserve a slot. Raises CapacityExceededError or RuntimeError."""
+        async with self._lock:
+            if session_id in self._active:
+                existing_op = self._active[session_id][0]
+                raise RuntimeError(
+                    f"Session {session_id} already has an active operation: {existing_op}"
+                )
+            if len(self._active) >= self._max:
+                logger.warning(
+                    "[concurrency] REJECTED %s (%s) - at capacity. Active: %d/%d",
+                    session_id[:8], operation, len(self._active), self._max,
+                )
+                raise CapacityExceededError(len(self._active), self._max)
+            self._active[session_id] = (operation, time.monotonic())
+            logger.info(
+                "[concurrency] Acquired slot for %s (%s). Active: %d/%d",
+                session_id[:8], operation, len(self._active), self._max,
+            )
+
+    async def release(self, session_id: str) -> None:
+        """Release a slot. Safe to call even if not acquired."""
+        async with self._lock:
+            entry = self._active.pop(session_id, None)
+            if entry:
+                operation, start_time = entry
+                duration = time.monotonic() - start_time
+                minutes, seconds = divmod(int(duration), 60)
+                logger.info(
+                    "[concurrency] Released slot for %s (%s). Duration: %dm %ds. Active: %d/%d",
+                    session_id[:8], operation, minutes, seconds,
+                    len(self._active), self._max,
+                )
+
+    async def get_active_count(self) -> int:
+        """Return the number of currently active operations."""
+        async with self._lock:
+            return len(self._active)
+
+
+concurrency_limiter = ConcurrencyLimiter(MAX_CONCURRENT_SESSIONS)
+logger.info("[concurrency] Concurrency limiter initialized: max %d sessions", MAX_CONCURRENT_SESSIONS)
+
 
 # Create singleton instances
 websocket_manager = WebSocketManager()

--- a/backend/app/services/continue_discovery_service.py
+++ b/backend/app/services/continue_discovery_service.py
@@ -6,6 +6,8 @@ discovering new columns, and incremental value extraction.
 
 import json
 import asyncio
+import functools
+import threading
 import uuid
 import math
 import shutil
@@ -21,6 +23,7 @@ from app.models.session import (
 from app.services.websocket_manager import WebSocketManager
 from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
+from app.services import qbsd_thread_pool, concurrency_limiter
 from app.storage.factory import get_storage
 from app.core.config import DEVELOPER_MODE, RELEASE_CONFIG, MAX_DOCUMENTS
 
@@ -96,14 +99,17 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
         self.active_operations: Dict[str, ContinueDiscoveryOperation] = {}
         self.stop_flags: Dict[str, bool] = {}
         self._tasks: Dict[str, asyncio.Task] = {}
+        self._state_lock = threading.Lock()
 
     def is_stop_requested(self, operation_id: str) -> bool:
         """Check if stop was requested for an operation."""
-        return self.stop_flags.get(operation_id, False)
+        with self._state_lock:
+            return self.stop_flags.get(operation_id, False)
 
     def clear_stop_flag(self, operation_id: str) -> None:
         """Clear the stop flag for an operation."""
-        self.stop_flags.pop(operation_id, None)
+        with self._state_lock:
+            self.stop_flags.pop(operation_id, None)
 
     def _get_data_dir(self) -> Path:
         """Get the data directory path - uses module location for reliability."""
@@ -800,7 +806,8 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
         operation.initial_columns = [col.name for col in session.columns if col.name]
         operation.document_source = document_source
         operation.llm_config = llm_config
-        self.active_operations[operation_id] = operation
+        with self._state_lock:
+            self.active_operations[operation_id] = operation
 
         # Save LLM config for later use
         session_dir = self._get_data_dir() / session_id
@@ -825,7 +832,8 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
 
         # Start background task
         task = asyncio.create_task(self._run_continue_discovery(operation_id))
-        self._tasks[operation_id] = task
+        with self._state_lock:
+            self._tasks[operation_id] = task
 
         return {
             "status": "started",
@@ -988,23 +996,27 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                 columns_before = {col.name.lower() for col in current_schema.columns}
                 cumulative_docs += len(batch_docs)
 
-                # Select relevant content from this batch's documents
-                relevant_content = QBSD.select_relevant_content(
-                    docs=batch_docs,
-                    query=query,
-                    retriever=retriever
+                # Select relevant content from this batch's documents (offloaded to thread pool)
+                loop = asyncio.get_running_loop()
+                relevant_content = await loop.run_in_executor(
+                    qbsd_thread_pool,
+                    functools.partial(QBSD.select_relevant_content, docs=batch_docs, query=query, retriever=retriever),
                 )
                 print(f"DEBUG: Selected {len(relevant_content)} relevant passages from batch")
 
-                # Generate schema for this batch
+                # Generate schema for this batch (offloaded to thread pool)
                 try:
-                    schema_result = QBSD.generate_schema(
-                        passages=relevant_content,
-                        query=query,
-                        max_keys_schema=config.get("max_keys_schema", 100),
-                        current_schema=current_schema,
-                        llm=llm,
-                        context_window_size=context_window_size
+                    schema_result = await loop.run_in_executor(
+                        qbsd_thread_pool,
+                        functools.partial(
+                            QBSD.generate_schema,
+                            passages=relevant_content,
+                            query=query,
+                            max_keys_schema=config.get("max_keys_schema", 100),
+                            current_schema=current_schema,
+                            llm=llm,
+                            context_window_size=context_window_size,
+                        ),
                     )
                     # generate_schema returns a tuple (Schema, bool)
                     new_schema = schema_result[0] if isinstance(schema_result, tuple) else schema_result
@@ -1013,8 +1025,11 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     print(f"DEBUG: ERROR in generate_schema: {e}")
                     raise
 
-                # Merge with existing schema
-                merged_schema = current_schema.merge(new_schema)
+                # Merge with existing schema (offloaded to thread pool)
+                merged_schema = await loop.run_in_executor(
+                    qbsd_thread_pool,
+                    functools.partial(current_schema.merge, new_schema),
+                )
                 print(f"DEBUG: Merged schema has {len(merged_schema.columns)} columns")
 
                 # Identify NEW columns added in this iteration
@@ -1037,8 +1052,12 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     cumulative_documents=cumulative_docs
                 ))
 
-                # Check convergence
-                if QBSD.evaluate_schema_convergence(current_schema, merged_schema):
+                # Check convergence (offloaded to thread pool)
+                converged = await loop.run_in_executor(
+                    qbsd_thread_pool,
+                    functools.partial(QBSD.evaluate_schema_convergence, current_schema, merged_schema),
+                )
+                if converged:
                     unchanged_count += 1
                     print(f"DEBUG: Schema unchanged (count: {unchanged_count}/{convergence_threshold})")
                     if unchanged_count >= convergence_threshold:
@@ -1209,6 +1228,8 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     "error": str(e)
                 }
             )
+        finally:
+            await concurrency_limiter.release(operation.session_id)
 
     # ==================== Incremental Extraction ====================
 
@@ -1298,7 +1319,8 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
 
         # Start extraction in background
         task = asyncio.create_task(self._run_incremental_extraction(operation_id))
-        self._tasks[operation_id] = task
+        with self._state_lock:
+            self._tasks[operation_id] = task
 
         return {
             "status": "started",
@@ -1490,7 +1512,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                         should_stop=should_stop
                     )
 
-                await asyncio.get_event_loop().run_in_executor(None, run_extraction)
+                await asyncio.get_event_loop().run_in_executor(qbsd_thread_pool, run_extraction)
                 print(f"DEBUG: Incremental extraction completed")
 
             # Clean up filtered docs directory
@@ -1567,6 +1589,8 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     "error": str(e)
                 }
             )
+        finally:
+            await concurrency_limiter.release(operation.session_id)
 
     async def _merge_incremental_data(
         self,
@@ -1687,7 +1711,8 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
 
     async def stop_operation(self, operation_id: str) -> Dict[str, Any]:
         """Stop a running operation."""
-        operation = self.active_operations.get(operation_id)
+        with self._state_lock:
+            operation = self.active_operations.get(operation_id)
         if not operation:
             return {"stopped": False, "message": f"Operation {operation_id} not found"}
 
@@ -1695,11 +1720,13 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             return {"stopped": False, "message": f"Operation already {operation.status}"}
 
         # Set stop flag
-        self.stop_flags[operation_id] = True
+        with self._state_lock:
+            self.stop_flags[operation_id] = True
         print(f"DEBUG: Stop requested for operation {operation_id}")
 
         # Cancel task if running - wait for it to finish gracefully
-        task = self._tasks.get(operation_id)
+        with self._state_lock:
+            task = self._tasks.get(operation_id)
         if task and not task.done():
             task.cancel()
             try:

--- a/backend/app/services/qbsd_runner.py
+++ b/backend/app/services/qbsd_runner.py
@@ -2,15 +2,18 @@
 
 import json
 import asyncio
+import functools
 import logging
 import math
 import random
+import threading
 import time
 from typing import Dict, Any, Optional, List
 from pathlib import Path
 from datetime import datetime
 
 from app.core.config import MAX_DOCUMENTS, DEVELOPER_MODE, RELEASE_CONFIG
+from app.services import qbsd_thread_pool, concurrency_limiter
 
 logger = logging.getLogger(__name__)
 
@@ -137,15 +140,17 @@ class QBSDRunner(WebSocketBroadcasterMixin):
         self.work_dir.mkdir(exist_ok=True)
         self.running_sessions: Dict[str, asyncio.Task] = {}
         self.stop_flags: Dict[str, bool] = {}  # Track stop requests per session
+        self._state_lock = threading.Lock()
 
     def is_stop_requested(self, session_id: str) -> bool:
         """Check if stop has been requested for a session."""
-        return self.stop_flags.get(session_id, False)
+        with self._state_lock:
+            return self.stop_flags.get(session_id, False)
 
     def clear_stop_flag(self, session_id: str):
         """Clear the stop flag for a session."""
-        if session_id in self.stop_flags:
-            del self.stop_flags[session_id]
+        with self._state_lock:
+            self.stop_flags.pop(session_id, None)
 
     def _create_value_extracted_callback(self, session_id: str, loop: asyncio.AbstractEventLoop):
         """Create a callback that streams extracted cell values via WebSocket.
@@ -510,25 +515,28 @@ class QBSDRunner(WebSocketBroadcasterMixin):
             
             # Create task for QBSD execution
             task = asyncio.create_task(self._execute_qbsd(session_id, config))
-            self.running_sessions[session_id] = task
-            
+            with self._state_lock:
+                self.running_sessions[session_id] = task
+
             # Wait for completion
             await task
-            
+
         except Exception as e:
             # Update session with error
             session = self.session_manager.get_session(session_id)
             session.status = SessionStatus.ERROR
             session.error_message = str(e)
             self.session_manager.update_session(session)
-            
+
             await self.broadcast_error(session_id, str(e))
-        
+
         finally:
             # Clean up
-            if session_id in self.running_sessions:
-                del self.running_sessions[session_id]
-    
+            with self._state_lock:
+                self.running_sessions.pop(session_id, None)
+            # Release concurrency slot (safe even if not acquired)
+            await concurrency_limiter.release(session_id)
+
     async def _execute_qbsd(self, session_id: str, config: QBSDConfig):
         """Execute the real QBSD process."""
         if not QBSD_AVAILABLE:
@@ -1028,20 +1036,33 @@ class QBSDRunner(WebSocketBroadcasterMixin):
             })
 
             try:
-                # Call generate_schema with empty passages
-                schema_result = QBSD.generate_schema(
-                    passages=[],
-                    query=query,
-                    max_keys_schema=qbsd_config.get("max_keys_schema", 100),
-                    current_schema=current_schema,
-                    llm=llm,
-                    context_window_size=qbsd_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192)
+                # Call generate_schema with empty passages (offloaded to thread pool)
+                loop = asyncio.get_running_loop()
+                logger.debug("[%s] Offloading QUERY_ONLY generate_schema to thread pool", session_id)
+                schema_result = await loop.run_in_executor(
+                    qbsd_thread_pool,
+                    functools.partial(
+                        QBSD.generate_schema,
+                        passages=[],
+                        query=query,
+                        max_keys_schema=qbsd_config.get("max_keys_schema", 100),
+                        current_schema=current_schema,
+                        llm=llm,
+                        context_window_size=qbsd_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192),
+                    )
                 )
                 new_schema = schema_result[0] if isinstance(schema_result, tuple) else schema_result
                 logger.debug("QUERY_ONLY generated schema with %d columns", len(new_schema.columns))
 
-                # Merge with any initial schema
-                merged_schema = current_schema.merge(new_schema) if current_schema.columns else new_schema
+                # Merge with any initial schema (offloaded to thread pool)
+                if current_schema.columns:
+                    logger.debug("[%s] Offloading QUERY_ONLY schema merge to thread pool", session_id)
+                    merged_schema = await loop.run_in_executor(
+                        qbsd_thread_pool,
+                        functools.partial(current_schema.merge, new_schema),
+                    )
+                else:
+                    merged_schema = new_schema
 
                 # Track new columns
                 new_column_names = [col.name for col in merged_schema.columns
@@ -1103,12 +1124,17 @@ class QBSDRunner(WebSocketBroadcasterMixin):
             columns_before = {col.name.lower() for col in current_schema.columns}
             cumulative_docs += len(batch_docs)
 
-            # Select relevant content from this batch's documents
-            logger.debug("Selecting relevant content with retriever")
-            relevant_content = QBSD.select_relevant_content(
-                docs=batch_docs,
-                query=query,
-                retriever=retriever
+            # Select relevant content from this batch's documents (offloaded to thread pool)
+            loop = asyncio.get_running_loop()
+            logger.debug("[%s] Offloading select_relevant_content to thread pool", session_id)
+            relevant_content = await loop.run_in_executor(
+                qbsd_thread_pool,
+                functools.partial(
+                    QBSD.select_relevant_content,
+                    docs=batch_docs,
+                    query=query,
+                    retriever=retriever,
+                )
             )
             logger.debug("Selected %d relevant passages from batch", len(relevant_content))
 
@@ -1122,12 +1148,17 @@ class QBSDRunner(WebSocketBroadcasterMixin):
             if iteration == 0 and (query or relevant_content) and not current_schema.observation_unit:
                 logger.info("Discovering observation unit from first batch...")
                 try:
-                    obs_unit = discover_observation_unit(
-                        query=query,
-                        passages=relevant_content,
-                        llm=llm,
-                        context_window_size=qbsd_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192),
-                        source_document=batch_names[0] if batch_names else None
+                    logger.debug("[%s] Offloading discover_observation_unit to thread pool", session_id)
+                    obs_unit = await loop.run_in_executor(
+                        qbsd_thread_pool,
+                        functools.partial(
+                            discover_observation_unit,
+                            query=query,
+                            passages=relevant_content,
+                            llm=llm,
+                            context_window_size=qbsd_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192),
+                            source_document=batch_names[0] if batch_names else None,
+                        )
                     )
                     # If name was pre-configured, override discovered name
                     if pending_observation_unit_name:
@@ -1156,16 +1187,20 @@ class QBSDRunner(WebSocketBroadcasterMixin):
                 logger.warning("Stop requested after observation unit discovery - saving partial schema")
                 break
 
-            # Generate schema for this iteration
-            logger.debug("Calling QBSD.generate_schema with LLM...")
+            # Generate schema for this iteration (offloaded to thread pool)
+            logger.debug("[%s] Offloading generate_schema to thread pool", session_id)
             try:
-                schema_result = QBSD.generate_schema(
-                    passages=relevant_content,
-                    query=query,
-                    max_keys_schema=qbsd_config.get("max_keys_schema", 100),
-                    current_schema=current_schema,
-                    llm=llm,
-                    context_window_size=qbsd_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192)
+                schema_result = await loop.run_in_executor(
+                    qbsd_thread_pool,
+                    functools.partial(
+                        QBSD.generate_schema,
+                        passages=relevant_content,
+                        query=query,
+                        max_keys_schema=qbsd_config.get("max_keys_schema", 100),
+                        current_schema=current_schema,
+                        llm=llm,
+                        context_window_size=qbsd_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192),
+                    )
                 )
                 # generate_schema returns a tuple (Schema, bool)
                 new_schema = schema_result[0] if isinstance(schema_result, tuple) else schema_result
@@ -1179,12 +1214,15 @@ class QBSDRunner(WebSocketBroadcasterMixin):
                 logger.warning("Stop requested after schema generation - saving partial schema")
                 break
 
-            # Merge with existing schema
-            logger.debug("Merging schemas...")
+            # Merge with existing schema (offloaded to thread pool)
+            logger.debug("[%s] Offloading schema merge to thread pool", session_id)
             logger.debug("Current schema has %d columns", len(current_schema.columns))
             logger.debug("New schema has %d columns", len(new_schema.columns))
             try:
-                merged_schema = current_schema.merge(new_schema)
+                merged_schema = await loop.run_in_executor(
+                    qbsd_thread_pool,
+                    functools.partial(current_schema.merge, new_schema),
+                )
                 logger.debug("Merged schema has %d columns", len(merged_schema.columns))
             except Exception as e:
                 logger.error("ERROR in schema merge: %s", e)
@@ -1219,9 +1257,13 @@ class QBSDRunner(WebSocketBroadcasterMixin):
 
             logger.debug("Evolution - batch %d: %d new columns: %s", iteration + 1, len(new_columns), new_columns)
 
-            # Check convergence
-            logger.debug("Checking convergence...")
-            if QBSD.evaluate_schema_convergence(current_schema, merged_schema):
+            # Check convergence (offloaded to thread pool)
+            logger.debug("[%s] Offloading evaluate_schema_convergence to thread pool", session_id)
+            converged = await loop.run_in_executor(
+                qbsd_thread_pool,
+                functools.partial(QBSD.evaluate_schema_convergence, current_schema, merged_schema),
+            )
+            if converged:
                 unchanged_count += 1
                 logger.debug("Schema unchanged (count: %d/%d)", unchanged_count, convergence_threshold)
                 if unchanged_count >= convergence_threshold:
@@ -1342,7 +1384,7 @@ class QBSDRunner(WebSocketBroadcasterMixin):
             return extraction_result
 
         # Track progress by monitoring output file
-        extraction_task = loop.run_in_executor(None, run_value_extraction)
+        extraction_task = loop.run_in_executor(qbsd_thread_pool, run_value_extraction)
         
         # Monitor progress while extraction runs
         start_time = time.time()
@@ -1707,9 +1749,10 @@ class QBSDRunner(WebSocketBroadcasterMixin):
 
     async def get_status(self, session_id: str) -> QBSDStatus:
         """Get current status of QBSD execution."""
-        if session_id in self.running_sessions:
+        with self._state_lock:
+            is_running = session_id in self.running_sessions
+        if is_running:
             status = "processing"
-            # You could track more detailed progress here
             progress = 0.5  # Mock progress
         else:
             # Check session status
@@ -1930,12 +1973,14 @@ class QBSDRunner(WebSocketBroadcasterMixin):
             "message": ""
         }
 
-        if session_id in self.running_sessions:
-            logger.debug("stop_execution: Session found in running_sessions, setting stop flag")
-            # Set stop flag first - the running task will check this and exit gracefully
-            self.stop_flags[session_id] = True
+        with self._state_lock:
+            is_running = session_id in self.running_sessions
+            if is_running:
+                logger.debug("stop_execution: Session found in running_sessions, setting stop flag")
+                self.stop_flags[session_id] = True
+                task = self.running_sessions[session_id]
 
-            task = self.running_sessions[session_id]
+        if is_running:
 
             # Give the task time to stop gracefully (LLM calls can take 30+ seconds)
             try:
@@ -1957,9 +2002,9 @@ class QBSDRunner(WebSocketBroadcasterMixin):
                 logger.error("Exception during stop: %s", e)
 
             # Clean up
-            if session_id in self.running_sessions:
-                del self.running_sessions[session_id]
-            self.clear_stop_flag(session_id)
+            with self._state_lock:
+                self.running_sessions.pop(session_id, None)
+                self.stop_flags.pop(session_id, None)
 
             # Check what was saved
             session_dir = self.work_dir / session_id

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -6,6 +6,7 @@ Handles schema change detection, paper discovery, and selective re-extraction.
 import json
 import asyncio
 import hashlib
+import threading
 import uuid
 from typing import List, Dict, Any, Optional, Set
 from pathlib import Path
@@ -17,6 +18,7 @@ from app.models.session import (
 from app.services.websocket_manager import WebSocketManager
 from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
+from app.services import qbsd_thread_pool, concurrency_limiter
 from app.storage.factory import get_storage
 from app.core.config import DEVELOPER_MODE, RELEASE_CONFIG
 
@@ -70,6 +72,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
         self.active_operations: Dict[str, ReextractionOperation] = {}
         self.stop_flags: Dict[str, bool] = {}  # operation_id -> stop requested
         self._extraction_tasks: Dict[str, asyncio.Task] = {}  # operation_id -> task
+        self._state_lock = threading.Lock()
 
     @classmethod
     def get_cached_retriever(cls):
@@ -81,11 +84,13 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
     def is_stop_requested(self, operation_id: str) -> bool:
         """Check if stop was requested for an operation."""
-        return self.stop_flags.get(operation_id, False)
+        with self._state_lock:
+            return self.stop_flags.get(operation_id, False)
 
     def clear_stop_flag(self, operation_id: str) -> None:
         """Clear the stop flag for an operation."""
-        self.stop_flags.pop(operation_id, None)
+        with self._state_lock:
+            self.stop_flags.pop(operation_id, None)
 
     async def stop_operation(self, operation_id: str) -> Dict[str, Any]:
         """
@@ -94,7 +99,8 @@ class ReextractionService(WebSocketBroadcasterMixin):
         Returns:
             Dictionary with stop status and any partial results
         """
-        operation = self.active_operations.get(operation_id)
+        with self._state_lock:
+            operation = self.active_operations.get(operation_id)
         if not operation:
             return {
                 "stopped": False,
@@ -108,11 +114,13 @@ class ReextractionService(WebSocketBroadcasterMixin):
             }
 
         # Set stop flag
-        self.stop_flags[operation_id] = True
+        with self._state_lock:
+            self.stop_flags[operation_id] = True
         print(f"🛑 Stop requested for re-extraction operation {operation_id}")
 
         # Cancel the extraction task if it exists
-        task = self._extraction_tasks.get(operation_id)
+        with self._state_lock:
+            task = self._extraction_tasks.get(operation_id)
         if task and not task.done():
             task.cancel()
             try:
@@ -760,7 +768,8 @@ class ReextractionService(WebSocketBroadcasterMixin):
             status="starting"
         )
         operation.total_documents = len(paper_discovery["available_papers"])
-        self.active_operations[operation_id] = operation
+        with self._state_lock:
+            self.active_operations[operation_id] = operation
 
         # Start background task and store reference for potential cancellation
         task = asyncio.create_task(self._run_reextraction(operation_id))
@@ -948,7 +957,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                         should_stop=should_stop  # Allow graceful stop
                     )
 
-                await asyncio.get_event_loop().run_in_executor(None, run_extraction)
+                await asyncio.get_event_loop().run_in_executor(qbsd_thread_pool, run_extraction)
                 print(f"DEBUG: build_table_jsonl completed, output_file exists: {output_file.exists()}")
             else:
                 print(f"DEBUG: No document directories exist, skipping extraction")
@@ -1001,6 +1010,8 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 }
             )
             raise
+        finally:
+            await concurrency_limiter.release(operation.session_id)
 
     async def _merge_reextracted_data(
         self,

--- a/backend/app/services/schema_manager.py
+++ b/backend/app/services/schema_manager.py
@@ -5,6 +5,7 @@ Handles schema editing operations and document reprocessing.
 
 import json
 import asyncio
+import threading
 from typing import List, Dict, Any, Optional
 from pathlib import Path
 from datetime import datetime
@@ -14,6 +15,7 @@ from app.models.session import ColumnInfo, SessionStatus
 from app.services.websocket_manager import WebSocketManager
 from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
+from app.services import qbsd_thread_pool, concurrency_limiter
 from app.core.config import DEVELOPER_MODE, RELEASE_CONFIG
 
 # QBSD library imports
@@ -33,6 +35,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
         self.session_manager = session_manager
         self.reprocessing_status: Dict[str, Dict[str, Any]] = {}
         self.running_tasks: Dict[str, asyncio.Task] = {}
+        self._state_lock = threading.Lock()
         
     def _get_value_extraction_llm_from_session(self, session_id: str):
         """Get value extraction LLM configuration from session, including API key."""
@@ -170,7 +173,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
                 output_file = session_dir / f"reprocessed_{column_name}.jsonl"
                 
                 await asyncio.get_event_loop().run_in_executor(
-                    None,
+                    qbsd_thread_pool,
                     lambda: build_table_jsonl(
                         schema_path=schema_file,
                         docs_directories=[docs_dir],
@@ -674,7 +677,9 @@ class SchemaManager(WebSocketBroadcasterMixin):
             }
             await self.broadcast_error(session_id, f"Schema-aware document reprocessing failed: {str(e)}")
             raise
-    
+        finally:
+            await concurrency_limiter.release(session_id)
+
     def _generate_extraction_instructions(self, session) -> str:
         """Generate enhanced extraction instructions based on schema context."""
         instructions = [
@@ -759,7 +764,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
                 output_file = session_dir / f"enhanced_reprocessed_{column_name}.jsonl"
                 
                 await asyncio.get_event_loop().run_in_executor(
-                    None,
+                    qbsd_thread_pool,
                     lambda: build_table_jsonl(
                         schema_path=enhanced_schema_file,
                         docs_directories=[docs_dir],

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -1,6 +1,7 @@
 """Session management service."""
 
 import hashlib
+import threading
 from typing import Dict, List, Optional
 from datetime import datetime
 
@@ -20,6 +21,7 @@ class SessionManager:
         """
         self._storage = storage or get_storage()
         self._sessions: Dict[str, VisualizationSession] = {}
+        self._lock = threading.Lock()
         self._load_sessions()
 
     def _load_sessions(self):
@@ -48,27 +50,30 @@ class SessionManager:
 
     def create_session(self, session: VisualizationSession) -> str:
         """Create a new session."""
-        self._sessions[session.id] = session
+        with self._lock:
+            self._sessions[session.id] = session
         self._save_session(session)
         return session.id
 
     def get_session(self, session_id: str) -> Optional[VisualizationSession]:
         """Get session by ID."""
-        return self._sessions.get(session_id)
+        with self._lock:
+            return self._sessions.get(session_id)
 
     def update_session(self, session: VisualizationSession):
         """Update existing session."""
         session.metadata.last_modified = datetime.now()
-        self._sessions[session.id] = session
+        with self._lock:
+            self._sessions[session.id] = session
         self._save_session(session)
 
     def delete_session(self, session_id: str) -> bool:
         """Delete session and all associated data."""
-        if session_id not in self._sessions:
-            return False
-
-        # Remove from memory
-        del self._sessions[session_id]
+        with self._lock:
+            if session_id not in self._sessions:
+                return False
+            # Remove from memory
+            del self._sessions[session_id]
 
         # Remove from storage (this also cleans up associated data)
         import asyncio
@@ -89,7 +94,8 @@ class SessionManager:
 
     def list_sessions(self, session_type: Optional[SessionType] = None) -> List[VisualizationSession]:
         """List all sessions, optionally filtered by type."""
-        sessions = list(self._sessions.values())
+        with self._lock:
+            sessions = list(self._sessions.values())
         if session_type:
             sessions = [s for s in sessions if s.type == session_type]
         return sorted(sessions, key=lambda s: s.metadata.created, reverse=True)

--- a/backend/app/services/upload_document_processor.py
+++ b/backend/app/services/upload_document_processor.py
@@ -2,6 +2,7 @@
 
 import json
 import asyncio
+import threading
 import time
 import math
 import os
@@ -21,6 +22,7 @@ from app.models.session import SessionStatus, DataRow, DataStatistics, ColumnInf
 from app.services.websocket_manager import WebSocketManager
 from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
+from app.services import qbsd_thread_pool, concurrency_limiter
 from app.core.config import DEFAULT_MAX_OUTPUT_TOKENS, DEFAULT_TEMPERATURE, DEFAULT_RETRIEVAL_K, PROGRESS_CHECK_INTERVAL, DEVELOPER_MODE, RELEASE_CONFIG
 
 
@@ -34,6 +36,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
         super().__init__(websocket_manager)
         self.session_manager = session_manager
         self.running_sessions: Dict[str, bool] = {}
+        self._state_lock = threading.Lock()
 
     def _create_value_extracted_callback(self, session_id: str, loop: asyncio.AbstractEventLoop):
         """Create a callback that streams extracted cell values via WebSocket.
@@ -70,8 +73,9 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
         if not QBSD_AVAILABLE:
             raise RuntimeError("QBSD components not available for document processing")
         
-        self.running_sessions[session_id] = True
-        
+        with self._state_lock:
+            self.running_sessions[session_id] = True
+
         try:
             session = self.session_manager.get_session(session_id)
             if not session:
@@ -156,7 +160,8 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
 
             # Create should_stop callback that checks for stop requests
             def should_stop():
-                return not self.running_sessions.get(session_id, True)
+                with self._state_lock:
+                    return not self.running_sessions.get(session_id, True)
 
             def run_extraction():
                 print(f"🚀 EXTRACTION STARTING for session {session_id}")
@@ -188,7 +193,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             # Monitor progress while extraction runs
             # NOTE: We only track progress here - actual data writing happens in _merge_extracted_data()
             # to avoid duplicate writes
-            extraction_task = loop.run_in_executor(None, run_extraction)
+            extraction_task = loop.run_in_executor(qbsd_thread_pool, run_extraction)
 
             start_time = time.time()
             total_docs = len(session.metadata.uploaded_documents)
@@ -196,7 +201,9 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
 
             while not extraction_task.done():
                 # Check for stop request
-                if not self.running_sessions.get(session_id, True):
+                with self._state_lock:
+                    stop_requested = not self.running_sessions.get(session_id, True)
+                if stop_requested:
                     print(f"🛑 Stop requested for session {session_id}, cancelling extraction...")
                     extraction_task.cancel()
                     try:
@@ -232,7 +239,8 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                     })
 
                     # Clean up and return
-                    self.running_sessions.pop(session_id, None)
+                    with self._state_lock:
+                        self.running_sessions.pop(session_id, None)
                     return
 
                 # Check output file for progress tracking only
@@ -364,8 +372,9 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
         
         finally:
             # Clean up
-            if session_id in self.running_sessions:
-                del self.running_sessions[session_id]
+            with self._state_lock:
+                self.running_sessions.pop(session_id, None)
+            await concurrency_limiter.release(session_id)
     
     
     async def _merge_extracted_data(self, session_id: str, session: VisualizationSession = None) -> int:
@@ -702,10 +711,11 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
 
     def stop_processing(self, session_id: str) -> bool:
         """Stop document processing for a session."""
-        if session_id in self.running_sessions:
-            self.running_sessions[session_id] = False
-            return True
-        return False
+        with self._state_lock:
+            if session_id in self.running_sessions:
+                self.running_sessions[session_id] = False
+                return True
+            return False
     
     def _build_schema_from_session(self, session) -> Dict[str, Any]:
         """Build schema dict from session.columns (includes user edits from SCHEMA tab).

--- a/backend/app/services/websocket_manager.py
+++ b/backend/app/services/websocket_manager.py
@@ -15,81 +15,94 @@ class WebSocketManager:
         self.log_connections: Dict[str, Set[WebSocket]] = {}
         # Buffer for cell events when no connections exist (handles race condition)
         self.pending_cell_events: Dict[str, List[Dict[str, Any]]] = {}
-    
-    def add_connection(self, session_id: str, websocket: WebSocket):
-        """Add a WebSocket connection for a session and flush any buffered events."""
-        if session_id not in self.connections:
-            self.connections[session_id] = set()
-        self.connections[session_id].add(websocket)
+        self._lock = asyncio.Lock()
 
-        # Schedule flush of any buffered cell events
+    async def add_connection(self, session_id: str, websocket: WebSocket):
+        """Add a WebSocket connection for a session and flush any buffered events."""
+        async with self._lock:
+            if session_id not in self.connections:
+                self.connections[session_id] = set()
+            self.connections[session_id].add(websocket)
+
+        # Schedule flush of any buffered cell events (outside lock)
         asyncio.create_task(self._flush_buffered_events(session_id))
-    
-    def remove_connection(self, session_id: str, websocket: WebSocket):
+
+    async def remove_connection(self, session_id: str, websocket: WebSocket):
         """Remove a WebSocket connection."""
-        if session_id in self.connections:
-            self.connections[session_id].discard(websocket)
-            if not self.connections[session_id]:
-                del self.connections[session_id]
-    
-    def add_log_connection(self, session_id: str, websocket: WebSocket):
+        async with self._lock:
+            if session_id in self.connections:
+                self.connections[session_id].discard(websocket)
+                if not self.connections[session_id]:
+                    del self.connections[session_id]
+
+    async def add_log_connection(self, session_id: str, websocket: WebSocket):
         """Add a WebSocket connection for log streaming."""
-        if session_id not in self.log_connections:
-            self.log_connections[session_id] = set()
-        self.log_connections[session_id].add(websocket)
-    
-    def remove_log_connection(self, session_id: str, websocket: WebSocket):
+        async with self._lock:
+            if session_id not in self.log_connections:
+                self.log_connections[session_id] = set()
+            self.log_connections[session_id].add(websocket)
+
+    async def remove_log_connection(self, session_id: str, websocket: WebSocket):
         """Remove a log WebSocket connection."""
-        if session_id in self.log_connections:
-            self.log_connections[session_id].discard(websocket)
-            if not self.log_connections[session_id]:
-                del self.log_connections[session_id]
+        async with self._lock:
+            if session_id in self.log_connections:
+                self.log_connections[session_id].discard(websocket)
+                if not self.log_connections[session_id]:
+                    del self.log_connections[session_id]
     
     async def broadcast_progress(self, session_id: str, progress_data: Dict[str, Any]):
         """Broadcast progress update to all connected clients."""
-        if session_id not in self.connections:
-            return
-        
+        # Snapshot connections under lock
+        async with self._lock:
+            ws_set = self.connections.get(session_id)
+            if not ws_set:
+                return
+            snapshot = list(ws_set)
+
         message = {
             "type": "progress",
             "timestamp": datetime.now().isoformat(),
             "data": progress_data
         }
-        
-        # Send to all connections for this session
+
+        # Send to all connections (outside lock to avoid blocking during I/O)
         dead_connections = []
-        for websocket in self.connections[session_id]:
+        for websocket in snapshot:
             try:
                 await websocket.send_json(message)
             except Exception:
                 dead_connections.append(websocket)
-        
+
         # Remove dead connections
         for websocket in dead_connections:
-            self.remove_connection(session_id, websocket)
+            await self.remove_connection(session_id, websocket)
     
     async def broadcast_log(self, session_id: str, log_data: Dict[str, Any]):
         """Broadcast log message to all log connections."""
-        if session_id not in self.log_connections:
-            return
-        
+        # Snapshot connections under lock
+        async with self._lock:
+            ws_set = self.log_connections.get(session_id)
+            if not ws_set:
+                return
+            snapshot = list(ws_set)
+
         message = {
             "type": "log",
             "timestamp": datetime.now().isoformat(),
             "data": log_data
         }
-        
-        # Send to all log connections for this session
+
+        # Send to all log connections (outside lock)
         dead_connections = []
-        for websocket in self.log_connections[session_id]:
+        for websocket in snapshot:
             try:
                 await websocket.send_json(message)
             except Exception:
                 dead_connections.append(websocket)
-        
+
         # Remove dead connections
         for websocket in dead_connections:
-            self.remove_log_connection(session_id, websocket)
+            await self.remove_log_connection(session_id, websocket)
     
     async def broadcast_error(self, session_id: str, error_message: str):
         """Broadcast error message to all connections."""
@@ -104,24 +117,30 @@ class WebSocketManager:
     
     async def broadcast_completion(self, session_id: str, result_data: Dict[str, Any]):
         """Broadcast completion message."""
+        # Snapshot connections under lock
+        async with self._lock:
+            ws_set = self.connections.get(session_id)
+            if not ws_set:
+                return
+            snapshot = list(ws_set)
+
         message = {
             "type": "completion",
             "timestamp": datetime.now().isoformat(),
             "data": result_data
         }
-        
-        # Send to all connections for this session
-        if session_id in self.connections:
-            dead_connections = []
-            for websocket in self.connections[session_id]:
-                try:
-                    await websocket.send_json(message)
-                except Exception:
-                    dead_connections.append(websocket)
-            
-            # Remove dead connections
-            for websocket in dead_connections:
-                self.remove_connection(session_id, websocket)
+
+        # Send to all connections (outside lock)
+        dead_connections = []
+        for websocket in snapshot:
+            try:
+                await websocket.send_json(message)
+            except Exception:
+                dead_connections.append(websocket)
+
+        # Remove dead connections
+        for websocket in dead_connections:
+            await self.remove_connection(session_id, websocket)
     
     # Schema editing specific broadcast methods
     async def broadcast_schema_updated(self, session_id: str, update_data: Dict[str, Any]):
@@ -159,22 +178,26 @@ class WebSocketManager:
     
     async def broadcast_to_session(self, session_id: str, message: Dict[str, Any]):
         """Generic method to broadcast a message to all connections for a session."""
-        if session_id not in self.connections:
-            print(f"⚠️ NO CONNECTIONS for session {session_id}")
-            print(f"⚠️ Active sessions: {list(self.connections.keys())}")
-            return
-        
+        # Snapshot connections under lock
+        async with self._lock:
+            ws_set = self.connections.get(session_id)
+            if not ws_set:
+                print(f"⚠️ NO CONNECTIONS for session {session_id}")
+                print(f"⚠️ Active sessions: {list(self.connections.keys())}")
+                return
+            snapshot = list(ws_set)
+
         dead_connections = []
-        for websocket in self.connections[session_id]:
+        for websocket in snapshot:
             try:
                 await websocket.send_json(message)
             except Exception as e:
                 print(f"Failed to send message to websocket: {e}")
                 dead_connections.append(websocket)
-        
+
         # Remove dead connections
         for websocket in dead_connections:
-            self.remove_connection(session_id, websocket)
+            await self.remove_connection(session_id, websocket)
     
     async def broadcast_schema_completed(self, session_id: str, schema_data: Dict[str, Any]):
         """Broadcast schema discovery completion."""
@@ -188,24 +211,29 @@ class WebSocketManager:
     
     async def broadcast_row_completed(self, session_id: str, row_data: Dict[str, Any]):
         """Broadcast individual row completion during value extraction."""
+        # Snapshot connections under lock
+        async with self._lock:
+            ws_set = self.connections.get(session_id)
+            if not ws_set:
+                return
+            snapshot = list(ws_set)
+
         message = {
-            "type": "row_completed", 
+            "type": "row_completed",
             "timestamp": datetime.now().isoformat(),
             "data": row_data
         }
-        
-        # Send to all connections for this session
-        if session_id in self.connections:
-            dead_connections = []
-            for websocket in self.connections[session_id]:
-                try:
-                    await websocket.send_json(message)
-                except Exception:
-                    dead_connections.append(websocket)
-            
-            # Remove dead connections
-            for websocket in dead_connections:
-                self.remove_connection(session_id, websocket)
+
+        dead_connections = []
+        for websocket in snapshot:
+            try:
+                await websocket.send_json(message)
+            except Exception:
+                dead_connections.append(websocket)
+
+        # Remove dead connections
+        for websocket in dead_connections:
+            await self.remove_connection(session_id, websocket)
     
     def get_connection_count(self, session_id: str) -> int:
         """Get number of active connections for a session."""
@@ -221,23 +249,25 @@ class WebSocketManager:
         This handles the race condition where cell extraction starts
         before the WebSocket connection is fully registered.
         """
-        if session_id not in self.connections or len(self.connections[session_id]) == 0:
-            # Buffer the event for later delivery
-            if session_id not in self.pending_cell_events:
-                self.pending_cell_events[session_id] = []
-            self.pending_cell_events[session_id].append(message)
-            cell_info = message.get('data', {})
-            print(f"📥 BUFFERED cell event: {cell_info.get('row_name')}/{cell_info.get('column')} (will flush when connected)")
-            return
+        async with self._lock:
+            has_conns = session_id in self.connections and len(self.connections[session_id]) > 0
+            if not has_conns:
+                # Buffer the event for later delivery
+                if session_id not in self.pending_cell_events:
+                    self.pending_cell_events[session_id] = []
+                self.pending_cell_events[session_id].append(message)
+                cell_info = message.get('data', {})
+                print(f"📥 BUFFERED cell event: {cell_info.get('row_name')}/{cell_info.get('column')} (will flush when connected)")
+                return
 
-        # Connection exists, broadcast immediately
+        # Connection exists, broadcast immediately (broadcast_to_session handles its own lock)
         await self.broadcast_to_session(session_id, message)
 
     async def _flush_buffered_events(self, session_id: str):
         """Send any buffered cell events to newly connected client."""
-        if session_id in self.pending_cell_events:
+        async with self._lock:
             events = self.pending_cell_events.pop(session_id, [])
-            if events:
-                print(f"📤 Flushing {len(events)} buffered cell events for {session_id}")
-                for event in events:
-                    await self.broadcast_to_session(session_id, event)
+        if events:
+            print(f"📤 Flushing {len(events)} buffered cell events for {session_id}")
+            for event in events:
+                await self.broadcast_to_session(session_id, event)

--- a/frontend/src/components/QBSDMonitor/QBSDMonitor.tsx
+++ b/frontend/src/components/QBSDMonitor/QBSDMonitor.tsx
@@ -10,6 +10,7 @@ import {
   Loader2,
   XCircle,
   ChevronDown,
+  Clock,
 } from 'lucide-react';
 import { useQuery, useQueryClient } from 'react-query';
 
@@ -53,6 +54,7 @@ const QBSDMonitor: React.FC<QBSDMonitorProps> = ({ sessionId }) => {
   const [processingState, setProcessingState] = useState<ProcessingState>('idle');
   const [currentStepMessage, setCurrentStepMessage] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
+  const [capacityMessage, setCapacityMessage] = useState<string>('');
 
   // Phase tracking state
   const [schemaProgress, setSchemaProgress] = useState({
@@ -219,6 +221,13 @@ const QBSDMonitor: React.FC<QBSDMonitorProps> = ({ sessionId }) => {
     };
   }, [sessionId, queryClient]);
 
+  // Auto-dismiss capacity message after 30 seconds
+  useEffect(() => {
+    if (!capacityMessage) return;
+    const timer = setTimeout(() => setCapacityMessage(''), 30000);
+    return () => clearTimeout(timer);
+  }, [capacityMessage]);
+
   const addLog = (level: LogEntry['level'], message: string, details?: any) => {
     const now = new Date();
     setLogs(prev => [
@@ -241,6 +250,7 @@ const QBSDMonitor: React.FC<QBSDMonitorProps> = ({ sessionId }) => {
     setProcessingState('starting');
     setCurrentStepMessage('Initializing...');
     setErrorMessage('');
+    setCapacityMessage('');
     setStoppedInfo(null);
 
     // Reset progress
@@ -261,9 +271,20 @@ const QBSDMonitor: React.FC<QBSDMonitorProps> = ({ sessionId }) => {
       addLog('info', 'QBSD execution started');
       // Stay in 'starting' state until we receive progress updates
     } catch (error: any) {
-      setProcessingState('error');
-      setErrorMessage(error.message || 'Failed to start QBSD');
-      addLog('error', `Failed to start QBSD: ${error.message}`);
+      const status = error?.response?.status;
+      const detail = error?.response?.data?.detail;
+
+      if (status === 503) {
+        // Server busy — show friendly amber banner, not error state
+        setProcessingState('idle');
+        setCapacityMessage(detail || 'The server is currently busy processing other requests. Please try again in a few minutes.');
+        addLog('warning', 'Server busy — please retry shortly');
+      } else {
+        setProcessingState('error');
+        const message = detail || error.message || 'Failed to start QBSD';
+        setErrorMessage(message);
+        addLog('error', `Failed to start QBSD: ${message}`);
+      }
     }
   };
 
@@ -311,17 +332,35 @@ const QBSDMonitor: React.FC<QBSDMonitorProps> = ({ sessionId }) => {
           {/* IDLE STATE */}
           {processingState === 'idle' && (
             <>
-              <div className="w-14 h-14 rounded-full bg-muted flex items-center justify-center mb-4">
-                <Play className="h-7 w-7 text-muted-foreground" />
-              </div>
-              <p className="text-xl font-semibold text-muted-foreground mb-1">Ready to Start</p>
-              <p className="text-sm text-muted-foreground mb-4">
-                Click the button below to begin QBSD execution
-              </p>
-              <Button size="lg" onClick={handleStart} className="px-8">
-                <Play className="h-5 w-5 mr-2" />
-                Start QBSD
-              </Button>
+              {capacityMessage ? (
+                <>
+                  <div className="w-14 h-14 rounded-full bg-amber-100 flex items-center justify-center mb-4">
+                    <Clock className="h-7 w-7 text-amber-600" />
+                  </div>
+                  <p className="text-xl font-semibold text-amber-600 mb-1">Server Busy</p>
+                  <p className="text-sm text-muted-foreground mb-4 text-center max-w-md">
+                    {capacityMessage}
+                  </p>
+                  <Button size="lg" onClick={handleStart} className="px-8">
+                    <Play className="h-5 w-5 mr-2" />
+                    Try Again
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <div className="w-14 h-14 rounded-full bg-muted flex items-center justify-center mb-4">
+                    <Play className="h-7 w-7 text-muted-foreground" />
+                  </div>
+                  <p className="text-xl font-semibold text-muted-foreground mb-1">Ready to Start</p>
+                  <p className="text-sm text-muted-foreground mb-4">
+                    Click the button below to begin QBSD execution
+                  </p>
+                  <Button size="lg" onClick={handleStart} className="px-8">
+                    <Play className="h-5 w-5 mr-2" />
+                    Start QBSD
+                  </Button>
+                </>
+              )}
             </>
           )}
 

--- a/frontend/src/components/SchemaEditor/ContinueDiscoveryDialog.tsx
+++ b/frontend/src/components/SchemaEditor/ContinueDiscoveryDialog.tsx
@@ -388,7 +388,12 @@ const ContinueDiscoveryDialog: React.FC<ContinueDiscoveryDialogProps> = ({
       }, 2000);
 
     } catch (error: any) {
-      onError(error.response?.data?.detail || 'Failed to start schema discovery');
+      const detail = error.response?.data?.detail;
+      if (error.response?.status === 503) {
+        onError(detail || 'The server is currently busy. Please try again in a few minutes.');
+      } else {
+        onError(detail || 'Failed to start schema discovery');
+      }
       setStep('documents');
     } finally {
       setLoading(false);
@@ -469,7 +474,12 @@ const ContinueDiscoveryDialog: React.FC<ContinueDiscoveryDialogProps> = ({
       }, 2000);
 
     } catch (error: any) {
-      onError(error.response?.data?.detail || 'Failed to start extraction');
+      const detail = error.response?.data?.detail;
+      if (error.response?.status === 503) {
+        onError(detail || 'The server is currently busy. Please try again in a few minutes.');
+      } else {
+        onError(detail || 'Failed to start extraction');
+      }
       setStep('review');
     } finally {
       setLoading(false);

--- a/frontend/src/components/SchemaEditor/ReextractionDialog.tsx
+++ b/frontend/src/components/SchemaEditor/ReextractionDialog.tsx
@@ -284,7 +284,12 @@ const ReextractionDialog: React.FC<ReextractionDialogProps> = ({
       onClose();
 
     } catch (error: any) {
-      onError(error.response?.data?.detail || 'Failed to start re-extraction');
+      const detail = error.response?.data?.detail;
+      if (error.response?.status === 503) {
+        onError(detail || 'The server is currently busy. Please try again in a few minutes.');
+      } else {
+        onError(detail || 'Failed to start re-extraction');
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/SchemaViewer/SchemaViewer.tsx
+++ b/frontend/src/components/SchemaViewer/SchemaViewer.tsx
@@ -804,11 +804,18 @@ const SchemaViewer: React.FC<SchemaViewerProps> = ({
       await schemaAPI.reprocessDocuments(sessionId, { incremental: true });
       toast({ title: 'Reprocessing Started', description: 'Document reprocessing started' });
     } catch (error: any) {
-      toast({
-        title: 'Error',
-        description: extractErrorMessage(error, 'Failed to start reprocessing'),
-        variant: 'destructive',
-      });
+      if (error.response?.status === 503) {
+        toast({
+          title: 'Server Busy',
+          description: extractErrorMessage(error, 'The server is currently busy. Please try again in a few minutes.'),
+        });
+      } else {
+        toast({
+          title: 'Error',
+          description: extractErrorMessage(error, 'Failed to start reprocessing'),
+          variant: 'destructive',
+        });
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/Visualize.tsx
+++ b/frontend/src/pages/Visualize.tsx
@@ -763,7 +763,10 @@ const Visualize = () => {
       await loadAPI.processDocuments(sessionId, configWithKey);
       queryClient.invalidateQueries(['session', sessionId]);
     } catch (err: any) {
-      const errorMessage = err.response?.data?.detail || err.message || 'Failed to start processing';
+      const detail = err.response?.data?.detail;
+      const errorMessage = err.response?.status === 503
+        ? (detail || 'The server is currently busy. Please try again in a few minutes.')
+        : (detail || err.message || 'Failed to start processing');
       setDocumentUploadError(errorMessage);
       setForceWebSocketConnect(false);
       if (wsRef.current) {


### PR DESCRIPTION
## Summary
- Add concurrency control infrastructure (`ConcurrencyLimiter`, shared `ThreadPoolExecutor`) to support multiple simultaneous QBSD sessions (target: 5-8 on Railway)
- Offload all blocking LLM/embedding calls via `run_in_executor` with `functools.partial` to avoid event-loop starvation
- Add thread safety with `threading.Lock` (for session/service state) and `asyncio.Lock` with snapshot-before-broadcast (for WebSocket manager)
- Introduce HTTP 503 capacity handling with frontend "Server Busy" banner, auto-dismiss, and "Try Again" button across all flows (QBSD creation, reextraction, continue discovery, document processing)
- Add `CapacityExceededError` custom exception and concurrency observability logging with `[concurrency]` prefix
- Update CLAUDE.md with concurrency architecture documentation

## Changes
- **`backend/app/services/__init__.py`** - New `ConcurrencyLimiter` class, shared thread pool, and service initialization
- **`backend/app/services/qbsd_runner.py`** - Thread pool offloading for QBSD pipeline, concurrency release in finally blocks
- **`backend/app/services/websocket_manager.py`** - `asyncio.Lock` with snapshot-before-broadcast pattern for thread safety
- **`backend/app/services/session_manager.py`** - `threading.Lock` for session state access
- **`backend/app/services/continue_discovery_service.py`** - Thread pool offloading, concurrency acquire/release
- **`backend/app/services/reextraction_service.py`** - Thread pool offloading, concurrency acquire/release
- **`backend/app/services/upload_document_processor.py`** - Thread pool offloading, concurrency acquire/release
- **`backend/app/services/schema_manager.py`** - Thread safety for stop flags
- **`backend/app/api/routes/`** - Concurrency acquire calls, 503 error handling
- **`backend/app/core/`** - New config vars (`MAX_CONCURRENT_SESSIONS`, `QBSD_THREAD_POOL_SIZE`), `CapacityExceededError`
- **`frontend/src/components/QBSDMonitor/`** - "Server Busy" amber banner with auto-dismiss
- **`frontend/src/components/SchemaEditor/`** - 503 detection in continue discovery and reextraction dialogs
- **`frontend/src/components/SchemaViewer/`** - 503 detection in reprocess flow

## Test plan
- [ ] Verify single-user QBSD creation still works end-to-end
- [ ] Test concurrent sessions by opening multiple browser tabs and starting QBSD simultaneously
- [ ] Confirm HTTP 503 is returned when `MAX_CONCURRENT_SESSIONS` is exceeded (set to 1 for easy testing)
- [ ] Verify "Server Busy" banner appears in QBSDMonitor on 503 and auto-dismisses after 30 seconds
- [ ] Test stop/cancel operations still work correctly under concurrent load
- [ ] Verify WebSocket progress updates are isolated per session
- [ ] Check `[concurrency]` logs appear in backend output

🤖 Generated with [Claude Code](https://claude.com/claude-code)