### PR TITLE
feat: Multi-user concurrency and session-filterable logging

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,9 @@ logging.basicConfig(
 for _handler in logging.root.handlers:
     _handler.addFilter(SessionFilter())
 
+# Suppress noisy uvicorn access logs (frontend polling every ~3s floods Railway logs)
+logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+
 # Add qbsd-lib to Python path (sibling directory to backend)
 _QBSD_LIB_PATH = Path(__file__).parent.parent.parent / "qbsd-lib"
 if _QBSD_LIB_PATH.exists() and str(_QBSD_LIB_PATH) not in sys.path:


### PR DESCRIPTION
## Summary

- **Concurrency control**: Added `ConcurrencyLimiter` to cap parallel LLM-heavy operations (`MAX_CONCURRENT_SESSIONS` env var, default 5). Routes acquire before scheduling work; services release in `finally` blocks. HTTP 503 with friendly message when at capacity.
- **Thread pool offloading**: All blocking LLM/embedding calls offloaded via `run_in_executor` with a shared `ThreadPoolExecutor` (`QBSD_THREAD_POOL_SIZE` env var, default 6). Thread-safe stop flags and session state via `threading.Lock`.
- **Session-filterable structured logging**: Every log line now includes a `[session_id]` prefix using Python `contextvars` + custom `logging.Filter`. All `print()` calls converted to `logger.*` across services and routes. Searchable in Railway by session ID.
- **Frontend capacity handling**: HTTP 503 shows an amber "Server Busy" banner (not red error) with "Try Again" button and 30-second auto-dismiss across all flows.
- **Uvicorn access log suppression**: Suppressed noisy polling access logs that flooded Railway, keeping only 4xx/5xx errors visible.

## Files changed (23 files)

**Infrastructure**: `logging_utils.py` (new), `config.py`, `exceptions.py`, `main.py`, `services/__init__.py`
**Services**: `qbsd_runner.py`, `schema_manager.py`, `upload_document_processor.py`, `reextraction_service.py`, `continue_discovery_service.py`, `websocket_manager.py`, `session_manager.py`
**Routes**: `load.py`, `qbsd.py`, `schema.py`, `websocket.py`, `observation_unit.py`
**Frontend**: `QBSDMonitor.tsx`, `ContinueDiscoveryDialog.tsx`, `ReextractionDialog.tsx`, `SchemaViewer.tsx`, `Visualize.tsx`

## Test plan

- [ ] Deploy to Railway and confirm logs show `[XXXXXXXX]` session prefix
- [ ] Search Railway logs by session ID (without brackets) — all session activity found
- [ ] Run concurrent QBSD sessions and verify capacity limit returns 503 with amber banner
- [ ] Verify uvicorn access logs (polling) no longer flood Railway logs
- [ ] Confirm single-user flows still work end-to-end (create, continue, reextract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)