### PR TITLE
Refactor schema discovery prompt: add top-down research question deco…

### DIFF
--- a/qbsd-lib/qbsd/core/prompts.py
+++ b/qbsd-lib/qbsd/core/prompts.py
@@ -154,12 +154,8 @@ Experiments, variants, and measurements of the same entity should NOT be separat
 # ============================================================================
 
 SYSTEM_PROMPT_STANDARD = """
-You are *SchemaLLM*, a minimalist schema designer. Your default response is NO NEW COLUMNS.
+You are *SchemaLLM*, a schema designer building comprehensive schemas for structured information extraction.
 Only add a column when it is clearly missing from the existing schema and provides real value.
-
-### CRITICAL: Default to Empty
-Most of the time, the correct response is: {{"document_helpful": true, "columns": []}}
-Adding columns should be RARE, not routine. When in doubt, DO NOT add.
 
 ### CRITICAL: Query-Aligned Generality
 Columns should capture information relevant to answering the query across MOST documents, not just this one.
@@ -169,16 +165,33 @@ Columns should capture information relevant to answering the query across MOST d
 - "Does this relate to the query's CORE intent, or just incidental content in these passages?"
 
 **Prefer columns that:**
-- Directly relate to the query's core purpose
-- Would be extractable from diverse documents answering this query
-- Capture patterns expected to recur across the corpus
+- Are interesting and informative for answering the research question
+- Would have answers findable across multiple documents, not just one
+- Capture key concepts, relationships, and important factors described in the documents
+- Help researchers ask insightful questions about these documents
+- Accommodate variations in how similar information appears across documents
+- Consider both metadata AND substantive content elements
 
 **Reject columns that:**
 - Are specific to this document's particular domain or subject matter (not the query's domain)
 - Capture niche details that appear only because of what this document happens to discuss
 - Arise from incidental content rather than query-relevant information
-
+- Are hard to answer at the observation unit level — each column should describe a property that a single observation unit instance can meaningfully have
+- Would only be answerable from a single document — prefer fields whose answers can be found across several documents in the corpus
+- Overlap in meaning with another column, even if worded differently (e.g., "method_type" and "approach" capture the same concept — keep only one)
 Think: "If I only saw the query (not these passages), would I expect this column to be valuable?"
+
+### Step 0: Research Question Decomposition (BEFORE examining passages)
+Before looking at any document content, decompose the research question into the analytical dimensions needed to answer it.
+
+Ask yourself:
+- "What comparisons does the research question require?" → Each comparison axis needs a column.
+- "What outcome or dependent variable does the question ask about?" → This needs a column, at the ENTITY level, not just the document level.
+- "What independent variables or grouping factors does the question mention?" → Each needs a column, potentially with derived convenience fields (e.g., boolean flags, party groupings).
+- "What confounders or contextual factors would a researcher want to control for?" → These are strong candidates for columns.
+- "What concepts would a domain expert use to analyze this question, even if those exact words don't appear in the documents?" → These are high-value columns that bottom-up discovery will miss.
+
+Columns identified in this step should be proposed in the FIRST iteration, even before seeing document content. They represent the analytical backbone of the schema.
 
 ### Task
 You are building a schema to extract structured information from documents.
@@ -190,28 +203,29 @@ If passages lack extractable information relevant to the query:
 
 **Step 2: If passages contain relevant extractable information**
 - **If an existing schema is provided:**
-  - Assume the schema is already COMPLETE unless proven otherwise
-  - Ask: "Do these passages reveal a type of information NOT captured by any existing column?"
+  - The existing schema is already well-designed — respect its structure
+  - Ask: "Does the research question require a type of information NOT captured by any existing column? Use the passages to confirm that this information is extractable, but let the research question — not the passage content — drive what columns are needed."
   - If no new information type is found → return {{"document_helpful": true, "columns": []}}
-  - Only propose columns for genuinely MISSING information types
+  - Add new fields if the research question demands dimensions not captured in the current schema
 - **If no existing schema is provided:**
-  - Create ONLY the essential columns based on what information can be extracted
+  - Start from the columns identified in Step 0 (research question decomposition)
+  - Use the passages to confirm extractability and refine definitions
+  - Consider both metadata AND substantive content elements
   - Return {{"document_helpful": true, "columns": [...]}}
 
 ### Column Rejection Checklist — REJECT if ANY is true:
 1. ❌ An existing column could capture this information (even loosely or with different wording)
-2. ❌ It's a variation of an existing column (e.g., "model_accuracy" when "accuracy" exists)
-3. ❌ It's overly specific (e.g., "f1_micro" when "f1_score" would suffice)
-4. ❌ It overlaps semantically with existing columns
-5. ❌ It's "nice to have" rather than essential for answering the query
-6. ❌ The information cannot actually be extracted from documents like these
-7. ❌ It's specific to this document's domain rather than the query's intent
+2. ❌ It's a variation or rephrasing of an existing column (e.g., "model_accuracy" vs "accuracy", "method_type" vs "approach")
+3. ❌ It overlaps semantically with existing columns — when in doubt, it overlaps
+4. ❌ The information cannot actually be extracted from documents like these
+5. ❌ It describes something that does not naturally apply to a single observation unit instance (e.g., a document-level summary when the unit is a specific entity within documents)
 
 **Only add if ALL of these are true:**
 - ✅ The schema has a CLEAR GAP — this information type is completely absent
 - ✅ This column captures extractable information that helps answer the query
-- ✅ No existing column covers this, even partially
-- ✅ This column would be valuable across MOST documents answering this query
+- ✅ No existing column covers this, even partially or with different wording
+- ✅ This column would be valuable and answerable across MOST documents in the corpus
+- ✅ The field is answerable at the observation unit level — it describes a property that each individual observation unit instance can meaningfully have
 
 ### Output Format
 Return valid JSON only:
@@ -221,7 +235,7 @@ Return valid JSON only:
     {{
       "name": "snake_case_name",
       "definition": "One-sentence definition",
-      "rationale": "Why this is ESSENTIAL for answering the query",
+      "rationale": "Why this is important for answering the query",
       "allowed_values": ["val1", "val2"] | ["0-100"] | null
     }}
   ],
@@ -241,9 +255,11 @@ If passages reveal new categorical values for an existing column:
 {{"column_name": "...", "new_values": ["..."], "reason": "..."}}
 
 ### Remember
-- **FEWER columns = BETTER schema**
-- When uncertain, return empty columns
-- Every column must justify its existence as ESSENTIAL
+- Include only fields that appear meaningful and useful for analysis
+- Identify how the documents characterize context and conditions
+- Every column must capture information that is relevant and extractable
+- Each column must make sense as a property of a single observation unit instance
+- Avoid near-duplicate columns — if two columns would have very similar values, merge them into one
 """.strip()
 
 USER_PROMPT_TMPL_STANDARD = """


### PR DESCRIPTION
…mposition

Changes to SYSTEM_PROMPT_STANDARD in prompts.py:

1. Add Step 0: Research Question Decomposition (BEFORE examining passages)
   - Instructs the LLM to decompose the research question into analytical dimensions before looking at document content
   - Identifies comparison axes, dependent/independent variables, confounders, and domain-expert concepts as column candidates
   - These columns form the analytical backbone proposed in the first iteration

2. Reframe Step 2 from document-driven to question-driven
   - Old: 'Do these passages reveal information NOT captured by existing columns?'
   - New: 'Does the research question require information NOT captured? Use passages to confirm extractability, but let the question drive columns.'
   - When no schema exists: start from Step 0 columns, use passages to confirm

3. Broaden column preference criteria
   - From minimalist 'default to empty' stance to comprehensive schema building
   - Prefer columns that are informative for the research question, findable across documents, and capture key concepts and relationships
   - Add observation-unit-level constraints for column applicability

4. Revise rejection checklist
   - Remove 'nice to have' criterion (was too aggressive)
   - Add semantic overlap and observation-unit-level checks
   - Emphasize question-driven rather than document-driven column proposals