### PR TITLE
feat: Multi-user concurrency support with session-filterable logging

### DIFF
--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -1,5 +1,6 @@
 """Upload API endpoints."""
 
+import logging
 import uuid
 import json
 import csv
@@ -24,6 +25,9 @@ from app.services.session_manager import SessionManager
 from app.services import session_manager, concurrency_limiter
 from app.storage import get_storage
 from app.core.exceptions import CapacityExceededError
+from app.core.logging_utils import set_session_context
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -67,6 +71,7 @@ async def load_template(template_name: str):
 
         # Create session
         session_id = str(uuid.uuid4())
+        set_session_context(session_id)
         metadata = SessionMetadata(
             source=f"template:{template_name}",
             file_size=len(template_content)
@@ -103,13 +108,13 @@ async def load_template(template_name: str):
             if metadata.get('observation_unit'):
                 from app.models.session import ObservationUnitInfo
                 session.observation_unit = ObservationUnitInfo(**metadata['observation_unit'])
-                print(f"DEBUG: Restored observation unit from template CSV: {session.observation_unit.name}")
+                logger.debug(f"Restored observation unit from template CSV: {session.observation_unit.name}")
 
         # Restore observation_unit from JSON parse result if present (and not already set)
         if result.get("observation_unit") and not session.observation_unit:
             from app.models.session import ObservationUnitInfo
             session.observation_unit = ObservationUnitInfo(**result["observation_unit"])
-            print(f"DEBUG: Restored observation unit from template JSON: {session.observation_unit.name}")
+            logger.debug(f"Restored observation unit from template JSON: {session.observation_unit.name}")
 
         # Update session with parsed data
         session.columns = result["columns"]
@@ -136,7 +141,7 @@ async def load_template(template_name: str):
     except HTTPException:
         raise
     except Exception as e:
-        print(f"Error loading template {template_name}: {e}")
+        logger.error(f"Error loading template {template_name}: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -145,48 +150,49 @@ async def load_template(template_name: str):
 async def upload_file(file: UploadFile = File(...)):
     """Upload and validate a file."""
     try:
-        print(f"DEBUG: Received file upload: {file.filename}, size: {file.size}")
-        
+        session_id = str(uuid.uuid4())
+        set_session_context(session_id)
+        logger.debug(f"Received file upload: {file.filename}, size: {file.size}")
+
         # Validate file
         parser = FileParser()
         validation = await parser.validate_file(file)
-        
-        print(f"DEBUG: File validation result: {validation}")
-        
+
+        logger.debug(f"File validation result: {validation}")
+
         if not validation.is_valid:
             raise HTTPException(status_code=400, detail=validation.errors)
-        
+
         # Create session
-        session_id = str(uuid.uuid4())
         metadata = SessionMetadata(
             source=file.filename,
             file_size=file.size
         )
-        
+
         session = VisualizationSession(
             id=session_id,
             type=SessionType.UPLOAD,
             metadata=metadata
         )
-        
-        print(f"DEBUG: Created session: {session_id}")
-        
+
+        logger.debug(f"Created session: {session_id}")
+
         # Save file content for processing
         await parser.save_uploaded_file(session_id, file)
-        print(f"DEBUG: File saved for session: {session_id}")
-        
+        logger.debug(f"File saved for session: {session_id}")
+
         # Store session
         session_manager.create_session(session)
-        print(f"DEBUG: Session stored")
-        
+        logger.debug("Session stored")
+
         return {
             "session_id": session_id,
             "validation": validation,
             "requires_column_mapping": validation.detected_format == "csv"
         }
-        
+
     except Exception as e:
-        print(f"DEBUG: Exception in upload_file: {e}")
+        logger.error(f"Exception in upload_file: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -195,24 +201,25 @@ async def upload_file(file: UploadFile = File(...)):
 async def parse_file(session_id: str, mapping: Optional[ColumnMappingRequest] = None):
     """Parse uploaded file with optional column mapping."""
     try:
-        print(f"DEBUG: Parsing file for session: {session_id}")
-        
+        set_session_context(session_id)
+        logger.debug(f"Parsing file for session: {session_id}")
+
         session = session_manager.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
-        
-        print(f"DEBUG: Found session: {session}")
-        
+
+        logger.debug(f"Found session: {session}")
+
         parser = FileParser()
         result = await parser.parse_file(session_id, mapping)
-        
-        print(f"DEBUG: Parse result: columns={len(result['columns'])}, statistics={result['statistics']}")
-        
+
+        logger.debug(f"Parse result: columns={len(result['columns'])}, statistics={result['statistics']}")
+
         # Check for extracted metadata from CSV comments
         if "extracted_metadata" in result:
             metadata = result["extracted_metadata"]
-            print(f"DEBUG: Found CSV metadata - query: {metadata.get('query')}, LLM config: {bool(metadata.get('llm_config'))}")
-            
+            logger.debug(f"Found CSV metadata - query: {metadata.get('query')}, LLM config: {bool(metadata.get('llm_config'))}")
+
             # Store extracted query
             if metadata.get('query'):
                 session.schema_query = metadata['query']
@@ -221,7 +228,7 @@ async def parse_file(session_id: str, mapping: Optional[ColumnMappingRequest] = 
             if metadata.get('observation_unit'):
                 from app.models.session import ObservationUnitInfo
                 session.observation_unit = ObservationUnitInfo(**metadata['observation_unit'])
-                print(f"DEBUG: Restored observation unit from CSV: {session.observation_unit.name}")
+                logger.debug(f"Restored observation unit from CSV: {session.observation_unit.name}")
 
             # Create a parsed schema file with the extracted LLM configuration
             if metadata.get('llm_config'):
@@ -253,13 +260,13 @@ async def parse_file(session_id: str, mapping: Optional[ColumnMappingRequest] = 
                 # Also populate the session's extracted_schema for frontend access
                 session.metadata.extracted_schema = schema_data
 
-                print(f"DEBUG: Saved parsed schema with extracted LLM configuration")
-        
+                logger.debug("Saved parsed schema with extracted LLM configuration")
+
         # Restore observation_unit from JSON parse result if present (and not already set from CSV metadata)
         if result.get("observation_unit") and not session.observation_unit:
             from app.models.session import ObservationUnitInfo
             session.observation_unit = ObservationUnitInfo(**result["observation_unit"])
-            print(f"DEBUG: Restored observation unit from JSON: {session.observation_unit.name}")
+            logger.debug(f"Restored observation unit from JSON: {session.observation_unit.name}")
 
         # Update session with parsed data
         session.columns = result["columns"]
@@ -270,7 +277,7 @@ async def parse_file(session_id: str, mapping: Optional[ColumnMappingRequest] = 
         # Capture schema baseline for re-extraction change detection
         session_manager.capture_schema_baseline(session_id)
 
-        print(f"DEBUG: Session updated successfully")
+        logger.debug("Session updated successfully")
         
         # Include metadata info in response if available
         response = {"status": "success", "message": "File parsed successfully"}
@@ -283,9 +290,9 @@ async def parse_file(session_id: str, mapping: Optional[ColumnMappingRequest] = 
             }
         
         return response
-        
+
     except Exception as e:
-        print(f"DEBUG: Exception in parse_file: {e}")
+        logger.error(f"Exception in parse_file: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -323,7 +330,7 @@ async def get_data_with_filters(
         return data
 
     except Exception as e:
-        print(f"DEBUG: Exception in get_data_with_filters: {e}")
+        logger.error(f"Exception in get_data_with_filters: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -362,44 +369,45 @@ async def upload_dual_files(
 ):
     """Upload and validate both schema and data files."""
     try:
-        print(f"DEBUG: Received dual file upload - schema: {schema_file.filename}, data: {data_file.filename}")
-        
-        parser = FileParser()
-        
-        # Validate schema file
-        print("DEBUG: Validating schema file...")
-        schema_validation = await parser.validate_schema_file(schema_file)
-        print(f"DEBUG: Schema validation result: {schema_validation}")
-        
-        # Validate data file  
-        print("DEBUG: Validating data file...")
-        data_validation = await parser.validate_file(data_file)
-        print(f"DEBUG: Data validation result: {data_validation}")
-        
-        # Create session
         session_id = str(uuid.uuid4())
+        set_session_context(session_id)
+        logger.debug(f"Received dual file upload - schema: {schema_file.filename}, data: {data_file.filename}")
+
+        parser = FileParser()
+
+        # Validate schema file
+        logger.debug("Validating schema file...")
+        schema_validation = await parser.validate_schema_file(schema_file)
+        logger.debug(f"Schema validation result: {schema_validation}")
+
+        # Validate data file
+        logger.debug("Validating data file...")
+        data_validation = await parser.validate_file(data_file)
+        logger.debug(f"Data validation result: {data_validation}")
+
+        # Create session
         metadata = SessionMetadata(
             source=f"Dual Upload: {schema_file.filename} + {data_file.filename}"
         )
-        
+
         session = VisualizationSession(
             id=session_id,
             type=SessionType.UPLOAD,
             metadata=metadata
         )
-        
-        print(f"DEBUG: Created session: {session_id}")
-        
+
+        logger.debug(f"Created session: {session_id}")
+
         # Save files
         await parser.save_schema_file(session_id, schema_file, schema_validation)
         await parser.save_uploaded_file(session_id, data_file)
-        print(f"DEBUG: Files saved for session: {session_id}")
-        
+        logger.debug(f"Files saved for session: {session_id}")
+
         # Check compatibility if both files are valid
         compatibility = CompatibilityCheck(is_compatible=False)
         if schema_validation.is_valid and data_validation.is_valid:
-            print("DEBUG: Checking schema-data compatibility...")
-            
+            logger.debug("Checking schema-data compatibility...")
+
             # Get data columns from sample data or parse file preview
             data_columns = []
             if data_validation.sample_data:
@@ -408,20 +416,20 @@ async def upload_dual_files(
                     if isinstance(sample, dict):
                         data_columns.extend(sample.keys())
                         break
-            
+
             # Remove duplicates and clean column names
             data_columns = list(set(data_columns))
-            print(f"DEBUG: Data columns: {data_columns}")
-            print(f"DEBUG: Schema columns: {schema_validation.detected_columns}")
-            
+            logger.debug(f"Data columns: {data_columns}")
+            logger.debug(f"Schema columns: {schema_validation.detected_columns}")
+
             compatibility = parser.check_schema_data_compatibility(
                 schema_validation, data_validation, data_columns
             )
-            print(f"DEBUG: Compatibility result: {compatibility}")
-        
+            logger.debug(f"Compatibility result: {compatibility}")
+
         # Store session
         session_manager.create_session(session)
-        print(f"DEBUG: Session stored")
+        logger.debug("Session stored")
         
         return {
             "session_id": session_id,
@@ -430,9 +438,9 @@ async def upload_dual_files(
             "compatibility": compatibility.model_dump(),
             "requires_column_mapping": data_validation.detected_format == "csv"
         }
-        
+
     except Exception as e:
-        print(f"DEBUG: Exception in upload_dual_files: {e}")
+        logger.error(f"Exception in upload_dual_files: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -441,13 +449,14 @@ async def upload_dual_files(
 async def process_dual_files(session_id: str, mapping: Optional[ColumnMappingRequest] = None):
     """Process dual uploaded files with optional column mapping."""
     try:
-        print(f"DEBUG: Processing dual files for session: {session_id}")
-        
+        set_session_context(session_id)
+        logger.debug(f"Processing dual files for session: {session_id}")
+
         session = session_manager.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
-        
-        print(f"DEBUG: Found session: {session}")
+
+        logger.debug(f"Found session: {session}")
         
         parser = FileParser()
         
@@ -483,7 +492,7 @@ async def process_dual_files(session_id: str, mapping: Optional[ColumnMappingReq
             if schema_data.get('observation_unit'):
                 from app.models.session import ObservationUnitInfo
                 session.observation_unit = ObservationUnitInfo(**schema_data['observation_unit'])
-                print(f"DEBUG: Restored observation unit from parsed schema: {session.observation_unit.name}")
+                logger.debug(f"Restored observation unit from parsed schema: {session.observation_unit.name}")
         else:
             # Fallback to basic column info from data
             session.columns = result["columns"]
@@ -492,7 +501,7 @@ async def process_dual_files(session_id: str, mapping: Optional[ColumnMappingReq
         if result.get("observation_unit") and not session.observation_unit:
             from app.models.session import ObservationUnitInfo
             session.observation_unit = ObservationUnitInfo(**result["observation_unit"])
-            print(f"DEBUG: Restored observation unit from data file: {session.observation_unit.name}")
+            logger.debug(f"Restored observation unit from data file: {session.observation_unit.name}")
 
         session.statistics = result["statistics"]
         session.status = SessionStatus.COMPLETED
@@ -501,12 +510,12 @@ async def process_dual_files(session_id: str, mapping: Optional[ColumnMappingReq
         # Capture schema baseline for re-extraction change detection
         session_manager.capture_schema_baseline(session_id)
 
-        print(f"DEBUG: Dual file processing completed successfully")
+        logger.debug("Dual file processing completed successfully")
 
         return {"status": "success", "message": "Files processed successfully"}
 
     except Exception as e:
-        print(f"DEBUG: Exception in process_dual_files: {e}")
+        logger.error(f"Exception in process_dual_files: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -725,30 +734,31 @@ async def export_upload_data(
 async def extract_schema(session_id: str, query: str = ""):
     """Extract schema from uploaded data and convert to QBSD format."""
     try:
-        print(f"DEBUG: Extracting schema for session: {session_id}")
-        
+        set_session_context(session_id)
+        logger.debug(f"Extracting schema for session: {session_id}")
+
         session = session_manager.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
-        
+
         if session.type != SessionType.UPLOAD:
             raise HTTPException(status_code=400, detail="Schema extraction only available for upload sessions")
-        
+
         # Ensure session data is processed
         if session.status != SessionStatus.COMPLETED:
             raise HTTPException(status_code=400, detail="Session must be completed before schema extraction. Please parse the file first.")
-        
-        print(f"DEBUG: Session status: {session.status}, type: {session.type}")
-        
+
+        logger.debug(f"Session status: {session.status}, type: {session.type}")
+
         parser = FileParser()
-        
+
         # Extract schema from parsed data
         extracted_schema = await parser.extract_schema_from_data(
-            session_id, 
+            session_id,
             query if query.strip() else None
         )
-        
-        print(f"DEBUG: Extracted schema with {len(extracted_schema['schema'])} columns")
+
+        logger.debug(f"Extracted schema with {len(extracted_schema['schema'])} columns")
         
         # Update session with extracted schema
         session.status = SessionStatus.SCHEMA_EXTRACTED
@@ -771,18 +781,18 @@ async def extract_schema(session_id: str, query: str = ""):
         session.columns = schema_columns
         session.schema_query = extracted_schema['query']
         session_manager.update_session(session)
-        
-        print(f"DEBUG: Session updated with extracted schema, status: {session.status}")
-        
+
+        logger.debug(f"Session updated with extracted schema, status: {session.status}")
+
         return {
             "status": "success",
             "message": "Schema extracted successfully",
             "schema": extracted_schema,
             "total_columns": len(extracted_schema['schema'])
         }
-        
+
     except Exception as e:
-        print(f"DEBUG: Exception in extract_schema: {e}")
+        logger.error(f"Exception in extract_schema: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -793,7 +803,8 @@ async def add_documents(session_id: str, files: List[UploadFile] = File(...), by
     from app.core.config import MAX_DOCUMENTS, DEVELOPER_MODE
 
     try:
-        print(f"DEBUG: Adding {len(files)} documents to session: {session_id}")
+        set_session_context(session_id)
+        logger.debug(f"Adding {len(files)} documents to session: {session_id}")
 
         session = session_manager.get_session(session_id)
         if not session:
@@ -825,7 +836,7 @@ async def add_documents(session_id: str, files: List[UploadFile] = File(...), by
 
         # Ignore bypass_limit if DEVELOPER_MODE is not enabled
         if bypass_limit and not DEVELOPER_MODE:
-            print(f"WARNING: bypass_limit requested but DEVELOPER_MODE is disabled (session: {session_id})")
+            logger.warning(f"bypass_limit requested but DEVELOPER_MODE is disabled (session: {session_id})")
             bypass_limit = False
 
         # If over limit and not bypassed, randomly select files to fit within limit
@@ -836,7 +847,7 @@ async def add_documents(session_id: str, files: List[UploadFile] = File(...), by
             random.shuffle(valid_files)
             valid_files = valid_files[:available_slots]
             limit_applied = True
-            print(f"DEBUG: Document limit applied. Selected {len(valid_files)} of {new_count} files (max {MAX_DOCUMENTS}, existing {existing_count})")
+            logger.debug(f"Document limit applied. Selected {len(valid_files)} of {new_count} files (max {MAX_DOCUMENTS}, existing {existing_count})")
         elif enforce_limit and available_slots <= 0:
             raise HTTPException(
                 status_code=400,
@@ -846,7 +857,7 @@ async def add_documents(session_id: str, files: List[UploadFile] = File(...), by
         # Reconstruct files list: valid (possibly trimmed) + system files
         files = valid_files + system_files
 
-        print(f"DEBUG: Session status: {session.status}, extracted schema available")
+        logger.debug(f"Session status: {session.status}, extracted schema available")
         
         # Validate files
         errors = []
@@ -865,11 +876,11 @@ async def add_documents(session_id: str, files: List[UploadFile] = File(...), by
         # Process each uploaded file
         total_size = 0
         for i, file in enumerate(files):
-            print(f"DEBUG: Processing file {i+1}/{len(files)}: {file.filename}")
-            
+            logger.debug(f"Processing file {i+1}/{len(files)}: {file.filename}")
+
             # Skip system files that shouldn't be processed
             if _is_system_file(file.filename):
-                print(f"DEBUG: Skipping system file: {file.filename}")
+                logger.debug(f"Skipping system file: {file.filename}")
                 continue
             
             # Validate file size (10MB limit per file)
@@ -917,13 +928,13 @@ async def add_documents(session_id: str, files: List[UploadFile] = File(...), by
                         file_path.unlink()
                         file_path = txt_path
                         safe_filename = txt_path.name
-                        print(f"DEBUG: Converted PDF to text: {txt_path}")
+                        logger.debug(f"Converted PDF to text: {txt_path}")
                     except Exception as e:
                         errors.append(f"Failed to convert PDF '{file.filename}': {str(e)}")
                         continue
 
                 uploaded_filenames.append(safe_filename)
-                print(f"DEBUG: Saved file to pending: {file_path}")
+                logger.debug(f"Saved file to pending: {file_path}")
                 
             except Exception as e:
                 errors.append(f"Failed to save file '{file.filename}': {str(e)}")
@@ -940,8 +951,8 @@ async def add_documents(session_id: str, files: List[UploadFile] = File(...), by
         session.metadata.uploaded_documents = uploaded_filenames
         session.metadata.last_modified = datetime.now()
         session_manager.update_session(session)
-        
-        print(f"DEBUG: Updated session with {len(uploaded_filenames)} uploaded documents")
+
+        logger.debug(f"Updated session with {len(uploaded_filenames)} uploaded documents")
         
         response = {
             "status": "success",
@@ -956,11 +967,11 @@ async def add_documents(session_id: str, files: List[UploadFile] = File(...), by
             response["warnings"] = warnings + [f"Only {MAX_DOCUMENTS} documents are allowed. {new_count - len(uploaded_filenames)} documents were excluded by random selection."]
 
         return response
-        
+
     except HTTPException:
         raise
     except Exception as e:
-        print(f"DEBUG: Exception in add_documents: {e}")
+        logger.error(f"Exception in add_documents: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -992,7 +1003,8 @@ async def remove_uploaded_document(session_id: str, request: RemoveDocumentReque
         Status and updated list of uploaded documents
     """
     try:
-        print(f"DEBUG: Removing document '{request.filename}' from session: {session_id}")
+        set_session_context(session_id)
+        logger.debug(f"Removing document '{request.filename}' from session: {session_id}")
 
         session = session_manager.get_session(session_id)
         if not session:
@@ -1028,11 +1040,11 @@ async def remove_uploaded_document(session_id: str, request: RemoveDocumentReque
         if pending_file.exists():
             pending_file.unlink()
             files_removed.append(str(pending_file))
-            print(f"DEBUG: Removed file from pending: {pending_file}")
+            logger.debug(f"Removed file from pending: {pending_file}")
         if docs_file.exists():
             docs_file.unlink()
             files_removed.append(str(docs_file))
-            print(f"DEBUG: Removed file from documents: {docs_file}")
+            logger.debug(f"Removed file from documents: {docs_file}")
 
         # Update session status if no more documents
         if not session.metadata.uploaded_documents:
@@ -1045,7 +1057,7 @@ async def remove_uploaded_document(session_id: str, request: RemoveDocumentReque
         session.metadata.last_modified = datetime.now()
         session_manager.update_session(session)
 
-        print(f"DEBUG: Document removed. Remaining: {session.metadata.uploaded_documents}")
+        logger.debug(f"Document removed. Remaining: {session.metadata.uploaded_documents}")
 
         return {
             "status": "success",
@@ -1057,7 +1069,7 @@ async def remove_uploaded_document(session_id: str, request: RemoveDocumentReque
     except HTTPException:
         raise
     except Exception as e:
-        print(f"DEBUG: Exception in remove_uploaded_document: {e}")
+        logger.error(f"Exception in remove_uploaded_document: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -1078,7 +1090,8 @@ async def add_cloud_documents(session_id: str, request: CloudDocumentRequest):
         Status and list of added files
     """
     try:
-        print(f"DEBUG: Adding cloud documents from '{request.dataset}' to session: {session_id}")
+        set_session_context(session_id)
+        logger.debug(f"Adding cloud documents from '{request.dataset}' to session: {session_id}")
 
         session = session_manager.get_session(session_id)
         if not session:
@@ -1131,7 +1144,7 @@ async def add_cloud_documents(session_id: str, request: CloudDocumentRequest):
                     with open(file_path, 'wb') as f:
                         f.write(content)
                     downloaded_files.append(filename)
-                    print(f"DEBUG: Downloaded cloud file: {filename}")
+                    logger.debug(f"Downloaded cloud file: {filename}")
                 else:
                     errors.append(f"Could not download file: {filename}")
             except Exception as e:
@@ -1151,7 +1164,7 @@ async def add_cloud_documents(session_id: str, request: CloudDocumentRequest):
         session.metadata.last_modified = datetime.now()
         session_manager.update_session(session)
 
-        print(f"DEBUG: Added {len(downloaded_files)} cloud documents to session")
+        logger.debug(f"Added {len(downloaded_files)} cloud documents to session")
 
         return {
             "status": "success",
@@ -1164,7 +1177,7 @@ async def add_cloud_documents(session_id: str, request: CloudDocumentRequest):
     except HTTPException:
         raise
     except Exception as e:
-        print(f"DEBUG: Exception in add_cloud_documents: {e}")
+        logger.error(f"Exception in add_cloud_documents: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -1185,8 +1198,9 @@ async def confirm_websocket_ready(session_id: str):
     """
     from services import websocket_manager
 
+    set_session_context(session_id)
     conn_count = websocket_manager.get_connection_count(session_id)
-    print(f"🔍 WebSocket confirmation request for {session_id}: {conn_count} connections")
+    logger.info(f"WebSocket confirmation request for {session_id}: {conn_count} connections")
 
     if conn_count == 0:
         raise HTTPException(
@@ -1201,7 +1215,8 @@ async def confirm_websocket_ready(session_id: str):
 async def process_documents(session_id: str, background_tasks: BackgroundTasks, request: Optional[DocumentProcessingRequest] = None):
     """Start processing uploaded documents with extracted schema using QBSD pipeline."""
     try:
-        print(f"DEBUG: Starting document processing for session: {session_id}")
+        set_session_context(session_id)
+        logger.debug(f"Starting document processing for session: {session_id}")
         
         session = session_manager.get_session(session_id)
         if not session:
@@ -1229,14 +1244,14 @@ async def process_documents(session_id: str, background_tasks: BackgroundTasks, 
 
         # If session has columns but no extracted_schema, create it (for regular upload or QBSD sessions)
         if not session.metadata.extracted_schema and session.columns:
-            print(f"DEBUG: Converting session columns to extracted_schema format (type: {session.type})")
+            logger.debug(f"Converting session columns to extracted_schema format (type: {session.type})")
             # Use schema_query for QBSD sessions, fallback for upload sessions
             query = session.schema_query if session.schema_query else f"Data processing for {session.metadata.source}"
             extracted_schema = {
                 "query": query,
                 "schema": []
             }
-            
+
             # Convert columns to schema format, excluding excerpt columns
             for col in session.columns:
                 if col.name and not col.name.lower().endswith('_excerpt'):
@@ -1254,13 +1269,13 @@ async def process_documents(session_id: str, background_tasks: BackgroundTasks, 
             # Store the converted schema in session metadata for processing
             session.metadata.extracted_schema = extracted_schema
             session_manager.update_session(session)
-            print(f"DEBUG: Created extracted_schema with {len(extracted_schema['schema'])} columns")
-        
+            logger.debug(f"Created extracted_schema with {len(extracted_schema['schema'])} columns")
+
         if not session.metadata.uploaded_documents:
             raise HTTPException(status_code=400, detail="No uploaded documents found for processing")
-        
+
         schema_count = len(session.metadata.extracted_schema['schema']) if session.metadata.extracted_schema else 0
-        print(f"DEBUG: Session ready for processing - {len(session.metadata.uploaded_documents)} documents, {schema_count} schema columns")
+        logger.debug(f"Session ready for processing - {len(session.metadata.uploaded_documents)} documents, {schema_count} schema columns")
         
         # Create UploadDocumentProcessor and start processing in background
         from app.services.upload_document_processor import UploadDocumentProcessor
@@ -1284,7 +1299,7 @@ async def process_documents(session_id: str, background_tasks: BackgroundTasks, 
             config_for_log = {k: v for k, v in user_llm_config.items() if k != 'api_key'}
             has_api_key = 'api_key' in user_llm_config and user_llm_config['api_key']
             api_key_info = f"api_key={'present ('+str(len(user_llm_config['api_key']))+' chars)' if has_api_key else 'MISSING'}"
-            print(f"DEBUG: Using user-provided LLM config: {config_for_log}, {api_key_info}")
+            logger.debug(f"Using user-provided LLM config: {config_for_log}, {api_key_info}")
 
             # Store the user configuration in session directory for processing
             session_dir = Path("./data") / session_id
@@ -1293,16 +1308,16 @@ async def process_documents(session_id: str, background_tasks: BackgroundTasks, 
 
             with open(user_config_file, 'w') as f:
                 json.dump(user_llm_config, f, indent=2)
-        
+
         session_manager.update_session(session)
-        
+
         # Reserve a concurrency slot
         await concurrency_limiter.acquire(session_id, "upload_extraction")
 
         # Start processing in background
         background_tasks.add_task(processor.process_documents, session_id)
 
-        print(f"DEBUG: Document processing started in background for session: {session_id}")
+        logger.debug(f"Document processing started in background for session: {session_id}")
 
         return {
             "status": "success",
@@ -1320,7 +1335,7 @@ async def process_documents(session_id: str, background_tasks: BackgroundTasks, 
         raise
     except Exception as e:
         await concurrency_limiter.release(session_id)
-        print(f"DEBUG: Exception in process_documents: {e}")
+        logger.error(f"Exception in process_documents: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -1396,7 +1411,7 @@ async def stop_document_processing(session_id: str):
             }
 
     except Exception as e:
-        print(f"DEBUG: Exception in stop_document_processing: {e}")
+        logger.error(f"Exception in stop_document_processing: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -1433,9 +1448,9 @@ async def get_processing_status(session_id: str):
             status_info["progress"] = 0.0
         
         return status_info
-        
+
     except Exception as e:
-        print(f"DEBUG: Exception in get_processing_status: {e}")
+        logger.error(f"Exception in get_processing_status: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/export-complete/{session_id}")
@@ -1616,7 +1631,7 @@ async def export_complete_data(session_id: str, format: str = "json"):
             raise HTTPException(status_code=400, detail="Unsupported format. Use 'json' or 'zip'")
         
     except Exception as e:
-        print(f"DEBUG: Exception in export_complete_data: {e}")
+        logger.error(f"Exception in export_complete_data: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -1746,7 +1761,7 @@ async def export_upload_rich_csv(session_id: str):
         )
         
     except Exception as e:
-        print(f"DEBUG: Exception in export_upload_rich_csv: {e}")
+        logger.error(f"Exception in export_upload_rich_csv: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -1810,9 +1825,9 @@ async def export_schema_only(session_id: str):
             media_type='application/json',
             headers={"Content-Disposition": f"attachment; filename={filename}"}
         )
-        
+
     except Exception as e:
-        print(f"DEBUG: Exception in export_schema_only: {e}")
+        logger.error(f"Exception in export_schema_only: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/backend/app/api/routes/observation_unit.py
+++ b/backend/app/api/routes/observation_unit.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
+from app.core.logging_utils import set_session_context
 from app.services.session_manager import SessionManager
 from app.services.observation_unit_manager import ObservationUnitManager
 from app.services import session_manager, websocket_manager
@@ -101,6 +102,7 @@ async def remove_observation_unit(
     Raises:
         HTTPException: If session not found or unit doesn't exist
     """
+    set_session_context(session_id)
     logger.info("Removing observation unit '%s' from session %s", request.unit_name, session_id)
     session = session_manager.get_session(session_id)
     if not session:
@@ -154,6 +156,7 @@ async def remove_bulk_observation_units(
     Raises:
         HTTPException: If session not found
     """
+    set_session_context(session_id)
     logger.info("Bulk removing %d observation units from session %s", len(request.unit_names), session_id)
     session = session_manager.get_session(session_id)
     if not session:
@@ -223,6 +226,7 @@ async def add_observation_unit(
     Raises:
         HTTPException: If session not found or unit already exists
     """
+    set_session_context(session_id)
     logger.info("Adding observation unit '%s' to session %s", request.unit_name, session_id)
     session = session_manager.get_session(session_id)
     if not session:
@@ -269,6 +273,7 @@ async def list_observation_units(session_id: str) -> dict:
     Raises:
         HTTPException: If session not found
     """
+    set_session_context(session_id)
     logger.debug("Listing observation units for session %s", session_id)
     session = session_manager.get_session(session_id)
     if not session:
@@ -305,6 +310,7 @@ async def update_observation_unit_definition(
     Raises:
         HTTPException: If session not found or validation fails
     """
+    set_session_context(session_id)
     logger.info("Updating observation unit definition for session %s: name='%s'", session_id, request.name)
     session = session_manager.get_session(session_id)
     if not session:

--- a/backend/app/api/routes/qbsd.py
+++ b/backend/app/api/routes/qbsd.py
@@ -5,6 +5,7 @@ import asyncio
 import csv
 import io
 import json
+import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import List, Optional
@@ -19,9 +20,11 @@ from app.services import websocket_manager, session_manager, concurrency_limiter
 from app.core.config import MAX_DOCUMENTS, DEVELOPER_MODE
 from app.core.exceptions import CapacityExceededError
 from app.storage import get_storage
+from app.core.logging_utils import set_session_context
 
 from qbsd.core.cost_estimator import estimate_from_config
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 # Create shared QBSD runner instance with shared managers
 qbsd_runner = QBSDRunner(websocket_manager=websocket_manager, session_manager=session_manager)
@@ -105,39 +108,42 @@ def _convert_estimate_result(result) -> CostEstimate:
 @router.post("/configure", response_model=dict)
 async def configure_qbsd(config: QBSDConfig):
     """Configure a new QBSD session."""
+    session_id = None
     try:
-        print(f"DEBUG: Received QBSD config: {config}")
-        
+        logger.debug(f"Received QBSD config: {config}")
+
         # Validate configuration
         validation = await qbsd_runner.validate_config(config)
-        
-        print(f"DEBUG: Validation result: {validation}")
-        
+
+        logger.debug(f"Validation result: {validation}")
+
         if not validation["is_valid"]:
             raise HTTPException(status_code=400, detail=validation["errors"])
-        
+
         # Create session
         session_id = str(uuid.uuid4())
+        set_session_context(session_id)
+
         metadata = SessionMetadata(source=f"QBSD Query: {config.query[:50]}...")
-        
+
         session = VisualizationSession(
             id=session_id,
             type=SessionType.QBSD,
             metadata=metadata,
             schema_query=config.query
         )
-        
+
         # Store session and config
         session_manager.create_session(session)
         await qbsd_runner.save_config(session_id, config)
-        
+
         return {
             "session_id": session_id,
             "message": "QBSD session configured successfully"
         }
-        
+
     except Exception as e:
-        print(f"DEBUG: Exception in configure_qbsd: {e}")
+        logger.error(f"Exception in configure_qbsd: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -450,7 +456,7 @@ async def list_document_directories():
                 break
 
         if research_data_path is None:
-            print(f"DEBUG: Could not find research/data directory. Tried: {[str(c) for c in candidates]}")
+            logger.debug(f"Could not find research/data directory. Tried: {[str(c) for c in candidates]}")
             return []
 
         directories = []
@@ -464,7 +470,7 @@ async def list_document_directories():
         return directories
 
     except Exception as e:
-        print(f"DEBUG: Error listing directories: {e}")
+        logger.error(f"Error listing directories: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -491,7 +497,7 @@ async def list_schema_files():
                 break
 
         if config_path is None:
-            print(f"DEBUG: Could not find research/experiments/configurations directory. Tried: {[str(c) for c in candidates]}")
+            logger.debug(f"Could not find research/experiments/configurations directory. Tried: {[str(c) for c in candidates]}")
             return []
 
         schema_files = []
@@ -532,7 +538,7 @@ async def list_schema_files():
         return schema_files
 
     except Exception as e:
-        print(f"DEBUG: Error listing schema files: {e}")
+        logger.error(f"Error listing schema files: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -550,6 +556,7 @@ async def export_qbsd_data(
         tz_offset: Timezone offset in minutes from UTC (for filename timestamp)
     """
     try:
+        set_session_context(session_id)
         session = session_manager.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
@@ -592,6 +599,7 @@ async def export_qbsd_data(
                         backend = qbsd_config["backend"]
                         output.write(f"# AI Model: {backend.get('provider', 'unknown')} {backend.get('model', 'unknown')}\n")
             except Exception as e:
+                logger.warning(f"Error loading LLM config for export: {e}")
                 output.write(f"# LLM Config: Error loading ({e})\n")
         
         output.write("#\n")
@@ -759,6 +767,7 @@ async def export_complete_qbsd_data(
 ):
     """Export complete QBSD data with schema metadata in multiple formats."""
     try:
+        set_session_context(session_id)
         session = session_manager.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
@@ -781,8 +790,8 @@ async def export_complete_qbsd_data(
                         "value_extraction_backend": qbsd_config.get("value_extraction_backend")
                     }
             except Exception as e:
-                print(f"DEBUG: Could not load LLM configuration for complete export: {e}")
-        
+                logger.warning(f"Could not load LLM configuration for complete export: {e}")
+
         # Prepare complete export data structure
         export_data = {
             "session_id": session_id,
@@ -969,7 +978,7 @@ async def export_complete_qbsd_data(
             raise HTTPException(status_code=400, detail="Unsupported format. Use 'json' or 'zip'")
         
     except Exception as e:
-        print(f"DEBUG: Exception in export_complete_qbsd_data: {e}")
+        logger.error(f"Exception in export_complete_qbsd_data: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -981,6 +990,7 @@ async def export_qbsd_rich_csv(
 ):
     """Export QBSD data as metadata-rich CSV with definition and rationale columns."""
     try:
+        set_session_context(session_id)
         session = session_manager.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
@@ -1116,6 +1126,7 @@ async def export_qbsd_schema_only(
 ):
     """Export only the QBSD schema metadata."""
     try:
+        set_session_context(session_id)
         session = session_manager.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
@@ -1134,7 +1145,7 @@ async def export_qbsd_schema_only(
                         "value_extraction_backend": qbsd_config.get("value_extraction_backend")
                     }
             except Exception as e:
-                print(f"DEBUG: Could not load LLM configuration: {e}")
+                logger.warning(f"Could not load LLM configuration: {e}")
 
         # Create QBSD schema export
         schema_columns = []
@@ -1191,5 +1202,5 @@ async def export_qbsd_schema_only(
         )
         
     except Exception as e:
-        print(f"DEBUG: Exception in export_qbsd_schema_only: {e}")
+        logger.error(f"Exception in export_qbsd_schema_only: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/api/routes/schema.py
+++ b/backend/app/api/routes/schema.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from datetime import datetime
 import json
 import asyncio
+import logging
 from pathlib import Path
 
 from app.models.session import VisualizationSession, SessionStatus, ColumnInfo
@@ -20,7 +21,9 @@ from app.services.reextraction_service import ReextractionService
 from app.services.continue_discovery_service import ContinueDiscoveryService
 from app.services import session_manager, websocket_manager, concurrency_limiter
 from app.core.exceptions import CapacityExceededError
+from app.core.logging_utils import set_session_context
 
+logger = logging.getLogger(__name__)
 router = APIRouter(tags=["schema"])
 
 # Create schema manager instance
@@ -158,6 +161,7 @@ async def edit_column(
 async def delete_column(session_id: str, column_name: str):
     """Delete a column from the schema and existing data."""
     try:
+        set_session_context(session_id)
         session = session_manager.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
@@ -189,9 +193,9 @@ async def delete_column(session_id: str, column_name: str):
         session_manager.update_session(session)
 
         # Remove column data from existing records
-        print(f"DEBUG: Starting column data removal for '{column_name}' in session {session_id}")
+        logger.debug(f"Starting column data removal for '{column_name}'")
         await schema_manager.remove_column_data(session_id, column_name)
-        print(f"DEBUG: Column data removal completed for '{column_name}'")
+        logger.debug(f"Column data removal completed for '{column_name}'")
         
         # Update statistics to reflect deleted column
         if session.statistics and session.statistics.column_stats:
@@ -235,12 +239,13 @@ async def delete_column(session_id: str, column_name: str):
 
 @router.post("/add-column/{session_id}")
 async def add_column(
-    session_id: str, 
+    session_id: str,
     add_request: ColumnAddRequest,
     background_tasks: BackgroundTasks
 ):
     """Add a new column to the schema and extract values from documents."""
     try:
+        set_session_context(session_id)
         session = session_manager.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
@@ -312,7 +317,7 @@ async def add_column(
                 json.dump(add_request.llm_config, f, indent=2)
             config_for_log = {k: v for k, v in add_request.llm_config.items() if k != 'api_key'}
             has_api_key = 'api_key' in add_request.llm_config and add_request.llm_config['api_key']
-            print(f"DEBUG: Saved user LLM config for add-column: {config_for_log}, api_key={'present' if has_api_key else 'MISSING'}")
+            logger.debug(f"Saved user LLM config for add-column: {config_for_log}, api_key={'present' if has_api_key else 'MISSING'}")
 
         # Schedule value extraction for new column
         background_tasks.add_task(
@@ -927,6 +932,7 @@ async def start_reextraction(
 ) -> ReextractionResponse:
     """Start selective re-extraction for specified columns."""
     try:
+        set_session_context(session_id)
         session = session_manager.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
@@ -944,7 +950,7 @@ async def start_reextraction(
             # Log without exposing full API key
             config_for_log = {k: v for k, v in request.llm_config.items() if k != 'api_key'}
             has_api_key = 'api_key' in request.llm_config and request.llm_config['api_key']
-            print(f"DEBUG: Saved user LLM config for re-extraction: {config_for_log}, api_key={'present' if has_api_key else 'MISSING'}")
+            logger.debug(f"Saved user LLM config for re-extraction: {config_for_log}, api_key={'present' if has_api_key else 'MISSING'}")
 
         # Reserve a concurrency slot
         await concurrency_limiter.acquire(session_id, "reextraction")

--- a/backend/app/api/routes/websocket.py
+++ b/backend/app/api/routes/websocket.py
@@ -3,8 +3,11 @@
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 import json
 import asyncio
+import logging
 from app.services import websocket_manager
+from app.core.logging_utils import set_session_context
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 # Server-side heartbeat interval (seconds) - keeps connection alive on Railway
@@ -15,7 +18,8 @@ SERVER_HEARTBEAT_INTERVAL = 20
 async def websocket_progress(websocket: WebSocket, session_id: str):
     """WebSocket endpoint for real-time progress updates."""
     await websocket.accept()
-    print(f"🔌 WebSocket CONNECTED: {session_id}")
+    set_session_context(session_id)
+    logger.info("WebSocket connected")
 
     # Flag to control heartbeat task
     connection_active = True
@@ -36,7 +40,7 @@ async def websocket_progress(websocket: WebSocket, session_id: str):
     try:
         # Add connection to manager
         await websocket_manager.add_connection(session_id, websocket)
-        print(f"🔌 WebSocket REGISTERED: {session_id} (total: {websocket_manager.get_connection_count(session_id)})")
+        logger.info(f"WebSocket registered (total: {websocket_manager.get_connection_count(session_id)})")
 
         # Send initial connection confirmation
         await websocket.send_json({
@@ -67,7 +71,7 @@ async def websocket_progress(websocket: WebSocket, session_id: str):
             except WebSocketDisconnect:
                 break
             except Exception as e:
-                print(f"🔌 WebSocket error for {session_id}: {e}")
+                logger.error(f"WebSocket error: {e}")
                 try:
                     await websocket.send_json({
                         "type": "error",
@@ -77,7 +81,7 @@ async def websocket_progress(websocket: WebSocket, session_id: str):
                     break
 
     except WebSocketDisconnect:
-        print(f"🔌 WebSocket DISCONNECTED: {session_id}")
+        logger.info("WebSocket disconnected")
     finally:
         connection_active = False
         heartbeat_task.cancel()
@@ -86,14 +90,15 @@ async def websocket_progress(websocket: WebSocket, session_id: str):
         except asyncio.CancelledError:
             pass
         await websocket_manager.remove_connection(session_id, websocket)
-        print(f"🔌 WebSocket REMOVED: {session_id} (remaining: {websocket_manager.get_connection_count(session_id)})")
+        logger.info(f"WebSocket removed (remaining: {websocket_manager.get_connection_count(session_id)})")
 
 
 @router.websocket("/logs/{session_id}")
 async def websocket_logs(websocket: WebSocket, session_id: str):
     """WebSocket endpoint for real-time log streaming."""
     await websocket.accept()
-    print(f"🔌 Log WebSocket CONNECTED: {session_id}")
+    set_session_context(session_id)
+    logger.info("Log WebSocket connected")
 
     # Flag to control heartbeat task
     connection_active = True
@@ -146,4 +151,4 @@ async def websocket_logs(websocket: WebSocket, session_id: str):
         except asyncio.CancelledError:
             pass
         await websocket_manager.remove_log_connection(session_id, websocket)
-        print(f"🔌 Log WebSocket REMOVED: {session_id}")
+        logger.info("Log WebSocket removed")

--- a/backend/app/core/logging_utils.py
+++ b/backend/app/core/logging_utils.py
@@ -1,0 +1,35 @@
+"""Session-aware logging utilities.
+
+Uses Python's contextvars to automatically inject session IDs into all
+logger.* calls via a custom logging.Filter. Set the session context once
+at the entry point (route handler or service method), and it propagates
+automatically through BackgroundTasks, run_in_executor threads, and
+asyncio.create_task calls.
+"""
+
+import contextvars
+import logging
+
+# Context variable holding the current session ID.
+# Empty string means no session context (e.g., startup, system-level logs).
+current_session_id: contextvars.ContextVar[str] = contextvars.ContextVar(
+    'current_session_id', default=''
+)
+
+
+class SessionFilter(logging.Filter):
+    """Injects session_id into every log record from the contextvar."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        sid = current_session_id.get('')
+        record.session_id = sid[:8] if sid else 'no-session'
+        return True
+
+
+def set_session_context(session_id: str) -> contextvars.Token:
+    """Set the session_id for the current async/thread context.
+
+    Returns a token that can be used to reset the context via
+    current_session_id.reset(token).
+    """
+    return current_session_id.set(session_id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,13 +7,19 @@ from pathlib import Path
 
 # Configure logging to show in container logs
 # Set LOG_LEVEL=DEBUG to see detailed schema column tracking
+# Format includes [session_id] for Railway log filtering per session
+from app.core.logging_utils import SessionFilter
+
 log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
     level=getattr(logging, log_level, logging.INFO),
-    format='%(levelname)s:%(name)s:%(message)s',
+    format='%(levelname)s:%(name)s:[%(session_id)s] %(message)s',
     stream=sys.stdout,
     force=True
 )
+# Attach session filter to all root handlers so every logger gets session_id
+for _handler in logging.root.handlers:
+    _handler.addFilter(SessionFilter())
 
 # Add qbsd-lib to Python path (sibling directory to backend)
 _QBSD_LIB_PATH = Path(__file__).parent.parent.parent / "qbsd-lib"

--- a/backend/app/services/continue_discovery_service.py
+++ b/backend/app/services/continue_discovery_service.py
@@ -4,6 +4,7 @@ Handles continuing schema discovery with existing schema as starting point,
 discovering new columns, and incremental value extraction.
 """
 
+import logging
 import json
 import asyncio
 import functools
@@ -14,6 +15,8 @@ import shutil
 from typing import List, Dict, Any, Optional, Set
 from pathlib import Path
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
 
 from app.models.session import (
     ColumnInfo, VisualizationSession
@@ -26,6 +29,7 @@ from app.services.websocket_mixin import WebSocketBroadcasterMixin
 from app.services import qbsd_thread_pool, concurrency_limiter
 from app.storage.factory import get_storage
 from app.core.config import DEVELOPER_MODE, RELEASE_CONFIG, MAX_DOCUMENTS
+from app.core.logging_utils import set_session_context
 
 # QBSD library imports
 from qbsd.core import qbsd as QBSD
@@ -202,11 +206,11 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
         """
         session = self.session_manager.get_session(session_id)
         if not session:
-            print(f"DEBUG: Cannot recompute statistics - session {session_id} not found")
+            logger.debug(f"Cannot recompute statistics - session {session_id} not found")
             return
 
         # Debug: print all column names before filtering
-        print(f"DEBUG: session.columns before filtering ({len(session.columns)}): {[c.name for c in session.columns]}")
+        logger.debug(f"session.columns before filtering ({len(session.columns)}): {[c.name for c in session.columns]}")
 
         # Deduplicate session.columns by name (keep first occurrence)
         # AND filter out _excerpt columns for statistics counting
@@ -221,22 +225,22 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                 if not col.name.lower().endswith('_excerpt'):
                     non_excerpt_columns.append(col)
             elif col.name:
-                print(f"DEBUG: Removing duplicate column: {col.name}")
+                logger.debug(f"Removing duplicate column: {col.name}")
 
         if len(unique_columns) != len(session.columns):
-            print(f"DEBUG: Deduplicated columns: {len(session.columns)} -> {len(unique_columns)}")
+            logger.debug(f"Deduplicated columns: {len(session.columns)} -> {len(unique_columns)}")
             session.columns = unique_columns
             self.session_manager.update_session(session)
 
         # Use non-excerpt count for statistics (this is what users care about)
         actual_column_count = len(non_excerpt_columns)
-        print(f"DEBUG: Non-excerpt columns for statistics: {actual_column_count} (total with excerpts: {len(unique_columns)})")
+        logger.debug(f"Non-excerpt columns for statistics: {actual_column_count} (total with excerpts: {len(unique_columns)})")
 
         session_dir = self._get_data_dir() / session_id
         data_file = session_dir / "data.jsonl"
 
         if not data_file.exists():
-            print(f"DEBUG: Cannot recompute statistics - no data.jsonl found")
+            logger.debug(f"Cannot recompute statistics - no data.jsonl found")
             return
 
         # Read all rows from data file
@@ -247,11 +251,11 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     if line.strip():
                         data_rows.append(json.loads(line))
         except Exception as e:
-            print(f"DEBUG: Error reading data for statistics: {e}")
+            logger.error(f"Error reading data for statistics: {e}")
             return
 
         if not data_rows:
-            print(f"DEBUG: No data rows found for statistics computation")
+            logger.debug(f"No data rows found for statistics computation")
             return
 
         # Preserve existing schema evolution and skipped_documents, but fix any corrupted data
@@ -263,14 +267,14 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             existing_evolution = session.statistics.schema_evolution
             actual_total = actual_column_count  # Use deduplicated count
 
-            print(f"DEBUG: Schema evolution cleanup - actual columns: {actual_total}")
-            print(f"DEBUG: Before cleanup - {len(existing_evolution.snapshots)} snapshots:")
+            logger.debug(f"Schema evolution cleanup - actual columns: {actual_total}")
+            logger.debug(f"Before cleanup - {len(existing_evolution.snapshots)} snapshots:")
             for i, snap in enumerate(existing_evolution.snapshots):
                 # Handle both dict and object formats
                 if isinstance(snap, dict):
-                    print(f"DEBUG:   Snapshot {i} (dict): iteration={snap.get('iteration')}, total_columns={snap.get('total_columns')}, new_columns={snap.get('new_columns')}")
+                    logger.debug(f"  Snapshot {i} (dict): iteration={snap.get('iteration')}, total_columns={snap.get('total_columns')}, new_columns={snap.get('new_columns')}")
                 else:
-                    print(f"DEBUG:   Snapshot {i} (obj): iteration={snap.iteration}, total_columns={snap.total_columns}, new_columns={snap.new_columns}")
+                    logger.debug(f"  Snapshot {i} (obj): iteration={snap.iteration}, total_columns={snap.total_columns}, new_columns={snap.new_columns}")
 
             # Helper to get/set snapshot attributes (handles both dict and object)
             def get_snap_attr(snap, attr):
@@ -294,9 +298,9 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                         seen_iterations.add(iteration)
                         unique_snapshots.append(snapshot)
                     else:
-                        print(f"DEBUG: Removing duplicate snapshot for iteration {iteration}")
+                        logger.debug(f"Removing duplicate snapshot for iteration {iteration}")
                 if len(unique_snapshots) != len(existing_evolution.snapshots):
-                    print(f"DEBUG: Removed {len(existing_evolution.snapshots) - len(unique_snapshots)} duplicate snapshots")
+                    logger.debug(f"Removed {len(existing_evolution.snapshots) - len(unique_snapshots)} duplicate snapshots")
                     existing_evolution.snapshots = unique_snapshots
 
                 # Fix all snapshots to ensure total_columns doesn't exceed actual column count
@@ -304,10 +308,10 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     total_cols = get_snap_attr(snapshot, 'total_columns')
                     iteration = get_snap_attr(snapshot, 'iteration')
                     if total_cols and total_cols > actual_total:
-                        print(f"DEBUG: Fixing snapshot {iteration} total_columns: {total_cols} -> {actual_total}")
+                        logger.debug(f"Fixing snapshot {iteration} total_columns: {total_cols} -> {actual_total}")
                         set_snap_attr(snapshot, 'total_columns', actual_total)
 
-            print(f"DEBUG: After cleanup - {len(existing_evolution.snapshots)} snapshots")
+            logger.debug(f"After cleanup - {len(existing_evolution.snapshots)} snapshots")
 
         # Helper function to check if a value is valid (non-null)
         def is_valid_value(value):
@@ -393,7 +397,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
         )
 
         self.session_manager.update_session(session)
-        print(f"DEBUG: Statistics recomputed - {len(data_rows)} rows, {total_documents} documents, {len(columns)} columns, {completeness:.1f}% complete")
+        logger.info(f"Statistics recomputed - {len(data_rows)} rows, {total_documents} documents, {len(columns)} columns, {completeness:.1f}% complete")
 
     # ==================== Document Discovery ====================
 
@@ -421,39 +425,39 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
         all_papers: Set[str] = set()
         paper_doc_dirs: Dict[str, str] = {}  # paper_name -> document_directory
 
-        print(f"DEBUG get_available_documents: session_id={session_id}")
-        print(f"DEBUG: storage type = {type(storage).__name__}")
-        print(f"DEBUG: cloud_dataset from session = {session.metadata.cloud_dataset if session.metadata else None}")
+        logger.debug(f"get_available_documents: session_id={session_id}")
+        logger.debug(f"storage type = {type(storage).__name__}")
+        logger.debug(f"cloud_dataset from session = {session.metadata.cloud_dataset if session.metadata else None}")
 
         # 1. Get data.jsonl content - try Supabase first, then local
         data_content = None
         try:
             # Try to download from Supabase 'data' bucket
-            print(f"DEBUG: Attempting Supabase download: data/{session_id}/data.jsonl")
+            logger.debug(f"Attempting Supabase download: data/{session_id}/data.jsonl")
             data_bytes = await storage.download_file('data', f'{session_id}/data.jsonl')
             if data_bytes:
                 data_content = data_bytes.decode('utf-8')
-                print(f"DEBUG: Downloaded data.jsonl from Supabase, size={len(data_content)} bytes")
+                logger.debug(f"Downloaded data.jsonl from Supabase, size={len(data_content)} bytes")
         except Exception as e:
-            print(f"DEBUG: Supabase download failed: {type(e).__name__}: {e}")
+            logger.debug(f"Supabase download failed: {type(e).__name__}: {e}")
 
         # Fallback to local file if Supabase didn't work
         if not data_content:
             data_dir = self._get_data_dir()
-            print(f"DEBUG: Local data_dir = {data_dir}")
+            logger.debug(f"Local data_dir = {data_dir}")
             session_dir = data_dir / session_id
             data_file = session_dir / "data.jsonl"
-            print(f"DEBUG: Checking local file: {data_file}, exists={data_file.exists()}")
+            logger.debug(f"Checking local file: {data_file}, exists={data_file.exists()}")
             if data_file.exists():
                 data_content = data_file.read_text()
-                print(f"DEBUG: Read data.jsonl from local, size={len(data_content)} bytes")
+                logger.debug(f"Read data.jsonl from local, size={len(data_content)} bytes")
             else:
                 # List what's in the data_dir
                 if data_dir.exists():
                     sessions_in_dir = list(data_dir.iterdir())[:5]
-                    print(f"DEBUG: data_dir exists, sample contents: {[s.name for s in sessions_in_dir]}")
+                    logger.debug(f"data_dir exists, sample contents: {[s.name for s in sessions_in_dir]}")
                 else:
-                    print(f"DEBUG: data_dir does not exist: {data_dir}")
+                    logger.debug(f"data_dir does not exist: {data_dir}")
 
         # 2. Parse data.jsonl to collect paper references
         if data_content:
@@ -495,7 +499,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                 except json.JSONDecodeError:
                     continue
 
-        print(f"DEBUG: Found {len(all_papers)} paper references in data.jsonl")
+        logger.debug(f"Found {len(all_papers)} paper references in data.jsonl")
 
         # 3. Check local documents
         local_docs: Set[str] = set()
@@ -530,12 +534,12 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
 
                 # If doc_dir is a local path, try to use cloud_dataset as fallback
                 if doc_dir and self._is_local_path(doc_dir):
-                    print(f"DEBUG: Detected local path for paper {paper}: {doc_dir}")
+                    logger.debug(f"Detected local path for paper {paper}: {doc_dir}")
                     if cloud_dataset:
                         doc_dir = f"datasets/{cloud_dataset}"
-                        print(f"DEBUG: Using cloud_dataset fallback: {doc_dir}")
+                        logger.debug(f"Using cloud_dataset fallback: {doc_dir}")
                     else:
-                        print(f"DEBUG: No cloud_dataset fallback - skipping paper {paper}")
+                        logger.debug(f"No cloud_dataset fallback - skipping paper {paper}")
                         continue
 
                 # If no doc_dir, try cloud_dataset as fallback
@@ -552,16 +556,16 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             for folder, papers in folders_to_check.items():
                 try:
                     folder_files = await storage.list_folder_files('datasets', folder)
-                    print(f"DEBUG: Found {len(folder_files)} files in datasets/{folder}")
+                    logger.debug(f"Found {len(folder_files)} files in datasets/{folder}")
                     for paper in papers:
                         if paper in folder_files or f"{paper}.txt" in folder_files:
                             cloud_docs.add(paper)
                 except Exception as e:
-                    print(f"DEBUG: Could not list folder {folder}: {e}")
+                    logger.debug(f"Could not list folder {folder}: {e}")
 
         # 6. Combine results
         available_docs = local_docs | cloud_docs
-        print(f"DEBUG: Available docs: {len(local_docs)} local + {len(cloud_docs)} cloud = {len(available_docs)} total")
+        logger.debug(f"Available docs: {len(local_docs)} local + {len(cloud_docs)} cloud = {len(available_docs)} total")
 
         # 7. Get list of all available cloud datasets
         cloud_datasets = []
@@ -572,7 +576,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                 for item in items:
                     if not item.get('id'):  # Folders don't have 'id'
                         cloud_datasets.append(item.get('name'))
-                print(f"DEBUG: Found {len(cloud_datasets)} cloud datasets via Supabase client")
+                logger.debug(f"Found {len(cloud_datasets)} cloud datasets via Supabase client")
             else:
                 # Local storage fallback
                 files = await storage.list_files('datasets', '')
@@ -587,9 +591,9 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     elif isinstance(f, str) and '/' in f:
                         seen_folders.add(f.split('/')[0])
                 cloud_datasets.extend(list(seen_folders))
-                print(f"DEBUG: Found {len(cloud_datasets)} cloud datasets via list_files")
+                logger.debug(f"Found {len(cloud_datasets)} cloud datasets via list_files")
         except Exception as e:
-            print(f"DEBUG: Could not list cloud datasets: {e}")
+            logger.debug(f"Could not list cloud datasets: {e}")
 
         return {
             "original_documents": sorted(list(available_docs)),
@@ -644,7 +648,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                             documents.append(content)
                             filenames.append(f.name)
                         except Exception as e:
-                            print(f"DEBUG: Could not read {f}: {e}")
+                            logger.debug(f"Could not read {f}: {e}")
 
             # Also check qbsd_work directory
             if not documents and qbsd_work_dir.exists():
@@ -657,7 +661,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                                     documents.append(content)
                                     filenames.append(f.name)
                                 except Exception as e:
-                                    print(f"DEBUG: Could not read {f}: {e}")
+                                    logger.debug(f"Could not read {f}: {e}")
 
         elif document_source == "cloud":
             # Download from cloud storage
@@ -682,9 +686,9 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                                 documents.append(text_content)
                                 filenames.append(file_info['name'])
                             except UnicodeDecodeError:
-                                print(f"DEBUG: Could not decode {file_info['name']} as UTF-8")
+                                logger.debug(f"Could not decode {file_info['name']} as UTF-8")
             except Exception as e:
-                print(f"DEBUG: Error downloading cloud documents: {e}")
+                logger.error(f"Error downloading cloud documents: {e}")
                 raise
 
         elif document_source == "upload":
@@ -700,7 +704,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                             # Copy to documents dir
                             (docs_dir / f.name).write_text(content, encoding='utf-8')
                         except Exception as e:
-                            print(f"DEBUG: Could not read {f}: {e}")
+                            logger.debug(f"Could not read {f}: {e}")
 
         # Enforce document limit (same as initial QBSD creation)
         # The limit can be bypassed in developer mode via config
@@ -713,9 +717,9 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             combined = combined[:MAX_DOCUMENTS]
             documents, filenames = zip(*combined) if combined else ([], [])
             documents, filenames = list(documents), list(filenames)
-            print(f"DEBUG: Document limit applied: {original_count} → {len(documents)} (max: {MAX_DOCUMENTS})")
+            logger.info(f"Document limit applied: {original_count} → {len(documents)} (max: {MAX_DOCUMENTS})")
 
-        print(f"DEBUG: Prepared {len(documents)} documents from {document_source}")
+        logger.info(f"Prepared {len(documents)} documents from {document_source}")
         return docs_dir, documents, filenames
 
     # ==================== Schema Discovery ====================
@@ -844,11 +848,15 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
 
     async def _run_continue_discovery(self, operation_id: str):
         """Execute continued schema discovery in background."""
-        print(f"DEBUG: _run_continue_discovery started for operation {operation_id}")
         operation = self.active_operations.get(operation_id)
         if not operation:
-            print(f"DEBUG: Operation {operation_id} not found")
+            logger.debug(f"Operation {operation_id} not found")
             return
+
+        # Set session context for logging
+        set_session_context(operation.session_id)
+
+        logger.info(f"_run_continue_discovery started for operation {operation_id}")
 
         try:
             operation.status = "running"
@@ -883,7 +891,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             )
 
             # Prepare documents
-            print(f"DEBUG: Preparing documents from {config['document_source']}")
+            logger.info(f"Preparing documents from {config['document_source']}")
             docs_dir, documents, filenames = await self._prepare_documents(
                 operation.session_id,
                 config["document_source"],
@@ -892,7 +900,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             )
 
             operation.total_documents = len(documents)
-            print(f"DEBUG: Prepared {len(documents)} documents")
+            logger.info(f"Prepared {len(documents)} documents")
 
             if not documents:
                 raise ValueError("No documents available for schema discovery")
@@ -900,7 +908,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             # Build initial schema from session columns
             query = config.get("query") or session.schema_query or ""
             initial_schema = self._convert_session_columns_to_schema(session.columns, query)
-            print(f"DEBUG: Initial schema has {len(initial_schema.columns)} columns")
+            logger.debug(f"Initial schema has {len(initial_schema.columns)} columns")
 
             # Build LLM - enforce release mode settings if applicable
             enforced_llm_config = _enforce_release_llm_config(llm_config, is_schema_creation=True)
@@ -940,7 +948,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             )
 
             # Manual iteration loop for schema discovery (allows stop between batches)
-            print(f"DEBUG: Starting manual schema discovery loop with initial_schema")
+            logger.info(f"Starting manual schema discovery loop with initial_schema")
 
             # Create document batches
             batches = [documents[i:i+batch_size] for i in range(0, len(documents), batch_size)]
@@ -961,7 +969,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             for iteration, (batch_docs, batch_names) in enumerate(zip(batches, filename_batches)):
                 # CHECK STOP FLAG BEFORE EACH ITERATION
                 if self.is_stop_requested(operation_id):
-                    print(f"🛑 Stop requested during schema discovery at iteration {iteration}")
+                    logger.info(f"Stop requested during schema discovery at iteration {iteration}")
                     stopped = True
                     operation.status = "stopped"
                     operation.completed_at = datetime.now()
@@ -990,7 +998,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     }
                 )
 
-                print(f"DEBUG: Schema discovery batch {iteration + 1}/{len(batches)} ({len(batch_docs)} docs: {batch_names})")
+                logger.debug(f"Schema discovery batch {iteration + 1}/{len(batches)} ({len(batch_docs)} docs: {batch_names})")
 
                 # Track column names before this iteration
                 columns_before = {col.name.lower() for col in current_schema.columns}
@@ -1002,7 +1010,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     qbsd_thread_pool,
                     functools.partial(QBSD.select_relevant_content, docs=batch_docs, query=query, retriever=retriever),
                 )
-                print(f"DEBUG: Selected {len(relevant_content)} relevant passages from batch")
+                logger.debug(f"Selected {len(relevant_content)} relevant passages from batch")
 
                 # Generate schema for this batch (offloaded to thread pool)
                 try:
@@ -1020,9 +1028,9 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     )
                     # generate_schema returns a tuple (Schema, bool)
                     new_schema = schema_result[0] if isinstance(schema_result, tuple) else schema_result
-                    print(f"DEBUG: Generated schema with {len(new_schema.columns)} columns")
+                    logger.debug(f"Generated schema with {len(new_schema.columns)} columns")
                 except Exception as e:
-                    print(f"DEBUG: ERROR in generate_schema: {e}")
+                    logger.error(f"ERROR in generate_schema: {e}")
                     raise
 
                 # Merge with existing schema (offloaded to thread pool)
@@ -1030,7 +1038,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     qbsd_thread_pool,
                     functools.partial(current_schema.merge, new_schema),
                 )
-                print(f"DEBUG: Merged schema has {len(merged_schema.columns)} columns")
+                logger.debug(f"Merged schema has {len(merged_schema.columns)} columns")
 
                 # Identify NEW columns added in this iteration
                 columns_after = {col.name.lower() for col in merged_schema.columns}
@@ -1059,9 +1067,9 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                 )
                 if converged:
                     unchanged_count += 1
-                    print(f"DEBUG: Schema unchanged (count: {unchanged_count}/{convergence_threshold})")
+                    logger.debug(f"Schema unchanged (count: {unchanged_count}/{convergence_threshold})")
                     if unchanged_count >= convergence_threshold:
-                        print(f"DEBUG: Schema converged after {iteration + 1} batches")
+                        logger.info(f"Schema converged after {iteration + 1} batches")
                         break
                 else:
                     unchanged_count = 0
@@ -1072,12 +1080,12 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                 await asyncio.sleep(0.1)
 
             result_schema = current_schema
-            print(f"DEBUG: Schema discovery completed with {len(result_schema.columns)} columns after {len(evolution.snapshots)} batches")
+            logger.info(f"Schema discovery completed with {len(result_schema.columns)} columns after {len(evolution.snapshots)} batches")
 
             # Identify new columns
             new_columns = self._identify_new_columns(operation.initial_columns, result_schema)
             operation.new_columns = new_columns
-            print(f"DEBUG: Discovered {len(new_columns)} new columns")
+            logger.info(f"Discovered {len(new_columns)} new columns")
 
             # Add new columns to session immediately after discovery
             # So they appear in Schema tab even without extraction
@@ -1094,7 +1102,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                         seen_names.add(col.name)
                         unique_cols.append(col)
                 if len(unique_cols) != len(session.columns):
-                    print(f"DEBUG: Deduplicated existing columns: {len(session.columns)} -> {len(unique_cols)}")
+                    logger.debug(f"Deduplicated existing columns: {len(session.columns)} -> {len(unique_cols)}")
                     session.columns = unique_cols
 
                 for col_data in new_columns:
@@ -1113,7 +1121,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                 # Count only non-excerpt columns for statistics (what users care about)
                 non_excerpt_count = sum(1 for c in session.columns if c.name and not c.name.lower().endswith('_excerpt'))
                 actual_unique_count = non_excerpt_count
-                print(f"DEBUG: Column count after adding new columns: {actual_unique_count} (non-excerpt), {len(session.columns)} (total with excerpts)")
+                logger.debug(f"Column count after adding new columns: {actual_unique_count} (non-excerpt), {len(session.columns)} (total with excerpts)")
 
                 # Add null values for new columns in data.jsonl
                 data_file = self._get_data_dir() / operation.session_id / "data.jsonl"
@@ -1131,7 +1139,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     with open(data_file, 'w') as f:
                         for row in rows:
                             f.write(json.dumps(row) + '\n')
-                    print(f"DEBUG: Added null values for {len(new_columns)} new columns in data.jsonl")
+                    logger.info(f"Added null values for {len(new_columns)} new columns in data.jsonl")
 
                 # Update schema_evolution for Statistics chart
                 if session.statistics:
@@ -1159,7 +1167,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                         cumulative_documents=operation.total_batches
                     )
                     stats_evolution.snapshots.append(new_snapshot)
-                    print(f"DEBUG: Created snapshot with total_columns={actual_unique_count}, new_columns={len(non_excerpt_new_cols)}")
+                    logger.debug(f"Created snapshot with total_columns={actual_unique_count}, new_columns={len(non_excerpt_new_cols)}")
 
                     # Update column sources with actual document name (not generic iteration)
                     for col_data in new_columns:
@@ -1175,18 +1183,18 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     session.statistics.total_columns = actual_unique_count  # Use deduplicated count
 
                 self.session_manager.update_session(session)
-                print(f"DEBUG: Added {len(new_columns)} new columns to session after discovery")
+                logger.info(f"Added {len(new_columns)} new columns to session after discovery")
 
             # Ensure session status is 'completed' so Data tab is enabled (always, even if no new columns)
             session = self.session_manager.get_session(operation.session_id)
             if session:
                 session.status = "completed"
                 self.session_manager.update_session(session)
-                print(f"DEBUG: Set session status to 'completed' after discovery")
+                logger.info(f"Set session status to 'completed' after discovery")
 
             # Recompute statistics with proper column stats (non_null_count, unique_count, etc.)
             self._recompute_statistics(operation.session_id, preserve_evolution=True)
-            print(f"DEBUG: Statistics recomputed after discovery phase")
+            logger.info(f"Statistics recomputed after discovery phase")
 
             # Complete discovery phase
             operation.status = "completed"
@@ -1212,9 +1220,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             llm_config_file.unlink(missing_ok=True)
 
         except Exception as e:
-            print(f"DEBUG: Continue discovery FAILED: {e}")
-            import traceback
-            traceback.print_exc()
+            logger.error(f"Continue discovery FAILED: {e}", exc_info=True)
 
             operation.status = "failed"
             operation.error = str(e)
@@ -1290,7 +1296,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             session.columns.append(new_col)
 
         self.session_manager.update_session(session)
-        print(f"DEBUG: Added {len(new_columns_to_add)} new columns to session")
+        logger.info(f"Added {len(new_columns_to_add)} new columns to session")
 
         # Determine rows to process
         if row_selection == "all":
@@ -1331,10 +1337,14 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
 
     async def _run_incremental_extraction(self, operation_id: str):
         """Execute incremental value extraction for new columns."""
-        print(f"DEBUG: _run_incremental_extraction started for operation {operation_id}")
         operation = self.active_operations.get(operation_id)
         if not operation:
             return
+
+        # Set session context for logging
+        set_session_context(operation.session_id)
+
+        logger.info(f"_run_incremental_extraction started for operation {operation_id}")
 
         try:
             session = self.session_manager.get_session(operation.session_id)
@@ -1425,7 +1435,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                             row_name = row_data.get('row_name') or row_data.get('_row_name')
                             if row_name:
                                 existing_rows.add(row_name)
-            print(f"DEBUG: Existing rows to extract: {existing_rows}")
+            logger.debug(f"Existing rows to extract: {existing_rows}")
 
             # Create filtered docs directory with only documents for existing rows
             filtered_docs_dir = session_dir / "documents_filtered"
@@ -1441,13 +1451,13 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                         row_name = doc_path.stem.split('_')[0]
                         if row_name in existing_rows:
                             shutil.copy2(doc_path, filtered_docs_dir / doc_path.name)
-                            print(f"DEBUG: Including document for existing row: {doc_path.name}")
+                            logger.debug(f"Including document for existing row: {doc_path.name}")
                         else:
-                            print(f"DEBUG: Skipping document for new row: {doc_path.name}")
+                            logger.debug(f"Skipping document for new row: {doc_path.name}")
 
             # Count filtered documents
             doc_count = sum(1 for f in filtered_docs_dir.iterdir() if f.is_file()) if filtered_docs_dir.exists() else 0
-            print(f"DEBUG: Filtered to {doc_count} documents for existing rows")
+            logger.info(f"Filtered to {doc_count} documents for existing rows")
             operation.total_documents = doc_count
 
             # Track progress via callback
@@ -1488,14 +1498,14 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                         loop
                     )
                 except Exception as e:
-                    print(f"DEBUG: Broadcast error: {e}")
+                    logger.warning(f"Broadcast error: {e}")
 
             def should_stop():
                 return self.is_stop_requested(operation_id)
 
             # Run extraction (using filtered docs directory with only existing rows)
             if filtered_docs_dir.exists() and doc_count > 0:
-                print(f"DEBUG: Starting incremental extraction for {len(columns_to_extract)} columns on {doc_count} documents")
+                logger.info(f"Starting incremental extraction for {len(columns_to_extract)} columns on {doc_count} documents")
 
                 def run_extraction():
                     return build_table_jsonl(
@@ -1513,7 +1523,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     )
 
                 await asyncio.get_event_loop().run_in_executor(qbsd_thread_pool, run_extraction)
-                print(f"DEBUG: Incremental extraction completed")
+                logger.info(f"Incremental extraction completed")
 
             # Clean up filtered docs directory
             if filtered_docs_dir.exists():
@@ -1539,18 +1549,18 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                 # Update total columns in statistics (should already be correct from discovery phase)
                 session.statistics.total_columns = len(session.columns)
                 self.session_manager.update_session(session)
-                print(f"DEBUG: Extraction complete, total columns: {len(session.columns)}")
+                logger.info(f"Extraction complete, total columns: {len(session.columns)}")
 
             # Update session status to completed after extraction
             session = self.session_manager.get_session(operation.session_id)
             if session:
                 session.status = "completed"
                 self.session_manager.update_session(session)
-                print(f"DEBUG: Set session status to 'completed' after incremental extraction")
+                logger.info(f"Set session status to 'completed' after incremental extraction")
 
             # Recompute statistics with proper column stats (non_null_count, unique_count, etc.)
             self._recompute_statistics(operation.session_id, preserve_evolution=True)
-            print(f"DEBUG: Statistics recomputed after extraction phase")
+            logger.info(f"Statistics recomputed after extraction phase")
 
             # Cleanup
             schema_file.unlink(missing_ok=True)
@@ -1573,9 +1583,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             )
 
         except Exception as e:
-            print(f"DEBUG: Incremental extraction FAILED: {e}")
-            import traceback
-            traceback.print_exc()
+            logger.error(f"Incremental extraction FAILED: {e}", exc_info=True)
 
             operation.status = "failed"
             operation.error = str(e)
@@ -1603,14 +1611,14 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
         Only adds NEW column values, preserves all existing columns.
         """
         if not extraction_file.exists():
-            print(f"DEBUG: Extraction file not found: {extraction_file}")
+            logger.debug(f"Extraction file not found: {extraction_file}")
             return
 
         session_dir = self._get_data_dir() / session_id
         data_file = session_dir / "data.jsonl"
 
         if not data_file.exists():
-            print(f"DEBUG: Data file not found: {data_file}")
+            logger.debug(f"Data file not found: {data_file}")
             return
 
         # Read extracted values indexed by row_name
@@ -1623,7 +1631,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     if row_name:
                         extracted_by_row[row_name] = row_data
 
-        print(f"DEBUG: Extracted data for {len(extracted_by_row)} rows")
+        logger.debug(f"Extracted data for {len(extracted_by_row)} rows")
 
         # Build paper stem mapping for fallback matching
         extracted_by_paper_stem: Dict[str, Dict[str, Any]] = {}
@@ -1688,7 +1696,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             for row in updated_rows:
                 f.write(json.dumps(row) + '\n')
 
-        print(f"DEBUG: Merged incremental data for {len(new_columns)} columns, {rows_updated} rows updated")
+        logger.info(f"Merged incremental data for {len(new_columns)} columns, {rows_updated} rows updated")
 
         # Update session statistics
         session = self.session_manager.get_session(session_id)
@@ -1722,7 +1730,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
         # Set stop flag
         with self._state_lock:
             self.stop_flags[operation_id] = True
-        print(f"DEBUG: Stop requested for operation {operation_id}")
+        logger.info(f"Stop requested for operation {operation_id}")
 
         # Cancel task if running - wait for it to finish gracefully
         with self._state_lock:

--- a/backend/app/services/qbsd_runner.py
+++ b/backend/app/services/qbsd_runner.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from datetime import datetime
 
 from app.core.config import MAX_DOCUMENTS, DEVELOPER_MODE, RELEASE_CONFIG
+from app.core.logging_utils import set_session_context
 from app.services import qbsd_thread_pool, concurrency_limiter
 
 logger = logging.getLogger(__name__)
@@ -491,6 +492,7 @@ class QBSDRunner(WebSocketBroadcasterMixin):
     
     async def run_qbsd(self, session_id: str):
         """Run QBSD discovery process."""
+        set_session_context(session_id)
         try:
             # Update session status
             session = self.session_manager.get_session(session_id)

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -8,6 +8,7 @@ import asyncio
 import hashlib
 import threading
 import uuid
+import logging
 from typing import List, Dict, Any, Optional, Set
 from pathlib import Path
 from datetime import datetime
@@ -21,6 +22,7 @@ from app.services.websocket_mixin import WebSocketBroadcasterMixin
 from app.services import qbsd_thread_pool, concurrency_limiter
 from app.storage.factory import get_storage
 from app.core.config import DEVELOPER_MODE, RELEASE_CONFIG
+from app.core.logging_utils import set_session_context
 
 # QBSD library imports
 from qbsd.value_extraction.main import build_table_jsonl
@@ -31,6 +33,8 @@ from qbsd.core.retrievers import EmbeddingRetriever
 from qbsd.core import utils as qbsd_utils
 
 QBSD_AVAILABLE = True
+
+logger = logging.getLogger(__name__)
 
 
 class ReextractionOperation:
@@ -78,7 +82,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
     def get_cached_retriever(cls):
         """Get or create the cached retriever instance."""
         if cls._cached_retriever is None:
-            print("📡 Creating cached EmbeddingRetriever (will be reused for all re-extractions)")
+            logger.info("Creating cached EmbeddingRetriever (will be reused for all re-extractions)")
             cls._cached_retriever = EmbeddingRetriever(**cls._retriever_config)
         return cls._cached_retriever
 
@@ -116,7 +120,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
         # Set stop flag
         with self._state_lock:
             self.stop_flags[operation_id] = True
-        print(f"🛑 Stop requested for re-extraction operation {operation_id}")
+        logger.info(f"Stop requested for re-extraction operation {operation_id}")
 
         # Cancel the extraction task if it exists
         with self._state_lock:
@@ -133,7 +137,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
             session_dir = Path("./data") / operation.session_id
             output_file = session_dir / f"reextract_output_{operation_id}.jsonl"
             if output_file.exists():
-                print(f"📦 Merging partial results from {output_file}")
+                logger.info(f"Merging partial results from {output_file}")
                 await self._merge_reextracted_data(
                     operation.session_id,
                     operation.columns,
@@ -143,9 +147,9 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 output_file.unlink(missing_ok=True)
                 schema_file = session_dir / f"reextract_schema_{operation_id}.json"
                 schema_file.unlink(missing_ok=True)
-                print(f"✅ Partial results merged and temp files cleaned up")
+                logger.info(f"Partial results merged and temp files cleaned up")
         except Exception as e:
-            print(f"⚠️ Warning: Could not merge partial results: {e}")
+            logger.warning(f"Warning: Could not merge partial results: {e}")
 
         # Update operation status
         operation.status = "stopped"
@@ -254,7 +258,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
         baseline = self.capture_baseline(session)
         session.schema_baseline = baseline
         self.session_manager.update_session(session)
-        print(f"DEBUG: Captured schema baseline for session {session_id} with {len(baseline.columns)} columns")
+        logger.debug(f"Captured schema baseline for session {session_id} with {len(baseline.columns)} columns")
 
     def detect_schema_changes(self, session: VisualizationSession) -> Dict[str, Any]:
         """
@@ -396,7 +400,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
         session_cloud_dataset = None
         if session.metadata and session.metadata.cloud_dataset:
             session_cloud_dataset = session.metadata.cloud_dataset
-            print(f"DEBUG: Session has cloud_dataset fallback: {session_cloud_dataset}")
+            logger.debug(f"Session has cloud_dataset fallback: {session_cloud_dataset}")
 
         session_dir = Path("./data") / session_id
         data_file = session_dir / "data.jsonl"
@@ -463,12 +467,12 @@ class ReextractionService(WebSocketBroadcasterMixin):
                             # These indicate documents were uploaded locally, not from cloud storage
                             # Fall back to session's cloud_dataset if available
                             elif doc_dir and self._is_local_path(doc_dir):
-                                print(f"DEBUG: Detected local path in document_directory: {doc_dir}")
+                                logger.debug(f"Detected local path in document_directory: {doc_dir}")
                                 if session_cloud_dataset:
                                     doc_dir = f"datasets/{session_cloud_dataset}"
-                                    print(f"DEBUG: Using session cloud_dataset fallback: {doc_dir}")
+                                    logger.debug(f"Using session cloud_dataset fallback: {doc_dir}")
                                 else:
-                                    print(f"DEBUG: No cloud_dataset fallback available - documents may not be found")
+                                    logger.debug(f"No cloud_dataset fallback available - documents may not be found")
                                     # No cloud fallback - will be checked locally only
                                     doc_dir = None
 
@@ -526,12 +530,12 @@ class ReextractionService(WebSocketBroadcasterMixin):
         # Step 3: List each folder ONCE (instead of N HTTP requests per paper)
         folder_contents: Dict[str, set] = {}
         for folder in folders_to_check:
-            print(f"DEBUG: Listing Supabase folder: {folder} (checking {len(folders_to_check[folder])} papers)")
+            logger.debug(f"Listing Supabase folder: {folder} (checking {len(folders_to_check[folder])} papers)")
             try:
                 folder_contents[folder] = await storage.list_folder_files('datasets', folder)
-                print(f"DEBUG: Found {len(folder_contents[folder])} files in {folder}")
+                logger.debug(f"Found {len(folder_contents[folder])} files in {folder}")
             except Exception as e:
-                print(f"DEBUG: Error listing Supabase folder {folder}: {e}")
+                logger.debug(f"Error listing Supabase folder {folder}: {e}")
                 folder_contents[folder] = set()
 
         # Step 4: Check membership (no HTTP requests - just set lookups)
@@ -565,11 +569,11 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
         rows_with_papers = sum(1 for papers in row_paper_mapping.values() if papers)
 
-        print(f"DEBUG: Paper discovery - local: {len(local_papers)}, cloud: {len(cloud_papers)}, missing: {len(missing)}")
+        logger.debug(f"Paper discovery - local: {len(local_papers)}, cloud: {len(cloud_papers)}, missing: {len(missing)}")
 
         # Backfill papers field for rows with empty papers but available documents
         if local_files and any(not papers for papers in row_paper_mapping.values()):
-            print(f"DEBUG: Some rows have empty papers, attempting to backfill from {len(local_files)} local documents")
+            logger.debug(f"Some rows have empty papers, attempting to backfill from {len(local_files)} local documents")
             await self._backfill_papers_from_documents(session_id, list(local_files), total_rows)
             # Re-read row_paper_mapping after backfill to update rows_with_papers count
             if data_file.exists():
@@ -590,7 +594,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                             except json.JSONDecodeError:
                                 continue
                 rows_with_papers = sum(1 for papers in row_paper_mapping.values() if papers)
-                print(f"DEBUG: After backfill - rows_with_papers: {rows_with_papers}")
+                logger.debug(f"After backfill - rows_with_papers: {rows_with_papers}")
 
         return {
             "total_rows": total_rows,
@@ -627,7 +631,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
         # Sort local files for consistent ordering
         sorted_docs = sorted(local_files)
-        print(f"DEBUG: Backfill - {len(sorted_docs)} documents available for {total_rows} rows")
+        logger.debug(f"Backfill - {len(sorted_docs)} documents available for {total_rows} rows")
 
         # Read all rows
         rows = []
@@ -690,9 +694,9 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     local_path = docs_dir / local_filename
                     local_path.write_bytes(content)
                     downloaded.append(paper_name)
-                    print(f"DEBUG: Downloaded {paper_name} from Supabase to {local_path}")
+                    logger.debug(f"Downloaded {paper_name} from Supabase to {local_path}")
             except Exception as e:
-                print(f"DEBUG: Error downloading {paper_name} from Supabase: {e}")
+                logger.debug(f"Error downloading {paper_name} from Supabase: {e}")
 
         return downloaded
 
@@ -786,16 +790,18 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
     async def _run_reextraction(self, operation_id: str):
         """Execute re-extraction in background."""
-        print(f"DEBUG: _run_reextraction started for operation {operation_id}")
         operation = self.active_operations.get(operation_id)
         if not operation:
-            print(f"DEBUG: Operation {operation_id} not found in active_operations")
+            logger.debug(f"Operation {operation_id} not found in active_operations")
             return
+
+        set_session_context(operation.session_id)
+        logger.debug(f"_run_reextraction started for operation {operation_id}")
 
         try:
             operation.status = "running"
             operation.started_at = datetime.now()
-            print(f"DEBUG: Re-extraction running for session {operation.session_id}, columns: {operation.columns}")
+            logger.debug(f"Re-extraction running for session {operation.session_id}, columns: {operation.columns}")
 
             session = self.session_manager.get_session(operation.session_id)
             if not session:
@@ -816,19 +822,19 @@ class ReextractionService(WebSocketBroadcasterMixin):
             )
 
             # Download cloud papers before extraction
-            print(f"DEBUG: Discovering papers for re-extraction...")
+            logger.debug(f"Discovering papers for re-extraction...")
             paper_discovery = await self.discover_papers(operation.session_id)
-            print(f"DEBUG: Paper discovery result - available: {len(paper_discovery.get('available_papers', []))}, cloud: {len(paper_discovery.get('cloud_papers', {}))}, missing: {len(paper_discovery.get('missing_papers', []))}")
+            logger.debug(f"Paper discovery result - available: {len(paper_discovery.get('available_papers', []))}, cloud: {len(paper_discovery.get('cloud_papers', {}))}, missing: {len(paper_discovery.get('missing_papers', []))}")
 
             if paper_discovery.get("cloud_papers"):
-                print(f"DEBUG: Downloading {len(paper_discovery['cloud_papers'])} cloud papers...")
+                logger.debug(f"Downloading {len(paper_discovery['cloud_papers'])} cloud papers...")
                 downloaded = await self.download_cloud_papers(
                     operation.session_id,
                     paper_discovery["cloud_papers"]
                 )
-                print(f"DEBUG: Downloaded {len(downloaded)} papers from cloud storage for re-extraction")
+                logger.debug(f"Downloaded {len(downloaded)} papers from cloud storage for re-extraction")
             else:
-                print(f"DEBUG: No cloud papers to download")
+                logger.debug(f"No cloud papers to download")
 
             # Get target columns
             target_columns = [
@@ -892,7 +898,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                             loop
                         )
                     except Exception as e:
-                        print(f"⚠️ Document started broadcast error: {e}")
+                        logger.warning(f"Document started broadcast error: {e}")
 
                 # Schedule broadcasts on main event loop from thread (fire and forget)
                 try:
@@ -929,14 +935,14 @@ class ReextractionService(WebSocketBroadcasterMixin):
                         loop
                     )
                 except Exception as e:
-                    print(f"⚠️ Broadcast error: {e}")
+                    logger.warning(f"Broadcast error: {e}")
 
             # Run extraction - check both documents/ and pending_documents/
             docs_directories = [d for d in [docs_dir, pending_dir] if d.exists()]
-            print(f"DEBUG: docs_directories={docs_directories}, count={len(docs_directories)}")
+            logger.debug(f"docs_directories={docs_directories}, count={len(docs_directories)}")
 
             if docs_directories:
-                print(f"DEBUG: Starting build_table_jsonl extraction...")
+                logger.debug(f"Starting build_table_jsonl extraction...")
 
                 # Create should_stop callback that checks for stop requests
                 def should_stop():
@@ -958,12 +964,12 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     )
 
                 await asyncio.get_event_loop().run_in_executor(qbsd_thread_pool, run_extraction)
-                print(f"DEBUG: build_table_jsonl completed, output_file exists: {output_file.exists()}")
+                logger.debug(f"build_table_jsonl completed, output_file exists: {output_file.exists()}")
             else:
-                print(f"DEBUG: No document directories exist, skipping extraction")
+                logger.debug(f"No document directories exist, skipping extraction")
 
             # Merge results with existing data
-            print(f"DEBUG: Merging re-extracted data...")
+            logger.debug(f"Merging re-extracted data...")
             await self._merge_reextracted_data(
                 operation.session_id,
                 operation.columns,
@@ -981,7 +987,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
             operation.progress = 1.0
             operation.completed_at = datetime.now()
 
-            print(f"DEBUG: Re-extraction completed successfully for operation {operation_id}")
+            logger.info(f"Re-extraction completed successfully for operation {operation_id}")
 
             await self.broadcast_event(
                 operation.session_id,
@@ -994,9 +1000,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
             )
 
         except Exception as e:
-            print(f"DEBUG: Re-extraction FAILED for operation {operation_id}: {e}")
-            import traceback
-            traceback.print_exc()
+            logger.error(f"Re-extraction FAILED for operation {operation_id}: {e}", exc_info=True)
             operation.status = "failed"
             operation.error = str(e)
             operation.completed_at = datetime.now()
@@ -1039,7 +1043,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     if row_name:
                         extracted_by_row[row_name] = row_data
 
-        print(f"DEBUG: Extracted row names from extraction file: {list(extracted_by_row.keys())}")
+        logger.debug(f"Extracted row names from extraction file: {list(extracted_by_row.keys())}")
 
         # Build a mapping from paper name stem to extracted data for fallback matching
         # This handles cases where existing data uses row_1, row_2, etc. but extraction uses paper names
@@ -1047,7 +1051,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
         for row_name, row_data in extracted_by_row.items():
             # The row_name from extraction is typically the paper stem (e.g., "CCTalpha")
             extracted_by_paper_stem[row_name.lower()] = row_data
-            print(f"DEBUG: Paper stem mapping: '{row_name.lower()}' -> extracted data")
+            logger.debug(f"Paper stem mapping: '{row_name.lower()}' -> extracted data")
 
         # Backup existing data
         backup_file = session_dir / f"data_backup_{int(datetime.now().timestamp())}.jsonl"
@@ -1103,7 +1107,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
             for row in updated_rows:
                 f.write(json.dumps(row) + '\n')
 
-        print(f"DEBUG: Merged re-extracted data for {len(columns)} columns, {rows_updated} rows updated")
+        logger.debug(f"Merged re-extracted data for {len(columns)} columns, {rows_updated} rows updated")
 
         # Update session statistics to reflect new data
         session = self.session_manager.get_session(session_id)
@@ -1118,17 +1122,17 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     )
                     old_count = col_stat.non_null_count
                     col_stat.non_null_count = non_null_count
-                    print(f"DEBUG: Updated stats for column '{col_stat.name}': non_null_count {old_count} -> {non_null_count}")
+                    logger.debug(f"Updated stats for column '{col_stat.name}': non_null_count {old_count} -> {non_null_count}")
 
             # Update session
             self.session_manager.update_session(session)
-            print(f"DEBUG: Updated session statistics for {len(columns)} columns")
+            logger.debug(f"Updated session statistics for {len(columns)} columns")
 
     def _get_llm_from_session(self, session_id: str):
         """Get LLM configuration from session, including API key."""
         # In release mode, always use the release-mode LLM (ignore user config)
         if not DEVELOPER_MODE:
-            print(f"DEBUG: Release mode - using locked LLM: {RELEASE_CONFIG['value_extraction_model']}")
+            logger.debug(f"Release mode - using locked LLM: {RELEASE_CONFIG['value_extraction_model']}")
             return GeminiLLM(
                 model=RELEASE_CONFIG["value_extraction_model"],
                 max_output_tokens=2048,
@@ -1143,10 +1147,10 @@ class ReextractionService(WebSocketBroadcasterMixin):
             if user_config_file.exists():
                 with open(user_config_file) as f:
                     user_config = json.load(f)
-                print(f"DEBUG: Using LLM config from user_llm_config.json: {user_config.get('provider')} {user_config.get('model')}, api_key={'present' if user_config.get('api_key') else 'MISSING'}")
+                logger.debug(f"Using LLM config from user_llm_config.json: {user_config.get('provider')} {user_config.get('model')}, api_key={'present' if user_config.get('api_key') else 'MISSING'}")
                 return qbsd_utils.build_llm(user_config)
         except Exception as e:
-            print(f"DEBUG: Could not load user LLM config: {e}")
+            logger.debug(f"Could not load user LLM config: {e}")
 
         # Priority 1: Check session's metadata.extracted_schema for llm_configuration
         try:
@@ -1158,10 +1162,10 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     # Use value_extraction_backend if available, fallback to schema_creation_backend
                     backend_config = llm_config.get("value_extraction_backend") or llm_config.get("schema_creation_backend")
                     if backend_config:
-                        print(f"DEBUG: Using LLM config from session metadata: {backend_config.get('provider')} {backend_config.get('model')}")
+                        logger.debug(f"Using LLM config from session metadata: {backend_config.get('provider')} {backend_config.get('model')}")
                         return qbsd_utils.build_llm(backend_config)
         except Exception as e:
-            print(f"DEBUG: Could not load LLM config from session metadata: {e}")
+            logger.debug(f"Could not load LLM config from session metadata: {e}")
 
         # Priority 2: Check parsed_schema.json (contains llm_configuration with api_key)
         try:
@@ -1173,10 +1177,10 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     llm_config = parsed_schema["llm_configuration"]
                     backend_config = llm_config.get("value_extraction_backend") or llm_config.get("schema_creation_backend")
                     if backend_config:
-                        print(f"DEBUG: Using LLM config from parsed_schema.json: {backend_config.get('provider')} {backend_config.get('model')}")
+                        logger.debug(f"Using LLM config from parsed_schema.json: {backend_config.get('provider')} {backend_config.get('model')}")
                         return qbsd_utils.build_llm(backend_config)
         except Exception as e:
-            print(f"DEBUG: Could not load LLM config from parsed_schema.json: {e}")
+            logger.debug(f"Could not load LLM config from parsed_schema.json: {e}")
 
         # Priority 3: Check qbsd_config.json (legacy location)
         try:
@@ -1186,13 +1190,13 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     qbsd_config = json.load(f)
                 backend_config = qbsd_config.get("value_extraction_backend") or qbsd_config.get("schema_creation_backend")
                 if backend_config:
-                    print(f"DEBUG: Using LLM config from qbsd_config.json: {backend_config.get('provider')} {backend_config.get('model')}")
+                    logger.debug(f"Using LLM config from qbsd_config.json: {backend_config.get('provider')} {backend_config.get('model')}")
                     return qbsd_utils.build_llm(backend_config)
         except Exception as e:
-            print(f"DEBUG: Could not load LLM config from qbsd_config.json: {e}")
+            logger.debug(f"Could not load LLM config from qbsd_config.json: {e}")
 
         # Fallback: Use default GeminiLLM (will use GEMINI_API_KEY env var)
-        print(f"DEBUG: Using default GeminiLLM - this will use GEMINI_API_KEY env var")
+        logger.debug(f"Using default GeminiLLM - this will use GEMINI_API_KEY env var")
         return GeminiLLM(model="gemini-2.5-flash-lite", max_output_tokens=2048, temperature=0)
 
     async def broadcast_event(self, session_id: str, event_type: str, data: Dict[str, Any]):

--- a/backend/app/services/schema_manager.py
+++ b/backend/app/services/schema_manager.py
@@ -5,6 +5,7 @@ Handles schema editing operations and document reprocessing.
 
 import json
 import asyncio
+import logging
 import threading
 from typing import List, Dict, Any, Optional
 from pathlib import Path
@@ -17,6 +18,9 @@ from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
 from app.services import qbsd_thread_pool, concurrency_limiter
 from app.core.config import DEVELOPER_MODE, RELEASE_CONFIG
+from app.core.logging_utils import set_session_context
+
+logger = logging.getLogger(__name__)
 
 # QBSD library imports
 from qbsd.value_extraction.main import build_table_jsonl
@@ -41,7 +45,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
         """Get value extraction LLM configuration from session, including API key."""
         # In release mode, always use the release-mode LLM (ignore user config)
         if not DEVELOPER_MODE:
-            print(f"DEBUG: Release mode - using locked LLM: {RELEASE_CONFIG['value_extraction_model']}")
+            logger.debug(f"Release mode - using locked LLM: {RELEASE_CONFIG['value_extraction_model']}")
             return GeminiLLM(
                 model=RELEASE_CONFIG["value_extraction_model"],
                 max_output_tokens=2048,
@@ -56,10 +60,10 @@ class SchemaManager(WebSocketBroadcasterMixin):
             if user_config_file.exists():
                 with open(user_config_file) as f:
                     user_config = json.load(f)
-                print(f"DEBUG: Using LLM config from user_llm_config.json: {user_config.get('provider')} {user_config.get('model')}, api_key={'present' if user_config.get('api_key') else 'MISSING'}")
+                logger.debug(f"Using LLM config from user_llm_config.json: {user_config.get('provider')} {user_config.get('model')}, api_key={'present' if user_config.get('api_key') else 'MISSING'}")
                 return utils.build_llm(user_config)
         except Exception as e:
-            print(f"DEBUG: Could not load user LLM config: {e}")
+            logger.debug(f"Could not load user LLM config: {e}")
 
         # Priority 1: Check session's metadata.extracted_schema for llm_configuration
         try:
@@ -70,10 +74,10 @@ class SchemaManager(WebSocketBroadcasterMixin):
                     llm_config = extracted_schema["llm_configuration"]
                     backend_config = llm_config.get("value_extraction_backend") or llm_config.get("schema_creation_backend")
                     if backend_config:
-                        print(f"DEBUG: Using LLM config from session metadata: {backend_config.get('provider')} {backend_config.get('model')}")
+                        logger.debug(f"Using LLM config from session metadata: {backend_config.get('provider')} {backend_config.get('model')}")
                         return utils.build_llm(backend_config)
         except Exception as e:
-            print(f"DEBUG: Could not load LLM config from session metadata: {e}")
+            logger.debug(f"Could not load LLM config from session metadata: {e}")
 
         # Priority 2: Check parsed_schema.json (contains llm_configuration with api_key)
         try:
@@ -85,10 +89,10 @@ class SchemaManager(WebSocketBroadcasterMixin):
                     llm_config = parsed_schema["llm_configuration"]
                     backend_config = llm_config.get("value_extraction_backend") or llm_config.get("schema_creation_backend")
                     if backend_config:
-                        print(f"DEBUG: Using LLM config from parsed_schema.json: {backend_config.get('provider')} {backend_config.get('model')}")
+                        logger.debug(f"Using LLM config from parsed_schema.json: {backend_config.get('provider')} {backend_config.get('model')}")
                         return utils.build_llm(backend_config)
         except Exception as e:
-            print(f"DEBUG: Could not load LLM config from parsed_schema.json: {e}")
+            logger.debug(f"Could not load LLM config from parsed_schema.json: {e}")
 
         # Priority 3: Check qbsd_config.json (legacy location)
         try:
@@ -98,13 +102,13 @@ class SchemaManager(WebSocketBroadcasterMixin):
                     qbsd_config = json.load(f)
                 backend_config = qbsd_config.get("value_extraction_backend") or qbsd_config.get("schema_creation_backend")
                 if backend_config:
-                    print(f"DEBUG: Using LLM config from qbsd_config.json: {backend_config.get('provider')} {backend_config.get('model')}")
+                    logger.debug(f"Using LLM config from qbsd_config.json: {backend_config.get('provider')} {backend_config.get('model')}")
                     return utils.build_llm(backend_config)
         except Exception as e:
-            print(f"DEBUG: Could not load LLM config from qbsd_config.json: {e}")
+            logger.debug(f"Could not load LLM config from qbsd_config.json: {e}")
 
         # Fallback: Use default GeminiLLM (will use GEMINI_API_KEY env var)
-        print(f"DEBUG: Using default GeminiLLM - this will use GEMINI_API_KEY env var")
+        logger.debug("Using default GeminiLLM - this will use GEMINI_API_KEY env var")
         return GeminiLLM(model="gemini-2.5-flash-lite", max_output_tokens=2048, temperature=0)
     
     async def reprocess_column(self, session_id: str, column_name: str):
@@ -253,7 +257,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
             if excerpt_column in columns_found:
                 columns_to_remove.append(excerpt_column)
             
-            print(f"DEBUG: Removing columns {columns_to_remove} from {len(existing_rows)} rows")
+            logger.debug(f"Removing columns {columns_to_remove} from {len(existing_rows)} rows")
             
             # Remove the columns from all rows
             updated_rows = []
@@ -265,7 +269,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
                         if col_to_remove in row_data['data']:
                             del row_data['data'][col_to_remove]
                             row_updated = True
-                            print(f"DEBUG: Removed column '{col_to_remove}' from row with row_name: {row_data.get('row_name', 'unknown')}")
+                            logger.debug(f"Removed column '{col_to_remove}' from row: {row_data.get('row_name', 'unknown')}")
                 
                 if row_updated:
                     columns_removed_count += 1
@@ -277,7 +281,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
                 for row in updated_rows:
                     f.write(json.dumps(row) + '\n')
             
-            print(f"DEBUG: Successfully removed columns {columns_to_remove} from {columns_removed_count} rows")
+            logger.info(f"Successfully removed columns {columns_to_remove} from {columns_removed_count} rows")
             
             await self.broadcast_progress(
                 session_id,
@@ -302,14 +306,12 @@ class SchemaManager(WebSocketBroadcasterMixin):
                     with open(json_data_file, 'w') as f:
                         json.dump(json_data, f, indent=2)
                     
-                    print(f"DEBUG: Also updated data.json file")
+                    logger.debug("Also updated data.json file")
                 except Exception as json_error:
-                    print(f"DEBUG: Could not update data.json: {json_error}")
+                    logger.warning(f"Could not update data.json: {json_error}")
             
         except Exception as e:
-            print(f"DEBUG: Failed to remove column data: {str(e)}")
-            import traceback
-            traceback.print_exc()
+            logger.error(f"Failed to remove column data: {e}", exc_info=True)
             await self.broadcast_error(session_id, f"Failed to remove column data: {str(e)}")
             raise
     

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -1,6 +1,7 @@
 """Session management service."""
 
 import hashlib
+import logging
 import threading
 from typing import Dict, List, Optional
 from datetime import datetime
@@ -8,6 +9,8 @@ from datetime import datetime
 from app.models.session import VisualizationSession, SessionType, SessionStatus, ColumnInfo, ColumnBaseline, SchemaBaseline
 from app.models.modification import CreationMetadata, ModificationAction
 from app.storage import get_storage, StorageInterface
+
+logger = logging.getLogger(__name__)
 
 
 class SessionManager:
@@ -40,9 +43,9 @@ class SessionManager:
                         session = self.migrate_session(session)
                         self._sessions[session.id] = session
                 except Exception as e:
-                    print(f"Error loading session {session_id}: {e}")
+                    logger.error(f"Error loading session {session_id}: {e}")
         except Exception as e:
-            print(f"Error loading sessions: {e}")
+            logger.error(f"Error loading sessions: {e}")
 
     def _save_session(self, session: VisualizationSession):
         """Save session to storage."""
@@ -135,7 +138,7 @@ class SessionManager:
         )
 
         self.update_session(session)
-        print(f"DEBUG: Captured schema baseline for session {session_id} with {len(columns_dict)} columns")
+        logger.debug(f"Captured schema baseline for session {session_id} with {len(columns_dict)} columns")
         return True
 
     def finalize_creation(self, session_id: str, llm_model: str = "", llm_provider: str = "") -> bool:
@@ -157,7 +160,7 @@ class SessionManager:
 
         # Only finalize if not already finalized
         if session.creation_metadata is not None:
-            print(f"DEBUG: Session {session_id} already has creation metadata, skipping finalize")
+            logger.debug(f"Session {session_id} already has creation metadata, skipping finalize")
             return True
 
         # Create immutable creation metadata
@@ -172,7 +175,7 @@ class SessionManager:
         )
 
         self.update_session(session)
-        print(f"DEBUG: Finalized creation for session {session_id}")
+        logger.debug(f"Finalized creation for session {session_id}")
         return True
 
     def migrate_session(self, session: VisualizationSession) -> VisualizationSession:
@@ -223,6 +226,6 @@ class SessionManager:
             modified = True
 
         if modified:
-            print(f"DEBUG: Migrated session {session.id} with new fields")
+            logger.debug(f"Migrated session {session.id} with new fields")
 
         return session

--- a/backend/app/services/upload_document_processor.py
+++ b/backend/app/services/upload_document_processor.py
@@ -6,6 +6,7 @@ import threading
 import time
 import math
 import os
+import logging
 from typing import Dict, Any, List, Optional
 from pathlib import Path
 from datetime import datetime
@@ -24,6 +25,9 @@ from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
 from app.services import qbsd_thread_pool, concurrency_limiter
 from app.core.config import DEFAULT_MAX_OUTPUT_TOKENS, DEFAULT_TEMPERATURE, DEFAULT_RETRIEVAL_K, PROGRESS_CHECK_INTERVAL, DEVELOPER_MODE, RELEASE_CONFIG
+from app.core.logging_utils import set_session_context
+
+logger = logging.getLogger(__name__)
 
 
 class UploadDocumentProcessor(WebSocketBroadcasterMixin):
@@ -45,7 +49,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
         """
         def on_value_extracted(row_name: str, column_name: str, value: Any):
             """Called for each cell value as it's extracted."""
-            print(f"📤 CELL EXTRACTED: {row_name} / {column_name} = {str(value)[:50]}...")
+            logger.debug(f"CELL EXTRACTED: {row_name} / {column_name} = {str(value)[:50]}...")
             try:
                 future = asyncio.run_coroutine_threadsafe(
                     self.broadcast_cell_extracted(session_id, {
@@ -58,21 +62,23 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                 # Check if future completed (with short timeout to not block extraction)
                 try:
                     future.result(timeout=0.1)
-                    print(f"✅ CELL BROADCAST SUCCESS: {row_name}/{column_name}")
+                    logger.debug(f"CELL BROADCAST SUCCESS: {row_name}/{column_name}")
                 except TimeoutError:
                     pass  # Still running, that's fine - async broadcast in progress
                 except Exception as e:
-                    print(f"❌ CELL BROADCAST FAILED: {row_name}/{column_name}: {e}")
+                    logger.warning(f"CELL BROADCAST FAILED: {row_name}/{column_name}: {e}")
             except Exception as e:
-                print(f"⚠️  Failed to schedule broadcast for {column_name}: {e}")
+                logger.warning(f"Failed to schedule broadcast for {column_name}: {e}")
 
         return on_value_extracted
     
     async def process_documents(self, session_id: str):
         """Process uploaded documents using QBSD pipeline."""
+        set_session_context(session_id)
+
         if not QBSD_AVAILABLE:
             raise RuntimeError("QBSD components not available for document processing")
-        
+
         with self._state_lock:
             self.running_sessions[session_id] = True
 
@@ -80,8 +86,8 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             session = self.session_manager.get_session(session_id)
             if not session:
                 raise ValueError(f"Session {session_id} not found")
-            
-            print(f"🔄 DEBUG: Starting document processing for session {session_id}")
+
+            logger.debug(f"Starting document processing for session {session_id}")
             
             # Progress tracking
             await self.broadcast_progress(session_id, "Initializing document processing", 0.0, "processing_documents")
@@ -101,7 +107,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             # This ensures that edits like allowed_values affect new document processing
             current_schema = self._build_schema_from_session(session)
 
-            print(f"🔄 DEBUG: Processing with schema: {len(current_schema['schema'])} columns")
+            logger.debug(f"Processing with schema: {len(current_schema['schema'])} columns")
 
             # Create enhanced QBSD schema file for value extraction
             await self.broadcast_progress(session_id, "Preparing schema for processing", 0.1, "processing_documents")
@@ -121,7 +127,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
 
             # In release mode, override with locked LLM settings
             if not DEVELOPER_MODE:
-                print(f"🔄 DEBUG: Release mode - overriding LLM config to {RELEASE_CONFIG['value_extraction_model']}")
+                logger.debug(f"Release mode - overriding LLM config to {RELEASE_CONFIG['value_extraction_model']}")
                 backend_config = {
                     "provider": RELEASE_CONFIG["llm_provider"],
                     "model": RELEASE_CONFIG["value_extraction_model"],
@@ -131,7 +137,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                 }
 
             llm = utils.build_llm(backend_config)
-            print(f"🔄 DEBUG: LLM interface created successfully")
+            logger.debug("LLM interface created successfully")
             
             # Create retriever
             retriever_config = {
@@ -144,7 +150,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                 "dynamic_k_minimum": 3
             }
             retriever = utils.build_retriever(retriever_config)
-            print(f"🔄 DEBUG: Retriever created successfully")
+            logger.debug("Retriever created successfully")
             
             # Run value extraction
             await self.broadcast_progress(session_id, "Processing documents with AI", 0.3, "processing_documents")
@@ -164,10 +170,10 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                     return not self.running_sessions.get(session_id, True)
 
             def run_extraction():
-                print(f"🚀 EXTRACTION STARTING for session {session_id}")
-                print(f"   Schema: {schema_path}")
-                print(f"   Docs: {pending_dir}")
-                print(f"   Output: {output_path}")
+                logger.info(f"EXTRACTION STARTING for session {session_id}")
+                logger.debug(f"Schema: {schema_path}")
+                logger.debug(f"Docs: {pending_dir}")
+                logger.debug(f"Output: {output_path}")
                 try:
                     result = build_table_jsonl(
                         schema_path=schema_path,
@@ -182,12 +188,10 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                         on_value_extracted=on_value_extracted,  # Stream values as extracted
                         should_stop=should_stop  # Allow graceful stop
                     )
-                    print(f"✅ EXTRACTION COMPLETED for session {session_id}")
+                    logger.info(f"EXTRACTION COMPLETED for session {session_id}")
                     return result
                 except Exception as e:
-                    print(f"❌ EXTRACTION FAILED for session {session_id}: {type(e).__name__}: {e}")
-                    import traceback
-                    traceback.print_exc()
+                    logger.error(f"EXTRACTION FAILED for session {session_id}: {type(e).__name__}: {e}", exc_info=True)
                     raise
             
             # Monitor progress while extraction runs
@@ -204,12 +208,12 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                 with self._state_lock:
                     stop_requested = not self.running_sessions.get(session_id, True)
                 if stop_requested:
-                    print(f"🛑 Stop requested for session {session_id}, cancelling extraction...")
+                    logger.info(f"Stop requested for session {session_id}, cancelling extraction...")
                     extraction_task.cancel()
                     try:
                         await extraction_task
                     except asyncio.CancelledError:
-                        print(f"✓ Extraction task cancelled for session {session_id}")
+                        logger.info(f"Extraction task cancelled for session {session_id}")
 
                     # Update session with partial results
                     session = self.session_manager.get_session(session_id)
@@ -225,7 +229,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                             session.metadata.additional_rows_added = rows_added
                             self.session_manager.update_session(session)
                         except Exception as e:
-                            print(f"⚠️ Failed to merge partial data after stop: {e}")
+                            logger.warning(f"Failed to merge partial data after stop: {e}")
 
                     # Broadcast stopped message
                     await self.broadcast_message(session_id, {
@@ -294,7 +298,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                                 })
 
                     except Exception as e:
-                        print(f"Progress monitoring error: {e}")
+                        logger.warning(f"Progress monitoring error: {e}")
 
                 await asyncio.sleep(PROGRESS_CHECK_INTERVAL)  # Check every few seconds for faster updates
             
@@ -310,7 +314,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             await self.broadcast_progress(session_id, "Processing complete", 1.0, "processing_documents")
 
             session = self.session_manager.get_session(session_id)
-            print(f"🔍 DEBUG: Session before completion update: status={session.status}")
+            logger.debug(f"Session before completion update: status={session.status}")
 
             session.status = SessionStatus.COMPLETED
             session.metadata.last_modified = datetime.now()
@@ -319,7 +323,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             session.metadata.additional_rows_added = rows_added
             session.metadata.processed_documents = len(session.metadata.uploaded_documents)
 
-            print(f"🔍 DEBUG: Session after completion update: status={session.status}, additional_rows={session.metadata.additional_rows_added}")
+            logger.debug(f"Session after completion update: status={session.status}, additional_rows={session.metadata.additional_rows_added}")
 
             self.session_manager.update_session(session)
 
@@ -329,11 +333,11 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                 if statistics:
                     session.statistics = statistics
                     self.session_manager.update_session(session)
-                    print(f"✓ Session statistics updated after document processing")
+                    logger.info("Session statistics updated after document processing")
                 else:
-                    print(f"⚠️  No statistics generated for session {session_id}")
+                    logger.warning(f"No statistics generated for session {session_id}")
             except Exception as e:
-                print(f"⚠️  Failed to compute statistics for session {session_id}: {e}")
+                logger.warning(f"Failed to compute statistics for session {session_id}: {e}")
                 # Don't fail the entire operation - statistics are supplementary
 
             # Capture schema baseline for re-extraction change detection
@@ -341,7 +345,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
 
             # Verify the update was successful
             updated_session = self.session_manager.get_session(session_id)
-            print(f"🔍 DEBUG: Session after manager update: status={updated_session.status}, additional_rows={updated_session.metadata.additional_rows_added}")
+            logger.debug(f"Session after manager update: status={updated_session.status}, additional_rows={updated_session.metadata.additional_rows_added}")
 
             # Small delay to ensure session update is committed before broadcasting completion
             await asyncio.sleep(0.5)
@@ -351,12 +355,12 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                 "additional_rows": rows_added,
                 "total_documents": len(session.metadata.uploaded_documents)
             }
-            
-            print(f"🎯 DEBUG: Broadcasting completion for session {session_id} with data: {completion_data}")
-            await self.broadcast_completion(session_id, 
+
+            logger.debug(f"Broadcasting completion for session {session_id} with data: {completion_data}")
+            await self.broadcast_completion(session_id,
                 "Document processing completed successfully", completion_data)
-            
-            print(f"✅ DEBUG: Document processing completed and broadcast sent for session {session_id}")
+
+            logger.info(f"Document processing completed and broadcast sent for session {session_id}")
             
         except Exception as e:
             # Update session with error
@@ -365,9 +369,9 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                 session.status = SessionStatus.ERROR
                 session.error_message = f"Document processing failed: {str(e)}"
                 self.session_manager.update_session(session)
-            
+
             await self.broadcast_error(session_id, str(e))
-            print(f"❌ DEBUG: Document processing failed for session {session_id}: {e}")
+            logger.error(f"Document processing failed for session {session_id}: {e}")
             raise
         
         finally:
@@ -389,14 +393,14 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
         additional_data_file = session_dir / "additional_data.jsonl"
 
         if not additional_data_file.exists():
-            print(f"No additional data to merge for session {session_id}")
+            logger.info(f"No additional data to merge for session {session_id}")
             return 0
 
         # Get cloud dataset name for document_directory if available
         cloud_dataset = None
         if session and session.metadata and session.metadata.cloud_dataset:
             cloud_dataset = session.metadata.cloud_dataset
-            print(f"DEBUG: Using cloud_dataset '{cloud_dataset}' for document_directory")
+            logger.debug(f"Using cloud_dataset '{cloud_dataset}' for document_directory")
 
         # Read original data to get the base row count and detect row name/papers column patterns
         original_rows = []
@@ -420,12 +424,12 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                                 if row_name_column_in_data is None:
                                     if key_lower in ['row name', 'rowname', 'row_name', 'name', 'id', 'identifier']:
                                         row_name_column_in_data = key
-                                        print(f"DEBUG: Detected row name column in data: '{key}'")
+                                        logger.debug(f"Detected row name column in data: '{key}'")
                                 # Detect papers column
                                 if papers_column_in_data is None:
                                     if key_lower in ['papers', 'paper']:
                                         papers_column_in_data = key
-                                        print(f"DEBUG: Detected papers column in data: '{key}'")
+                                        logger.debug(f"Detected papers column in data: '{key}'")
 
         # Read new extracted data and append to original file
         new_rows_added = 0
@@ -550,7 +554,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                 original_f.flush()
                 os.fsync(original_f.fileno())
 
-        print(f"Successfully appended {new_rows_added} new rows to session {session_id}. Total rows: {len(original_rows) + new_rows_added}")
+        logger.info(f"Successfully appended {new_rows_added} new rows to session {session_id}. Total rows: {len(original_rows) + new_rows_added}")
 
         # Clean up the additional data file
         additional_data_file.unlink(missing_ok=True)
@@ -574,7 +578,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                             dest_path = docs_dir / f"{base_name}_{counter}{extension}"
                             counter += 1
                     shutil.move(str(file_path), str(dest_path))
-                    print(f"Moved {file_path.name} to documents/")
+                    logger.debug(f"Moved {file_path.name} to documents/")
 
         return new_rows_added
 
@@ -1011,10 +1015,10 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             try:
                 with open(user_config_file) as f:
                     user_config = json.load(f)
-                    print(f"DEBUG: Using user-selected LLM configuration for session {session_id}")
+                    logger.debug(f"Using user-selected LLM configuration for session {session_id}")
                     return user_config
             except Exception as e:
-                print(f"DEBUG: Could not load user LLM config: {e}")
+                logger.debug(f"Could not load user LLM config: {e}")
         
         # Second priority: Preserved schema metadata LLM configuration
         if "llm_configuration" in extracted_schema:
@@ -1022,10 +1026,10 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             
             # Use value_extraction_backend if available, fallback to schema_creation_backend
             if llm_config.get("value_extraction_backend"):
-                print(f"DEBUG: Using preserved value_extraction_backend for session {session_id}")
+                logger.debug(f"Using preserved value_extraction_backend for session {session_id}")
                 return llm_config["value_extraction_backend"]
             elif llm_config.get("schema_creation_backend"):
-                print(f"DEBUG: Using preserved schema_creation_backend for extraction in session {session_id}")
+                logger.debug(f"Using preserved schema_creation_backend for extraction in session {session_id}")
                 return llm_config["schema_creation_backend"]
         
         # Third priority: Session-level QBSD config file
@@ -1037,19 +1041,19 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                     
                 # Use value_extraction_backend if available
                 if "value_extraction_backend" in qbsd_config:
-                    print(f"DEBUG: Using session QBSD value_extraction_backend for session {session_id}")
+                    logger.debug(f"Using session QBSD value_extraction_backend for session {session_id}")
                     return qbsd_config["value_extraction_backend"]
                 elif "schema_creation_backend" in qbsd_config:
-                    print(f"DEBUG: Using session QBSD schema_creation_backend for extraction in session {session_id}")
+                    logger.debug(f"Using session QBSD schema_creation_backend for extraction in session {session_id}")
                     return qbsd_config["schema_creation_backend"]
                 elif "backend" in qbsd_config:  # Legacy support
-                    print(f"DEBUG: Using legacy backend config for session {session_id}")
+                    logger.debug(f"Using legacy backend config for session {session_id}")
                     return qbsd_config["backend"]
             except Exception as e:
-                print(f"DEBUG: Could not load session QBSD config: {e}")
+                logger.debug(f"Could not load session QBSD config: {e}")
         
         # Fallback to default configuration
-        print(f"DEBUG: Using default LLM configuration for extraction in session {session_id}")
+        logger.debug(f"Using default LLM configuration for extraction in session {session_id}")
         return {
             "provider": "gemini",
             "model": "gemini-2.5-flash-lite",  # Use lite model for extraction by default
@@ -1064,12 +1068,12 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
         for system_file in system_files:
             file_path = directory / system_file
             if file_path.exists():
-                print(f"🧹 Removing system file: {file_path}")
+                logger.debug(f"Removing system file: {file_path}")
                 file_path.unlink()
-                
+
         # Also remove any hidden files starting with ._
         for file_path in directory.glob('._*'):
-            print(f"🧹 Removing hidden system file: {file_path}")
+            logger.debug(f"Removing hidden system file: {file_path}")
             file_path.unlink()
 
     def _compute_statistics_from_data(self, session_id: str, session: VisualizationSession) -> Optional[DataStatistics]:
@@ -1091,7 +1095,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
         data_file = session_dir / "data.jsonl"
 
         if not data_file.exists():
-            print(f"⚠️  Statistics: No data.jsonl found for session {session_id}")
+            logger.warning(f"Statistics: No data.jsonl found for session {session_id}")
             return None
 
         # Read all rows from the data file
@@ -1102,15 +1106,15 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                     if line.strip():
                         data_rows.append(json.loads(line))
         except Exception as e:
-            print(f"⚠️  Statistics: Error reading data: {e}")
+            logger.warning(f"Statistics: Error reading data: {e}")
             return None
 
         if not data_rows:
-            print(f"⚠️  Statistics: No data rows found in data.jsonl")
+            logger.warning("Statistics: No data rows found in data.jsonl")
             return None
 
         if not session.columns:
-            print(f"⚠️  Statistics: No columns defined in session {session_id}")
+            logger.warning(f"Statistics: No columns defined in session {session_id}")
             return None
 
         # Count unique documents from papers field
@@ -1194,5 +1198,5 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             schema_evolution=None  # Upload sessions don't have schema evolution
         )
 
-        print(f"✓ Statistics computed: {len(data_rows)} rows, {total_documents} documents, {len(columns)} columns, {completeness:.1f}% complete")
+        logger.info(f"Statistics computed: {len(data_rows)} rows, {total_documents} documents, {len(columns)} columns, {completeness:.1f}% complete")
         return stats

--- a/backend/app/services/websocket_manager.py
+++ b/backend/app/services/websocket_manager.py
@@ -2,9 +2,12 @@
 
 import json
 import asyncio
+import logging
 from typing import Dict, Set, Any, List
 from fastapi import WebSocket
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
 
 class WebSocketManager:
     """Manages WebSocket connections for real-time updates."""
@@ -182,8 +185,8 @@ class WebSocketManager:
         async with self._lock:
             ws_set = self.connections.get(session_id)
             if not ws_set:
-                print(f"⚠️ NO CONNECTIONS for session {session_id}")
-                print(f"⚠️ Active sessions: {list(self.connections.keys())}")
+                logger.warning(f"No connections for session {session_id}")
+                logger.warning(f"Active sessions: {list(self.connections.keys())}")
                 return
             snapshot = list(ws_set)
 
@@ -192,7 +195,7 @@ class WebSocketManager:
             try:
                 await websocket.send_json(message)
             except Exception as e:
-                print(f"Failed to send message to websocket: {e}")
+                logger.warning(f"Failed to send message to websocket: {e}")
                 dead_connections.append(websocket)
 
         # Remove dead connections
@@ -257,7 +260,7 @@ class WebSocketManager:
                     self.pending_cell_events[session_id] = []
                 self.pending_cell_events[session_id].append(message)
                 cell_info = message.get('data', {})
-                print(f"📥 BUFFERED cell event: {cell_info.get('row_name')}/{cell_info.get('column')} (will flush when connected)")
+                logger.debug(f"Buffered cell event: {cell_info.get('row_name')}/{cell_info.get('column')} (will flush when connected)")
                 return
 
         # Connection exists, broadcast immediately (broadcast_to_session handles its own lock)
@@ -268,6 +271,6 @@ class WebSocketManager:
         async with self._lock:
             events = self.pending_cell_events.pop(session_id, [])
         if events:
-            print(f"📤 Flushing {len(events)} buffered cell events for {session_id}")
+            logger.info(f"Flushing {len(events)} buffered cell events for {session_id}")
             for event in events:
                 await self.broadcast_to_session(session_id, event)


### PR DESCRIPTION
## Summary

- **Concurrent QBSD sessions**: Backend now supports 5-8 parallel QBSD sessions on Railway (8 vCPU / 8 GB RAM) by offloading blocking LLM/embedding calls to a shared `ThreadPoolExecutor` via `run_in_executor`
- **Concurrency control**: `ConcurrencyLimiter` tracks active operations across all services (QBSD creation, reextraction, continue discovery, document processing). Returns HTTP 503 with friendly message when at capacity
- **Thread safety**: Added `threading.Lock` and `asyncio.Lock` to all shared state in services (`SessionManager`, `WebSocketManager`, `QBSDRunner`, etc.)
- **Frontend capacity handling**: HTTP 503 shows an amber "Server Busy" banner in QBSDMonitor with a "Try Again" button and 30s auto-dismiss (not a red error). Same pattern in ContinueDiscovery, Reextraction, SchemaViewer, and Visualize
- **Session-filterable structured logging**: Replaced all `print()` with `logger.*` across 12 service/route files (~240 conversions). Uses Python `contextvars` to auto-inject `[session_id]` into every log line — search Railway logs by 8-char session prefix to trace all activity for a specific session

## Test plan

- [ ] Start backend — verify `[no-session]` prefix appears on startup logs
- [ ] Run a QBSD session — verify all logs show `[XXXXXXXX]` prefix matching session ID
- [ ] Search Railway logs by the 8-char prefix — confirm ALL session logs are captured
- [ ] Start 5 QBSD sessions — all should proceed
- [ ] Attempt a 6th — should get HTTP 503 with friendly amber banner, not red error
- [ ] Click "Try Again" on the banner — should retry
- [ ] POST `/run/{same_session}` twice — should get HTTP 409
- [ ] Stop a running session — should work correctly with partial results
- [ ] `GET /health` responds during QBSD processing (event loop not blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)