### PR TITLE
fix: add schematiq-ai.com to frontend URL detection and backend CORS

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -46,7 +46,9 @@ DEFAULT_PORT = int(os.environ.get("PORT", 8000))
 _default_origins = [
     "http://localhost:3000",
     "http://127.0.0.1:3000",
-    "https://querydiscovery-production.up.railway.app",  # Production frontend
+    "https://querydiscovery-production.up.railway.app",  # Production frontend (Railway)
+    "https://www.schematiq-ai.com",  # Production frontend (custom domain)
+    "https://schematiq-ai.com",  # Production frontend (custom domain, no www)
 ]
 _env_origins = os.environ.get("ALLOWED_ORIGINS", "")
 ALLOWED_ORIGINS = (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -51,10 +51,10 @@ function getApiBaseUrl(): string {
     return `${process.env.REACT_APP_API_URL}/api`;
   }
 
-  // Runtime detection for Railway
+  // Runtime detection for Railway or custom domain
   if (typeof window !== 'undefined') {
     const hostname = window.location.hostname;
-    if (hostname.includes('railway.app') || hostname.includes('up.railway.app')) {
+    if (hostname.includes('railway.app') || hostname.includes('up.railway.app') || hostname.includes('schematiq-ai.com')) {
       return `${RAILWAY_BACKEND_URL}/api`;
     }
   }
@@ -72,7 +72,7 @@ export const getBackendBaseUrl = (): string => {
   }
   if (typeof window !== 'undefined') {
     const hostname = window.location.hostname;
-    if (hostname.includes('railway.app') || hostname.includes('up.railway.app')) {
+    if (hostname.includes('railway.app') || hostname.includes('up.railway.app') || hostname.includes('schematiq-ai.com')) {
       return RAILWAY_BACKEND_URL;
     }
   }


### PR DESCRIPTION
## Summary
- Frontend served from `www.schematiq-ai.com` couldn't reach the Railway backend — hostname detection in `api.ts` only checked for `railway.app`, so API/WebSocket calls fell through to relative `/api` path (the Nginx frontend, not the backend)
- Backend CORS defaults didn't include `schematiq-ai.com`, so requests from the custom domain would be blocked even if they reached the backend
- Added `schematiq-ai.com` to both the frontend runtime detection and backend default CORS origins

## Test plan
- [ ] Deploy both services to Railway
- [ ] Visit https://www.schematiq-ai.com and verify the landing page loads
- [ ] Open browser DevTools Network tab — confirm API calls go to `backend-production-5a26.up.railway.app` (not to `schematiq-ai.com/api`)
- [ ] Confirm no CORS errors in the console
- [ ] Run an end-to-end flow (upload docs → schema discovery) to verify WebSocket connectivity
- [ ] If `ALLOWED_ORIGINS` env var is set on Railway backend, add `https://www.schematiq-ai.com,https://schematiq-ai.com` to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)