### PR TITLE
feat: LLM API Call Tracking System with Global Quota

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -123,6 +123,12 @@ DATA_COLLECTION_ENABLED = (
     and bool(GOOGLE_SERVICE_ACCOUNT_JSON or GOOGLE_SERVICE_ACCOUNT_FILE or GOOGLE_OAUTH_CREDENTIALS_JSON)
 )
 
+# ── LLM Call Quota ───────────────────────────────────────────────
+# Global limit on cumulative LLM API calls across all sessions.
+# Always enforced in release mode. In developer mode the quota is bypassed.
+# Set to 0 to allow unlimited calls (no quota enforced).
+LLM_CALL_GLOBAL_LIMIT = int(os.environ.get("LLM_CALL_GLOBAL_LIMIT", "20"))
+
 # ── Concurrency Configuration ────────────────────────────────────
 MAX_CONCURRENT_SESSIONS = int(os.environ.get("MAX_CONCURRENT_SESSIONS", "5"))
 QBSD_THREAD_POOL_SIZE = int(os.environ.get("QBSD_THREAD_POOL_SIZE", "6"))

--- a/backend/app/models/qbsd.py
+++ b/backend/app/models/qbsd.py
@@ -66,6 +66,8 @@ class QBSDConfig(BaseModel):
     document_randomization_seed: int = 42
     skip_value_extraction: bool = False  # Schema discovery only mode
     previous_session_id: Optional[str] = None  # Session ID to copy uploaded files from
+    count_toward_quota: bool = True  # If False, this session's LLM calls won't count toward the global quota
+    llm_call_limit: Optional[int] = None  # Developer-only: override the global quota limit for this session
 
 class QBSDStatus(BaseModel):
     """Status of QBSD execution."""

--- a/backend/app/services/continue_discovery_service.py
+++ b/backend/app/services/continue_discovery_service.py
@@ -38,6 +38,7 @@ from qbsd.core.schema import Schema, Column, SchemaEvolution, SchemaSnapshot
 from qbsd.core.llm_backends import GeminiLLM
 from qbsd.core.retrievers import EmbeddingRetriever
 from qbsd.core import utils as qbsd_utils
+from qbsd.core.llm_call_tracker import LLMCallTracker
 from qbsd.value_extraction.main import build_table_jsonl
 
 QBSD_AVAILABLE = True
@@ -857,6 +858,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
 
         # Set session context for logging
         set_session_context(operation.session_id)
+        LLMCallTracker.get_instance().set_stage("continue_discovery")
 
         logger.info(f"_run_continue_discovery started for operation {operation_id}")
 

--- a/backend/app/services/data_collection_service.py
+++ b/backend/app/services/data_collection_service.py
@@ -114,6 +114,16 @@ class DataCollectionService:
             if session.observation_unit:
                 obs_unit = session.observation_unit.name or ""
 
+            # Read LLM call count from session stats file
+            llm_calls = 0
+            try:
+                llm_stats_file = Path("./qbsd_work") / session_id / "llm_call_stats.json"
+                if llm_stats_file.exists():
+                    llm_stats = json.loads(llm_stats_file.read_text(encoding="utf-8"))
+                    llm_calls = llm_stats.get("total_calls", 0)
+            except Exception as e:
+                logger.debug("[data-collection] Could not read LLM call stats: %s", e)
+
             self._sheets_logger.log_session(
                 session_id=session_id,
                 query=query,
@@ -124,6 +134,7 @@ class DataCollectionService:
                 observation_unit=obs_unit,
                 trigger_source=trigger_source,
                 drive_file_id=file_id,
+                llm_calls=llm_calls,
             )
 
     # ── Helpers ─────────────────────────────────────────────────────

--- a/backend/app/services/qbsd_runner.py
+++ b/backend/app/services/qbsd_runner.py
@@ -13,7 +13,7 @@ from typing import Dict, Any, Optional, List
 from pathlib import Path
 from datetime import datetime
 
-from app.core.config import MAX_DOCUMENTS, DEVELOPER_MODE, RELEASE_CONFIG
+from app.core.config import MAX_DOCUMENTS, DEVELOPER_MODE, RELEASE_CONFIG, LLM_CALL_GLOBAL_LIMIT
 from app.core.logging_utils import set_session_context
 from app.services import qbsd_thread_pool, concurrency_limiter
 
@@ -26,6 +26,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
 from qbsd.core import qbsd as QBSD
 from qbsd.core.schema import Schema, Column, ObservationUnit
 from qbsd.core.llm_backends import LLMInterface, TogetherLLM, OpenAILLM, GeminiLLM
+from qbsd.core.llm_call_tracker import LLMCallTracker, GlobalLLMUsageTracker, QuotaExceededError
 from qbsd.core.retrievers import EmbeddingRetriever
 from qbsd.value_extraction.main import build_table_jsonl
 from qbsd import discover_observation_unit, ObservationUnitDiscoveryError
@@ -145,6 +146,26 @@ class QBSDRunner(WebSocketBroadcasterMixin):
         self._data_collection_service = data_collection_service
         self.stop_flags: Dict[str, bool] = {}  # Track stop requests per session
         self._state_lock = threading.Lock()
+        self._global_usage = GlobalLLMUsageTracker(self.work_dir / "global_llm_usage.json")
+
+    def _sync_usage_from_sheets(self) -> None:
+        """Sync the local global usage file from Google Sheets.
+
+        After a redeploy the local file is empty, but Google Sheets retains
+        the full history.  This reads the cumulative LLM call total from
+        the Sheet and updates the local tracker if it is behind.
+        Fails silently if Sheets is not configured.
+        """
+        try:
+            from app.storage.google_sheets import GoogleSheetsLogger
+            sheets = GoogleSheetsLogger.get_instance()
+            if sheets is None:
+                return
+            external_total = sheets.read_total_llm_calls()
+            if external_total > 0:
+                self._global_usage.sync_from_external(external_total)
+        except Exception as e:
+            logger.debug("Could not sync usage from Google Sheets: %s", e)
 
     def is_stop_requested(self, session_id: str) -> bool:
         """Check if stop has been requested for a session."""
@@ -496,6 +517,7 @@ class QBSDRunner(WebSocketBroadcasterMixin):
     async def run_qbsd(self, session_id: str):
         """Run QBSD discovery process."""
         set_session_context(session_id)
+        config = None  # Loaded inside try; referenced in except for quota info
         try:
             # Update session status
             session = self.session_manager.get_session(session_id)
@@ -533,7 +555,23 @@ class QBSDRunner(WebSocketBroadcasterMixin):
             session.error_message = str(e)
             self.session_manager.update_session(session)
 
-            await self.broadcast_error(session_id, str(e))
+            # Check if this is a quota exceeded error — broadcast distinct message
+            is_quota_error = "quota exceeded" in str(e).lower()
+            if is_quota_error:
+                usage = self._global_usage.get_usage()
+                total_used = usage.get("total_calls", 0)
+                effective_limit = LLM_CALL_GLOBAL_LIMIT if not DEVELOPER_MODE else ((config.llm_call_limit or 0) if config else 0)
+                await self.websocket_manager.broadcast_progress(session_id, {
+                    "type": "quota_exceeded",
+                    "message": "The system has reached its API usage limit and cannot start new processing sessions.",
+                    "data": {
+                        "total_used": total_used,
+                        "limit": effective_limit,
+                    },
+                    "timestamp": datetime.now().isoformat(),
+                })
+            else:
+                await self.broadcast_error(session_id, str(e))
 
         finally:
             # Clean up
@@ -577,6 +615,28 @@ class QBSDRunner(WebSocketBroadcasterMixin):
             )
         
         try:
+            # Reset LLM call tracker for this session
+            llm_tracker = LLMCallTracker.get_instance()
+            llm_tracker.reset()
+
+            # Check global LLM usage quota before starting.
+            # In release mode: always enforced using LLM_CALL_GLOBAL_LIMIT.
+            # In developer mode: only enforced if config.llm_call_limit is set
+            #   (lets developers choose their own threshold).
+            if DEVELOPER_MODE:
+                effective_limit = config.llm_call_limit or 0  # 0 = no limit
+            else:
+                effective_limit = LLM_CALL_GLOBAL_LIMIT  # from env var
+
+            if effective_limit > 0:
+                # Sync local usage counter from Google Sheets (survives redeploys)
+                self._sync_usage_from_sheets()
+                try:
+                    self._global_usage.check_quota(effective_limit)
+                except QuotaExceededError as exc:
+                    logger.warning("Session %s blocked by global LLM quota: %s", session_id, exc)
+                    raise RuntimeError(str(exc)) from exc
+
             # Step 1: Initializing
             logger.debug("Starting QBSD execution for session %s", session_id)
             await update_progress("Initializing", 0.0)
@@ -749,6 +809,7 @@ class QBSDRunner(WebSocketBroadcasterMixin):
                     pass  # Expected when cancelling
             logger.debug("Schema discovery completed with %d columns", len(discovered_schema.columns))
             logger.debug("Schema evolution: %d snapshots tracked", len(schema_evolution.snapshots))
+            logger.info("LLM call stats after schema discovery: %s", llm_tracker.get_summary())
             
             # Save discovered schema with frontend-compatible format
             schema_file = session_dir / "discovered_schema.json"
@@ -878,6 +939,7 @@ class QBSDRunner(WebSocketBroadcasterMixin):
                         pass  # Expected when cancelling
 
                 await update_progress("Extracting values", 1.0)
+                logger.info("LLM call stats after value extraction: %s", llm_tracker.get_summary())
 
             # Check if stop was requested during value extraction - skip finalization
             if self.is_stop_requested(session_id):
@@ -914,6 +976,21 @@ class QBSDRunner(WebSocketBroadcasterMixin):
                 session_id, discovered_schema, schema_evolution, skipped_documents
             )
 
+            # Save LLM call tracking stats to session directory
+            llm_call_summary = llm_tracker.get_summary()
+            llm_call_summary["log"] = llm_tracker.get_log()
+            llm_stats_file = session_dir / "llm_call_stats.json"
+            with open(llm_stats_file, 'w') as f:
+                json.dump(llm_call_summary, f, indent=2)
+            logger.info("LLM call stats saved to %s: %s", llm_stats_file, llm_tracker.get_counts())
+
+            # Update global cumulative LLM usage (persisted across sessions)
+            # Skip if the session opted out of quota tracking
+            if config.count_toward_quota:
+                self._global_usage.record_session(session_id, llm_tracker.get_counts())
+            else:
+                logger.info("Session %s opted out of quota tracking (count_toward_quota=False)", session_id)
+
             # Update session as completed with statistics
             session = self.session_manager.get_session(session_id)
             session.statistics = statistics
@@ -932,11 +1009,15 @@ class QBSDRunner(WebSocketBroadcasterMixin):
                 if schema_only
                 else "QBSD execution completed successfully"
             )
-            await self.broadcast_completion(session_id, completion_message, {
+            completion_details = {
                 "total_documents": total_docs,
                 "schema_columns": len(discovered_schema.columns),
-                "schema_only": schema_only
-            })
+                "schema_only": schema_only,
+            }
+            # Only expose LLM call stats to developers, not end users
+            if DEVELOPER_MODE:
+                completion_details["llm_call_stats"] = llm_tracker.get_counts()
+            await self.broadcast_completion(session_id, completion_message, completion_details)
 
             # Archive session data for research (fire-and-forget)
             if self._data_collection_service:

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -31,6 +31,7 @@ from qbsd.core.schema import Schema, Column
 from qbsd.core.llm_backends import GeminiLLM
 from qbsd.core.retrievers import EmbeddingRetriever
 from qbsd.core import utils as qbsd_utils
+from qbsd.core.llm_call_tracker import LLMCallTracker
 
 QBSD_AVAILABLE = True
 
@@ -855,6 +856,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
             return
 
         set_session_context(operation.session_id)
+        LLMCallTracker.get_instance().set_stage("reextraction")
         logger.debug(f"_run_reextraction started for operation {operation_id}")
 
         try:

--- a/backend/app/storage/google_sheets.py
+++ b/backend/app/storage/google_sheets.py
@@ -20,7 +20,7 @@ from app.core.config import (
 logger = logging.getLogger(__name__)
 
 # Column headers for the summary sheet (must match append_row order)
-# A-L: session data + feedback in a single row
+# A-M: session data + feedback in a single row
 HEADER_ROW = [
     "Timestamp",
     "Session ID",
@@ -34,6 +34,7 @@ HEADER_ROW = [
     "Drive File ID",
     "Rating",
     "Comment",
+    "LLM Calls",  # Total LLM API calls made during this session
 ]
 
 
@@ -128,7 +129,7 @@ class GoogleSheetsLogger:
             body = {"values": [values]}
             self._service.spreadsheets().values().append(
                 spreadsheetId=GOOGLE_SHEETS_SPREADSHEET_ID,
-                range="Sheet1!A:L",
+                range="Sheet1!A:M",
                 valueInputOption="USER_ENTERED",
                 insertDataOption="INSERT_ROWS",
                 body=body,
@@ -150,6 +151,7 @@ class GoogleSheetsLogger:
         observation_unit: str,
         trigger_source: str,
         drive_file_id: Optional[str],
+        llm_calls: int = 0,
     ) -> bool:
         """Log a session summary row with default Rating=N/A."""
         return self.append_row([
@@ -165,7 +167,36 @@ class GoogleSheetsLogger:
             drive_file_id or "",
             "N/A",  # Rating — updated later if user submits feedback
             "",     # Comment
+            llm_calls,
         ])
+
+    def read_total_llm_calls(self) -> int:
+        """Read the sum of all LLM calls from column M of the Google Sheet.
+
+        Returns 0 if the sheet is empty, inaccessible, or Sheets logging
+        is not configured.
+        """
+        if not self._enabled or not self._service:
+            return 0
+
+        try:
+            result = self._service.spreadsheets().values().get(
+                spreadsheetId=GOOGLE_SHEETS_SPREADSHEET_ID,
+                range="Sheet1!M:M",
+            ).execute()
+            values = result.get("values", [])
+            total = 0
+            for row in values[1:]:  # skip header row
+                if row and row[0]:
+                    try:
+                        total += int(row[0])
+                    except (ValueError, TypeError):
+                        pass
+            logger.debug("[data-collection] Read total LLM calls from Sheet: %d", total)
+            return total
+        except Exception as e:
+            logger.error("[data-collection] Failed to read LLM calls from Sheet: %s", e)
+            return 0
 
     def log_feedback(
         self,

--- a/frontend/src/components/QBSDMonitor/QBSDMonitor.tsx
+++ b/frontend/src/components/QBSDMonitor/QBSDMonitor.tsx
@@ -55,6 +55,7 @@ const QBSDMonitor: React.FC<QBSDMonitorProps> = ({ sessionId }) => {
   const [currentStepMessage, setCurrentStepMessage] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [capacityMessage, setCapacityMessage] = useState<string>('');
+  const [quotaExceeded, setQuotaExceeded] = useState(false);
 
   // Phase tracking state
   const [schemaProgress, setSchemaProgress] = useState({
@@ -152,6 +153,10 @@ const QBSDMonitor: React.FC<QBSDMonitorProps> = ({ sessionId }) => {
         setProcessingState('error');
         setErrorMessage(message.message || 'An error occurred');
         addLog('error', message.message || 'An error occurred', message.data);
+      } else if (message.type === 'quota_exceeded') {
+        setProcessingState('idle');
+        setQuotaExceeded(true);
+        addLog('warning', message.message || 'API usage limit reached', message.data);
       } else if (message.type === 'completed') {
         addLog('success', 'QBSD execution completed successfully!', message.data);
         setProcessingState('completed');
@@ -251,6 +256,7 @@ const QBSDMonitor: React.FC<QBSDMonitorProps> = ({ sessionId }) => {
     setCurrentStepMessage('Initializing...');
     setErrorMessage('');
     setCapacityMessage('');
+    setQuotaExceeded(false);
     setStoppedInfo(null);
 
     // Reset progress
@@ -332,7 +338,20 @@ const QBSDMonitor: React.FC<QBSDMonitorProps> = ({ sessionId }) => {
           {/* IDLE STATE */}
           {processingState === 'idle' && (
             <>
-              {capacityMessage ? (
+              {quotaExceeded ? (
+                <>
+                  <div className="w-14 h-14 rounded-full bg-orange-100 flex items-center justify-center mb-4">
+                    <AlertTriangle className="h-7 w-7 text-orange-600" />
+                  </div>
+                  <p className="text-xl font-semibold text-orange-600 mb-1">Service Temporarily Unavailable</p>
+                  <p className="text-sm text-muted-foreground mb-3 text-center max-w-md">
+                    The system has reached its processing capacity and is unable to start new sessions at this time.
+                  </p>
+                  <p className="text-xs text-muted-foreground text-center max-w-sm">
+                    Please try again later or contact us for assistance.
+                  </p>
+                </>
+              ) : capacityMessage ? (
                 <>
                   <div className="w-14 h-14 rounded-full bg-amber-100 flex items-center justify-center mb-4">
                     <Clock className="h-7 w-7 text-amber-600" />

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -276,7 +276,7 @@ export interface StoppedData {
 }
 
 export interface WebSocketMessage {
-  type: 'progress' | 'log' | 'error' | 'completed' | 'connected' | 'disconnected' | 'reconnecting' | 'pong' | 'heartbeat' | 'schema_completed' | 'row_completed' | 'schema_updated' | 'reprocessing_progress' | 'reprocessing_completed' | 'cell_extracted' | 'stopped' | 'continue_discovery_progress' | 'continue_discovery_completed' | 'continue_discovery_stopped' | 'incremental_extraction_progress';
+  type: 'progress' | 'log' | 'error' | 'completed' | 'connected' | 'disconnected' | 'reconnecting' | 'pong' | 'heartbeat' | 'schema_completed' | 'row_completed' | 'schema_updated' | 'reprocessing_progress' | 'reprocessing_completed' | 'cell_extracted' | 'stopped' | 'continue_discovery_progress' | 'continue_discovery_completed' | 'continue_discovery_stopped' | 'incremental_extraction_progress' | 'quota_exceeded';
   timestamp?: string;
   session_id?: string;
   message?: string;

--- a/qbsd-lib/qbsd/__init__.py
+++ b/qbsd-lib/qbsd/__init__.py
@@ -10,6 +10,7 @@ __version__ = "0.1.0"
 
 from qbsd.core.schema import Column, Schema, SchemaSnapshot, SchemaEvolution, ObservationUnit
 from qbsd.core.llm_backends import LLMInterface, TogetherLLM, OpenAILLM, GeminiLLM
+from qbsd.core.llm_call_tracker import LLMCallTracker, GlobalLLMUsageTracker, QuotaExceededError
 from qbsd.core.retrievers import EmbeddingRetriever
 from qbsd.core.prompts import SchemaMode
 from qbsd.core.model_specs import ModelSpec, get_model_spec, MODEL_SPECS, GLOBAL_FALLBACK
@@ -33,6 +34,9 @@ __all__ = [
     "TogetherLLM",
     "OpenAILLM",
     "GeminiLLM",
+    "LLMCallTracker",
+    "GlobalLLMUsageTracker",
+    "QuotaExceededError",
     "EmbeddingRetriever",
     "DocumentPreprocessor",
     "PreprocessorConfig",

--- a/qbsd-lib/qbsd/core/llm_backends.py
+++ b/qbsd-lib/qbsd/core/llm_backends.py
@@ -15,6 +15,7 @@ from typing import List, Dict, Any, Union, Optional
 import re
 
 from qbsd.core.model_specs import get_model_spec
+from qbsd.core.llm_call_tracker import LLMCallTracker
 
 
 ##############################################################################
@@ -151,6 +152,10 @@ class TogetherLLM(LLMInterface):
             • str  – plain prompt → wrapped as [{'role':'user', 'content': prompt}]
             • list – already‑formatted chat messages (role/content pairs)
         """
+        # Track LLM call
+        prompt_len = sum(len(m.get("content", "")) for m in (prompt if isinstance(prompt, list) else [{"content": prompt}]))
+        LLMCallTracker.get_instance().increment(model=self.model, prompt_length=prompt_len)
+
         params = {**self._default_args, **kwargs}
 
         # Detect format
@@ -250,6 +255,10 @@ class OpenAILLM(LLMInterface):
             • str  – plain prompt → wrapped as [{'role':'user', 'content': prompt}]
             • list – already‑formatted chat messages (role/content pairs)
         """
+        # Track LLM call
+        prompt_len = sum(len(m.get("content", "")) for m in (prompt if isinstance(prompt, list) else [{"content": prompt}]))
+        LLMCallTracker.get_instance().increment(model=self.model, prompt_length=prompt_len)
+
         params = {**self._default_args, **kwargs}
 
         # Detect format
@@ -379,6 +388,10 @@ class HuggingFaceLLM(LLMInterface):
             • str  – plain prompt
             • list – chat-style messages (merged to prompt text)
         """
+        # Track LLM call
+        prompt_len = sum(len(m.get("content", "")) for m in (prompt if isinstance(prompt, list) else [{"content": prompt}]))
+        LLMCallTracker.get_instance().increment(model=self.model_name, prompt_length=prompt_len)
+
         if isinstance(prompt, list):
             # Convert messages to plain prompt text
             prompt = "\n".join([f"{m['role']}: {m['content']}" for m in prompt])
@@ -530,6 +543,10 @@ class GeminiLLM(LLMInterface):
             • str  – plain prompt
             • list – chat-style messages (converted to plain prompt)
         """
+        # Track LLM call
+        prompt_len = sum(len(m.get("content", "")) for m in (prompt if isinstance(prompt, list) else [{"content": prompt}]))
+        LLMCallTracker.get_instance().increment(model=self.model, prompt_length=prompt_len)
+
         # Convert chat messages to plain text if needed
         if isinstance(prompt, list):
             prompt_text = "\n".join([f"{m['role']}: {m['content']}" for m in prompt])
@@ -537,8 +554,7 @@ class GeminiLLM(LLMInterface):
             prompt_text = prompt
 
         # Log prompt size for performance correlation
-        prompt_len = len(prompt_text)
-        print(f"🚀 Starting Gemini API call (model: {self.model}, prompt: ~{prompt_len:,} chars)")
+        print(f"🚀 Starting Gemini API call (model: {self.model}, prompt: ~{len(prompt_text):,} chars)")
         start_time = time.time()
 
         # Add scientific context to help with safety filtering

--- a/qbsd-lib/qbsd/core/llm_call_tracker.py
+++ b/qbsd-lib/qbsd/core/llm_call_tracker.py
@@ -1,0 +1,296 @@
+"""
+LLM API Call Tracker
+====================
+Thread-safe singleton that counts and logs all LLM API calls,
+broken down by pipeline stage.
+
+Also provides ``GlobalLLMUsageTracker`` — a persistent, file-backed
+aggregator that accumulates call counts across sessions and enforces
+a configurable global quota.
+
+Usage
+-----
+    from qbsd.core.llm_call_tracker import LLMCallTracker, GlobalLLMUsageTracker
+
+    tracker = LLMCallTracker.get_instance()
+    tracker.set_stage("schema_discovery")
+    # ... LLM generate() calls will be counted automatically ...
+    print(tracker.get_summary())
+    tracker.reset()  # reset all counters
+
+    # Global quota check
+    global_tracker = GlobalLLMUsageTracker("./qbsd_work/global_llm_usage.json")
+    global_tracker.check_quota(limit=1000)  # raises QuotaExceededError if over
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class LLMCallTracker:
+    """Thread-safe singleton that tracks LLM API calls per pipeline stage."""
+
+    _instance: Optional[LLMCallTracker] = None
+    _init_lock = threading.Lock()
+
+    # -- Singleton access -------------------------------------------------- #
+
+    @classmethod
+    def get_instance(cls) -> LLMCallTracker:
+        """Return the global tracker instance (created on first call)."""
+        if cls._instance is None:
+            with cls._init_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    # -- Construction ------------------------------------------------------ #
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._counts: Dict[str, int] = {}
+        self._log: List[Dict[str, Any]] = []
+        self._current_stage: str = "unknown"
+
+    # -- Public API -------------------------------------------------------- #
+
+    def set_stage(self, stage: str) -> None:
+        """Set the current pipeline stage (e.g. ``"schema_discovery"``)."""
+        with self._lock:
+            self._current_stage = stage
+
+    def get_stage(self) -> str:
+        """Return the current pipeline stage."""
+        with self._lock:
+            return self._current_stage
+
+    def increment(self, *, model: str = "", prompt_length: int = 0) -> None:
+        """Record one LLM API call under the current stage.
+
+        Parameters
+        ----------
+        model : str, optional
+            Model identifier (e.g. ``"gemini-2.5-flash-lite"``).
+        prompt_length : int, optional
+            Approximate character length of the prompt sent to the LLM.
+        """
+        with self._lock:
+            stage = self._current_stage
+            self._counts[stage] = self._counts.get(stage, 0) + 1
+            self._log.append({
+                "timestamp": time.time(),
+                "stage": stage,
+                "model": model,
+                "prompt_length": prompt_length,
+            })
+
+    def get_counts(self) -> Dict[str, int]:
+        """Return a copy of per-stage call counts."""
+        with self._lock:
+            return dict(self._counts)
+
+    def get_total(self) -> int:
+        """Return the total number of LLM calls across all stages."""
+        with self._lock:
+            return sum(self._counts.values())
+
+    def get_log(self) -> List[Dict[str, Any]]:
+        """Return a copy of the detailed call log."""
+        with self._lock:
+            return list(self._log)
+
+    def get_summary(self) -> Dict[str, Any]:
+        """Return a full summary dictionary suitable for JSON serialisation."""
+        with self._lock:
+            return {
+                "total_calls": sum(self._counts.values()),
+                "per_stage": dict(self._counts),
+                "log_length": len(self._log),
+            }
+
+    def reset(self, stage: Optional[str] = None) -> None:
+        """Reset counters and log.
+
+        Parameters
+        ----------
+        stage : str, optional
+            If provided, only reset the counter for that stage.
+            If ``None``, reset everything.
+        """
+        with self._lock:
+            if stage is None:
+                self._counts.clear()
+                self._log.clear()
+                self._current_stage = "unknown"
+            else:
+                self._counts.pop(stage, None)
+                self._log = [
+                    entry for entry in self._log if entry["stage"] != stage
+                ]
+
+
+##############################################################################
+# Global quota / budget tracking                                             #
+##############################################################################
+
+
+class QuotaExceededError(Exception):
+    """Raised when the global LLM call quota has been exceeded."""
+
+    def __init__(self, used: int, limit: int):
+        self.used = used
+        self.limit = limit
+        super().__init__(
+            f"Global LLM call quota exceeded: {used}/{limit} calls used. "
+            "Please contact an administrator to raise the limit."
+        )
+
+
+class GlobalLLMUsageTracker:
+    """Persistent, file-backed tracker of cumulative LLM calls across sessions.
+
+    Stores a simple JSON file with the structure::
+
+        {
+            "total_calls": 123,
+            "per_stage": {"schema_discovery": 40, "value_extraction": 83},
+            "sessions": [
+                {"session_id": "abc", "calls": 47, "timestamp": 1700000000},
+                ...
+            ]
+        }
+
+    Thread-safe: multiple sessions can update concurrently.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._lock = threading.Lock()
+        # Ensure the parent directory exists
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    # -- Reading ----------------------------------------------------------- #
+
+    def _load(self) -> Dict[str, Any]:
+        """Load the usage file, returning defaults if missing or corrupt."""
+        if not self._path.exists():
+            return {"total_calls": 0, "per_stage": {}, "sessions": []}
+        try:
+            return json.loads(self._path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Could not read global usage file %s: %s", self._path, exc)
+            return {"total_calls": 0, "per_stage": {}, "sessions": []}
+
+    def _save(self, data: Dict[str, Any]) -> None:
+        """Atomically write the usage file."""
+        tmp = self._path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        tmp.replace(self._path)  # atomic on POSIX
+
+    # -- Public API -------------------------------------------------------- #
+
+    def get_total(self) -> int:
+        """Return the cumulative total of LLM calls across all sessions."""
+        with self._lock:
+            return self._load().get("total_calls", 0)
+
+    def get_usage(self) -> Dict[str, Any]:
+        """Return the full usage data."""
+        with self._lock:
+            return self._load()
+
+    def check_quota(self, limit: int) -> None:
+        """Raise ``QuotaExceededError`` if cumulative calls >= *limit*.
+
+        A *limit* of ``0`` disables the check (no quota enforced).
+        """
+        if limit <= 0:
+            return  # quota disabled
+        total = self.get_total()
+        if total >= limit:
+            raise QuotaExceededError(used=total, limit=limit)
+
+    def record_session(
+        self,
+        session_id: str,
+        session_counts: Dict[str, int],
+    ) -> Dict[str, Any]:
+        """Add a completed session's LLM call counts to the global totals.
+
+        Parameters
+        ----------
+        session_id : str
+            Unique identifier of the session that just finished.
+        session_counts : dict
+            Per-stage call counts from ``LLMCallTracker.get_counts()``.
+
+        Returns
+        -------
+        dict
+            Updated global usage data.
+        """
+        session_total = sum(session_counts.values())
+        with self._lock:
+            data = self._load()
+            data["total_calls"] = data.get("total_calls", 0) + session_total
+
+            # Merge per-stage counts
+            global_stages = data.get("per_stage", {})
+            for stage, count in session_counts.items():
+                global_stages[stage] = global_stages.get(stage, 0) + count
+            data["per_stage"] = global_stages
+
+            # Append session entry
+            sessions = data.get("sessions", [])
+            sessions.append({
+                "session_id": session_id,
+                "calls": session_total,
+                "per_stage": session_counts,
+                "timestamp": time.time(),
+            })
+            data["sessions"] = sessions
+
+            self._save(data)
+            logger.info(
+                "Global LLM usage updated: session %s added %d calls (new total: %d)",
+                session_id[:8], session_total, data["total_calls"],
+            )
+            return data
+
+    def sync_from_external(self, external_total: int) -> None:
+        """Sync local file with an externally-sourced cumulative total.
+
+        If the local file has a lower total (e.g. after a redeploy wiped it),
+        the local total is updated to match the external source.
+        If the local total is already >= the external total, no change is made.
+
+        Parameters
+        ----------
+        external_total : int
+            Cumulative LLM call count from an external source
+            (e.g. Google Sheets).
+        """
+        with self._lock:
+            data = self._load()
+            local_total = data.get("total_calls", 0)
+            if external_total > local_total:
+                logger.info(
+                    "Syncing global usage from external source: local=%d → external=%d",
+                    local_total, external_total,
+                )
+                data["total_calls"] = external_total
+                self._save(data)
+
+    def reset(self) -> None:
+        """Reset all global usage data (e.g. new billing cycle)."""
+        with self._lock:
+            self._save({"total_calls": 0, "per_stage": {}, "sessions": []})
+

--- a/qbsd-lib/qbsd/core/qbsd.py
+++ b/qbsd-lib/qbsd/core/qbsd.py
@@ -28,6 +28,7 @@ import time
 import random
 from pathlib import Path
 from qbsd.core.schema import Schema, Column, SchemaEvolution, ObservationUnit
+from qbsd.core.llm_call_tracker import LLMCallTracker
 from qbsd.core.prompts import (
     get_prompts, get_observation_unit_prompts, SchemaMode, DRAFT_SCHEMA_TMPL,
     SYSTEM_PROMPT_OBSERVATION_UNIT, USER_PROMPT_TMPL_OBSERVATION_UNIT,
@@ -315,6 +316,7 @@ def _discover_observation_unit(
     trimmed = utils.fit_prompt(messages, truncate=True, context_window_size=context_window_size)
 
     try:
+        LLMCallTracker.get_instance().set_stage("observation_unit_discovery")
         llm_response = llm.generate(trimmed)
         observation_unit = _parse_observation_unit_from_llm(llm_response)
 
@@ -435,6 +437,7 @@ def generate_schema(
     """
     messages, mode = build_messages(query, passages, current_schema, observation_unit)
     trimmed = utils.fit_prompt(messages, truncate=True, context_window_size=context_window_size)
+    LLMCallTracker.get_instance().set_stage("schema_discovery")
     llm_response = llm.generate(trimmed)
 
     # For query-only mode, document_helpful doesn't apply

--- a/qbsd-lib/qbsd/core/retrievers.py
+++ b/qbsd-lib/qbsd/core/retrievers.py
@@ -485,6 +485,7 @@ class EmbeddingRetriever(Retriever):
 ##############################################################################
 
 from qbsd.core.llm_backends import LLMInterface   # assumes the base class lives there
+from qbsd.core.llm_call_tracker import LLMCallTracker
 
 
 LLM_RANK_INSTRUCTION = """
@@ -553,6 +554,7 @@ class PromptingRetriever(Retriever):
 
     # ---- Public API ----------------------------------------------------- #
     def query(self, docs: Sequence[str], question: str, k: int | None = None) -> List[str]:
+        LLMCallTracker.get_instance().set_stage("retrieval")
         # 1. chunk
         passages: List[str] = []
         for d in docs:

--- a/qbsd-lib/qbsd/value_extraction/core/paper_processor.py
+++ b/qbsd-lib/qbsd/value_extraction/core/paper_processor.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, Any, Set, Callable, Optional, List, Iterator
 from qbsd.core.schema import Schema, Column, ObservationUnit
 from qbsd.core.llm_backends import LLMInterface
+from qbsd.core.llm_call_tracker import LLMCallTracker
 from qbsd.core import utils
 
 from .llm_cache import LLMCache
@@ -356,6 +357,7 @@ class PaperProcessor:
         Note: Document preprocessing is handled by the retriever when configured,
         avoiding redundant preprocessing overhead.
         """
+        LLMCallTracker.get_instance().set_stage("value_extraction")
         if mode == "one":
             mode = "one_by_one"
 
@@ -903,6 +905,7 @@ class PaperProcessor:
         Note: Document preprocessing is handled by the retriever when configured,
         avoiding redundant preprocessing overhead.
         """
+        LLMCallTracker.get_instance().set_stage("value_extraction")
         observation_unit = schema.observation_unit
 
         # Observation unit is required

--- a/qbsd-lib/tests/test_full_quota_flow.py
+++ b/qbsd-lib/tests/test_full_quota_flow.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Full end-to-end quota flow test (local, no Google Sheets needed).
+
+Simulates the exact sequence that QBSDRunner does:
+  1. Reset tracker
+  2. Check quota
+  3. Run LLM calls (mocked — just increments)
+  4. Save stats to file
+  5. Record session in global usage
+
+Then verifies:
+  - Session 1 (4 calls) → allowed, total=4
+  - Session 2 (5 calls) → allowed, total=9
+  - Session 3 → BLOCKED (total=9 ≥ limit=8)
+
+Also tests:
+  - count_toward_quota=False (unmetered session doesn't block future ones)
+  - reset() clears everything
+  - Persistence: new tracker instance reads same file
+"""
+
+import json
+import sys
+from pathlib import Path
+
+from qbsd.core.llm_call_tracker import (
+    GlobalLLMUsageTracker,
+    LLMCallTracker,
+    QuotaExceededError,
+)
+
+# ── Config ──
+LIMIT = 8  # small limit to trigger quickly
+WORK_DIR = Path("/tmp/qbsd_quota_test")
+
+
+def setup():
+    """Clean start."""
+    if WORK_DIR.exists():
+        import shutil
+        shutil.rmtree(WORK_DIR)
+    WORK_DIR.mkdir(parents=True)
+    LLMCallTracker.get_instance().reset()
+    print(f"Work dir: {WORK_DIR}")
+    print(f"Quota limit: {LIMIT}")
+    print()
+
+
+def simulate_session(
+    session_id: str,
+    global_tracker: GlobalLLMUsageTracker,
+    stages: dict,
+    count_toward_quota: bool = True,
+) -> bool:
+    """Simulate one QBSD session. Returns True if allowed, False if blocked."""
+    tracker = LLMCallTracker.get_instance()
+    tracker.reset()
+
+    # 1. Check quota
+    try:
+        global_tracker.check_quota(LIMIT)
+    except QuotaExceededError as e:
+        print(f"  BLOCKED: {e}")
+        return False
+
+    # 2. Simulate LLM calls per stage
+    total_calls = 0
+    for stage, count in stages.items():
+        tracker.set_stage(stage)
+        for _ in range(count):
+            tracker.increment(model="test-model", prompt_length=100)
+        total_calls += count
+
+    # 3. Save session stats to file (like QBSDRunner does)
+    session_dir = WORK_DIR / session_id
+    session_dir.mkdir(exist_ok=True)
+    summary = tracker.get_summary()
+    summary["log"] = tracker.get_log()
+    stats_file = session_dir / "llm_call_stats.json"
+    stats_file.write_text(json.dumps(summary, indent=2))
+
+    # 4. Record in global usage (unless opted out)
+    if count_toward_quota:
+        global_tracker.record_session(session_id, tracker.get_counts())
+    else:
+        print(f"  (unmetered — not counting toward quota)")
+
+    print(f"  Session calls: {total_calls} | Global total: {global_tracker.get_total()}")
+    return True
+
+
+def main():
+    setup()
+    global_tracker = GlobalLLMUsageTracker(WORK_DIR / "global_llm_usage.json")
+
+    # ── Session 1: 4 calls → should pass ──
+    print("SESSION 1 (4 calls):")
+    ok = simulate_session("session-1", global_tracker, {
+        "observation_unit_discovery": 1,
+        "schema_discovery": 2,
+        "value_extraction": 1,
+    })
+    assert ok, "Session 1 should have been allowed"
+    assert global_tracker.get_total() == 4
+    print("  ✅ Allowed\n")
+
+    # ── Session 2: 4 calls → should pass (total=8 after, but checked before) ──
+    print("SESSION 2 (4 calls):")
+    ok = simulate_session("session-2", global_tracker, {
+        "schema_discovery": 1,
+        "value_extraction": 3,
+    })
+    assert ok, "Session 2 should have been allowed"
+    assert global_tracker.get_total() == 8
+    print("  ✅ Allowed\n")
+
+    # ── Session 3: should be BLOCKED (total=8 ≥ limit=8) ──
+    print("SESSION 3 (blocked before running):")
+    ok = simulate_session("session-3", global_tracker, {
+        "schema_discovery": 1,
+    })
+    assert not ok, "Session 3 should have been BLOCKED"
+    assert global_tracker.get_total() == 8  # unchanged
+    print("  ✅ Correctly blocked\n")
+
+    # ── Session 4: unmetered → runs but doesn't count ──
+    # First reset to allow it to run (since we're at limit)
+    # Actually, unmetered sessions still get quota-checked in the real flow.
+    # But the user asked for "run without counting" — let's show that:
+    print("RESET (simulating admin raising limit or resetting):")
+    global_tracker.reset()
+    assert global_tracker.get_total() == 0
+    print("  ✅ Reset to 0\n")
+
+    print("SESSION 4 — metered (3 calls):")
+    ok = simulate_session("session-4", global_tracker, {
+        "value_extraction": 3,
+    })
+    assert ok
+    assert global_tracker.get_total() == 3
+    print("  ✅ Allowed\n")
+
+    print("SESSION 5 — UNMETERED (10 calls, doesn't count):")
+    ok = simulate_session("session-5", global_tracker, {
+        "value_extraction": 10,
+    }, count_toward_quota=False)
+    assert ok
+    assert global_tracker.get_total() == 3  # still 3, not 13
+    print("  ✅ Allowed, total unchanged\n")
+
+    print("SESSION 6 — metered (4 calls, total→7):")
+    ok = simulate_session("session-6", global_tracker, {
+        "schema_discovery": 2,
+        "value_extraction": 2,
+    })
+    assert ok
+    assert global_tracker.get_total() == 7
+    print("  ✅ Allowed\n")
+
+    print("SESSION 7 — metered (2 calls → total=9 ≥ 8 after, but check is before):")
+    ok = simulate_session("session-7", global_tracker, {
+        "value_extraction": 2,
+    })
+    assert ok  # 7 < 8, so check passes; after recording, total=9
+    assert global_tracker.get_total() == 9
+    print("  ✅ Allowed (checked at 7, now 9)\n")
+
+    print("SESSION 8 — should be BLOCKED (total=9 ≥ limit=8):")
+    ok = simulate_session("session-8", global_tracker, {
+        "schema_discovery": 1,
+    })
+    assert not ok
+    print("  ✅ Correctly blocked\n")
+
+    # ── Verify persistence: new tracker instance reads the same file ──
+    print("PERSISTENCE TEST:")
+    tracker2 = GlobalLLMUsageTracker(WORK_DIR / "global_llm_usage.json")
+    assert tracker2.get_total() == 9
+    print(f"  New tracker instance reads total={tracker2.get_total()} ✅\n")
+
+    # ── Verify saved files ──
+    print("SAVED FILES:")
+    for d in sorted(WORK_DIR.iterdir()):
+        if d.is_dir():
+            stats = d / "llm_call_stats.json"
+            if stats.exists():
+                data = json.loads(stats.read_text())
+                print(f"  {d.name}/llm_call_stats.json → {data['total_calls']} calls")
+    global_file = WORK_DIR / "global_llm_usage.json"
+    if global_file.exists():
+        data = json.loads(global_file.read_text())
+        print(f"\n  global_llm_usage.json:")
+        print(f"    total_calls: {data['total_calls']}")
+        print(f"    per_stage: {data['per_stage']}")
+        print(f"    sessions: {len(data['sessions'])} recorded")
+
+    print("\n" + "=" * 50)
+    print("ALL TESTS PASSED ✅")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/qbsd-lib/tests/test_llm_call_tracker.py
+++ b/qbsd-lib/tests/test_llm_call_tracker.py
@@ -1,0 +1,326 @@
+"""
+Tests for the LLM Call Tracking System.
+
+Verifies:
+- Per-stage call counting
+- Reset capability
+- Global quota enforcement (allow → allow → block on third)
+- count_toward_quota opt-out
+- File persistence across tracker instances
+"""
+
+import json
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+from qbsd.core.llm_call_tracker import (
+    GlobalLLMUsageTracker,
+    LLMCallTracker,
+    QuotaExceededError,
+)
+
+
+# ──────────────────────────────────────────────────────────────────
+# LLMCallTracker (per-session, in-memory)
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestLLMCallTracker:
+    """Tests for the in-memory per-session tracker."""
+
+    def setup_method(self):
+        """Get a fresh tracker for each test."""
+        tracker = LLMCallTracker.get_instance()
+        tracker.reset()
+
+    def test_increment_counts_by_stage(self):
+        tracker = LLMCallTracker.get_instance()
+
+        tracker.set_stage("schema_discovery")
+        tracker.increment(model="gemini-2.5-flash")
+        tracker.increment(model="gemini-2.5-flash")
+
+        tracker.set_stage("value_extraction")
+        tracker.increment(model="gemini-2.5-flash-lite")
+
+        counts = tracker.get_counts()
+        assert counts["schema_discovery"] == 2
+        assert counts["value_extraction"] == 1
+        assert tracker.get_total() == 3
+
+    def test_increment_default_stage_is_unknown(self):
+        tracker = LLMCallTracker.get_instance()
+        tracker.increment()
+        assert tracker.get_counts().get("unknown", 0) == 1
+
+    def test_get_summary(self):
+        tracker = LLMCallTracker.get_instance()
+        tracker.set_stage("observation_unit_discovery")
+        tracker.increment(model="test-model", prompt_length=500)
+
+        summary = tracker.get_summary()
+        assert summary["total_calls"] == 1
+        assert summary["per_stage"]["observation_unit_discovery"] == 1
+        assert summary["log_length"] == 1
+
+    def test_get_log_records_details(self):
+        tracker = LLMCallTracker.get_instance()
+        tracker.set_stage("schema_discovery")
+        tracker.increment(model="gpt-4o", prompt_length=1234)
+
+        log = tracker.get_log()
+        assert len(log) == 1
+        assert log[0]["stage"] == "schema_discovery"
+        assert log[0]["model"] == "gpt-4o"
+        assert log[0]["prompt_length"] == 1234
+        assert "timestamp" in log[0]
+
+    def test_reset_all(self):
+        tracker = LLMCallTracker.get_instance()
+        tracker.set_stage("schema_discovery")
+        tracker.increment()
+        tracker.increment()
+
+        tracker.reset()
+
+        assert tracker.get_total() == 0
+        assert tracker.get_counts() == {}
+        assert tracker.get_log() == []
+        assert tracker.get_stage() == "unknown"
+
+    def test_reset_specific_stage(self):
+        tracker = LLMCallTracker.get_instance()
+
+        tracker.set_stage("schema_discovery")
+        tracker.increment()
+        tracker.set_stage("value_extraction")
+        tracker.increment()
+        tracker.increment()
+
+        tracker.reset(stage="schema_discovery")
+
+        counts = tracker.get_counts()
+        assert "schema_discovery" not in counts
+        assert counts["value_extraction"] == 2
+        assert tracker.get_total() == 2
+        # Log entries for schema_discovery should be removed
+        assert all(e["stage"] != "schema_discovery" for e in tracker.get_log())
+
+    def test_singleton(self):
+        a = LLMCallTracker.get_instance()
+        b = LLMCallTracker.get_instance()
+        assert a is b
+
+    def test_thread_safety(self):
+        """Concurrent increments should not lose counts."""
+        tracker = LLMCallTracker.get_instance()
+        tracker.set_stage("concurrent_test")
+
+        n_threads = 10
+        n_per_thread = 100
+        barrier = threading.Barrier(n_threads)
+
+        def worker():
+            barrier.wait()
+            for _ in range(n_per_thread):
+                tracker.increment()
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert tracker.get_counts()["concurrent_test"] == n_threads * n_per_thread
+
+
+# ──────────────────────────────────────────────────────────────────
+# GlobalLLMUsageTracker (persistent, file-backed)
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestGlobalLLMUsageTracker:
+    """Tests for the persistent global quota tracker."""
+
+    def _make_tracker(self, tmp_path: Path) -> GlobalLLMUsageTracker:
+        return GlobalLLMUsageTracker(tmp_path / "global_llm_usage.json")
+
+    def test_empty_start(self, tmp_path):
+        tracker = self._make_tracker(tmp_path)
+        assert tracker.get_total() == 0
+        usage = tracker.get_usage()
+        assert usage["total_calls"] == 0
+        assert usage["per_stage"] == {}
+        assert usage["sessions"] == []
+
+    def test_record_session(self, tmp_path):
+        tracker = self._make_tracker(tmp_path)
+        tracker.record_session("session-1", {"schema_discovery": 3, "value_extraction": 10})
+
+        assert tracker.get_total() == 13
+        usage = tracker.get_usage()
+        assert usage["per_stage"]["schema_discovery"] == 3
+        assert usage["per_stage"]["value_extraction"] == 10
+        assert len(usage["sessions"]) == 1
+        assert usage["sessions"][0]["session_id"] == "session-1"
+        assert usage["sessions"][0]["calls"] == 13
+
+    def test_accumulates_across_sessions(self, tmp_path):
+        tracker = self._make_tracker(tmp_path)
+        tracker.record_session("s1", {"schema_discovery": 5})
+        tracker.record_session("s2", {"schema_discovery": 3, "value_extraction": 7})
+
+        assert tracker.get_total() == 15
+        usage = tracker.get_usage()
+        assert usage["per_stage"]["schema_discovery"] == 8
+        assert usage["per_stage"]["value_extraction"] == 7
+        assert len(usage["sessions"]) == 2
+
+    def test_persists_to_disk(self, tmp_path):
+        path = tmp_path / "usage.json"
+        tracker1 = GlobalLLMUsageTracker(path)
+        tracker1.record_session("s1", {"schema_discovery": 5})
+
+        # Create a NEW tracker instance pointing at the same file
+        tracker2 = GlobalLLMUsageTracker(path)
+        assert tracker2.get_total() == 5
+
+    def test_reset(self, tmp_path):
+        tracker = self._make_tracker(tmp_path)
+        tracker.record_session("s1", {"schema_discovery": 100})
+        tracker.reset()
+        assert tracker.get_total() == 0
+        assert tracker.get_usage()["sessions"] == []
+
+
+# ──────────────────────────────────────────────────────────────────
+# Quota enforcement: allow → allow → BLOCK
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestQuotaEnforcement:
+    """
+    Core scenario: set limit=10.
+    Session 1 uses 4 calls  → total 4  → allowed.
+    Session 2 uses 5 calls  → total 9  → allowed.
+    Session 3 tries to start → total 10 ≥ limit → BLOCKED.
+    """
+
+    def test_two_sessions_pass_third_blocked(self, tmp_path):
+        tracker = GlobalLLMUsageTracker(tmp_path / "usage.json")
+        limit = 10
+
+        # ── Session 1: 4 calls → should pass ──
+        tracker.check_quota(limit)  # no exception
+        tracker.record_session("session-1", {
+            "observation_unit_discovery": 1,
+            "schema_discovery": 2,
+            "value_extraction": 1,
+        })
+        assert tracker.get_total() == 4
+
+        # ── Session 2: 5 calls → should pass ──
+        tracker.check_quota(limit)  # no exception (total=4 < 10)
+        tracker.record_session("session-2", {
+            "schema_discovery": 1,
+            "value_extraction": 4,
+        })
+        assert tracker.get_total() == 9
+
+        # ── Session 3: tries to start → BLOCKED ──
+        # Total is 9, but after session-2 completed we record 9.
+        # Actually 9 < 10, so one more should still be allowed.
+        # Let's add 1 more call to hit exactly 10:
+        tracker.record_session("session-2b", {"value_extraction": 1})
+        assert tracker.get_total() == 10
+
+        with pytest.raises(QuotaExceededError) as exc_info:
+            tracker.check_quota(limit)
+
+        assert exc_info.value.used == 10
+        assert exc_info.value.limit == 10
+        assert "quota exceeded" in str(exc_info.value).lower()
+
+    def test_quota_zero_means_disabled(self, tmp_path):
+        tracker = GlobalLLMUsageTracker(tmp_path / "usage.json")
+        tracker.record_session("s1", {"value_extraction": 9999})
+        # limit=0 should never raise
+        tracker.check_quota(0)  # no exception
+
+    def test_quota_exceeded_error_fields(self):
+        err = QuotaExceededError(used=42, limit=50)
+        assert err.used == 42
+        assert err.limit == 50
+        assert "42" in str(err)
+        assert "50" in str(err)
+
+
+# ──────────────────────────────────────────────────────────────────
+# count_toward_quota opt-out
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestCountTowardQuota:
+    """Verify that sessions can opt out of counting toward the quota."""
+
+    def test_unmetered_session_does_not_increase_total(self, tmp_path):
+        tracker = GlobalLLMUsageTracker(tmp_path / "usage.json")
+        limit = 10
+
+        # Session 1: metered, uses 6
+        tracker.record_session("s1", {"value_extraction": 6})
+        assert tracker.get_total() == 6
+
+        # Session 2: UNMETERED — simulated by NOT calling record_session
+        # (in production, QBSDRunner skips record_session when count_toward_quota=False)
+        # ... session runs, uses 20 calls, but we don't record them ...
+
+        # Total should still be 6, not 26
+        assert tracker.get_total() == 6
+
+        # Session 3: metered, uses 3 → total 9 → under limit
+        tracker.check_quota(limit)  # should pass (6 < 10)
+        tracker.record_session("s3", {"schema_discovery": 3})
+        assert tracker.get_total() == 9
+
+    def test_metered_session_does_increase_total(self, tmp_path):
+        tracker = GlobalLLMUsageTracker(tmp_path / "usage.json")
+        tracker.record_session("s1", {"value_extraction": 5})
+        tracker.record_session("s2", {"schema_discovery": 5})
+        assert tracker.get_total() == 10
+
+
+# ──────────────────────────────────────────────────────────────────
+# Edge cases
+# ──────────────────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+
+    def test_corrupt_file_recovers(self, tmp_path):
+        path = tmp_path / "usage.json"
+        path.write_text("NOT VALID JSON!!!", encoding="utf-8")
+
+        tracker = GlobalLLMUsageTracker(path)
+        assert tracker.get_total() == 0  # should not crash
+
+    def test_empty_session_counts(self, tmp_path):
+        tracker = GlobalLLMUsageTracker(tmp_path / "usage.json")
+        tracker.record_session("empty", {})
+        assert tracker.get_total() == 0
+        assert len(tracker.get_usage()["sessions"]) == 1
+
+    def test_check_quota_at_exactly_limit(self, tmp_path):
+        tracker = GlobalLLMUsageTracker(tmp_path / "usage.json")
+        tracker.record_session("s1", {"x": 10})
+        with pytest.raises(QuotaExceededError):
+            tracker.check_quota(10)  # 10 >= 10 → blocked
+
+    def test_check_quota_one_below_limit(self, tmp_path):
+        tracker = GlobalLLMUsageTracker(tmp_path / "usage.json")
+        tracker.record_session("s1", {"x": 9})
+        tracker.check_quota(10)  # 9 < 10 → allowed
+


### PR DESCRIPTION
## What
Adds a system to monitor and track all LLM API calls across the pipeline, with a global usage quota to prevent runaway costs.

## Features
- **Per-stage call counting** — tracks calls for each pipeline stage (observation unit discovery, schema discovery, value extraction, retrieval, reextraction, continue discovery)
- **Source tracking** — every call is tagged with its originating stage, model, and prompt length
- **Global quota** — cumulative call limit across all sessions (default: 20 for testing). Enforced in release mode, configurable per-session in developer mode
- **Unmetered sessions** — `count_toward_quota=False` lets a session run without counting against the quota
- **Reset capability** — admin can reset counters at any time
- **Persistent tracking** — LLM call counts are logged to Google Sheets (column M) and survive Railway redeploys
- **Frontend notification** — quota-exceeded sessions show a friendly 'Service Temporarily Unavailable' banner (no internal numbers exposed to users)
- **Per-session stats** — each session saves `llm_call_stats.json` (auto-archived to Google Drive)

## Files
- **New:** `qbsd-lib/qbsd/core/llm_call_tracker.py` — LLMCallTracker + GlobalLLMUsageTracker + QuotaExceededError
- **New:** `qbsd-lib/tests/test_llm_call_tracker.py` — 22 pytest unit tests
- **New:** `qbsd-lib/tests/test_full_quota_flow.py` — end-to-end flow test
- **Modified:** 14 existing files (backends, pipeline stages, runner, config, frontend)

## Testing
- 22 unit tests pass (`pytest tests/test_llm_call_tracker.py`)
- Full flow test passes (session 1 allowed → session 2 allowed → session 3 blocked)
- Default limit set to 20 for prod verification