### PR TITLE
fix: show friendly quota message instead of generic error

### DIFF
--- a/backend/app/api/routes/qbsd.py
+++ b/backend/app/api/routes/qbsd.py
@@ -264,12 +264,28 @@ async def run_qbsd(session_id: str, background_tasks: BackgroundTasks):
         session = session_manager.get_session(session_id)
         if not session or session.type != SessionType.QBSD:
             raise HTTPException(status_code=404, detail="QBSD session not found")
-        
+
+        # Pre-check global LLM quota before starting background task.
+        # This gives the user an immediate HTTP error instead of a delayed WebSocket error.
+        from app.core.config import LLM_CALL_GLOBAL_LIMIT, DEVELOPER_MODE
+        from qbsd.core.llm_call_tracker import QuotaExceededError
+        if not DEVELOPER_MODE and LLM_CALL_GLOBAL_LIMIT > 0:
+            try:
+                qbsd_runner._sync_usage_from_sheets()
+                qbsd_runner._global_usage.check_quota(LLM_CALL_GLOBAL_LIMIT)
+            except QuotaExceededError:
+                raise HTTPException(
+                    status_code=429,
+                    detail="The system has reached its processing capacity and is unable to start new sessions at this time. Please try again later or contact us for assistance."
+                )
+
         # Start QBSD in background
         background_tasks.add_task(qbsd_runner.run_qbsd, session_id)
         
         return {"message": "QBSD execution started", "session_id": session_id}
-        
+
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/frontend/src/components/QBSDMonitor/QBSDMonitor.tsx
+++ b/frontend/src/components/QBSDMonitor/QBSDMonitor.tsx
@@ -280,7 +280,12 @@ const QBSDMonitor: React.FC<QBSDMonitorProps> = ({ sessionId }) => {
       const status = error?.response?.status;
       const detail = error?.response?.data?.detail;
 
-      if (status === 503) {
+      if (status === 429) {
+        // Quota exceeded — show orange banner
+        setProcessingState('idle');
+        setQuotaExceeded(true);
+        addLog('warning', 'API usage limit reached');
+      } else if (status === 503) {
         // Server busy — show friendly amber banner, not error state
         setProcessingState('idle');
         setCapacityMessage(detail || 'The server is currently busy processing other requests. Please try again in a few minutes.');


### PR DESCRIPTION
Pre-check quota in the /run endpoint (HTTP 429) before starting the background task. Frontend catches 429 and shows the orange 'Service Temporarily Unavailable' banner instead of the red 'Error Occurred'.

**Changes:**
- `backend/app/api/routes/qbsd.py`: Add quota pre-check returning HTTP 429 with user-friendly message
- `frontend/src/components/QBSDMonitor/QBSDMonitor.tsx`: Handle 429 status like 503, show orange quota banner