### PR TITLE
feat: auto-enrich source documents with PubMed/DOI links

### DIFF
--- a/backend/app/api/routes/units.py
+++ b/backend/app/api/routes/units.py
@@ -11,7 +11,7 @@ from app.models.unit import (
     MergeUnitsResponse,
     UnitSuggestionsResponse,
 )
-from app.models.session import PaginatedData, DataRow
+from app.models.session import PaginatedData, DataRow, FilterSortRequest
 from app.services.unit_view_service import unit_view_service
 from app.services import session_manager
 
@@ -86,37 +86,49 @@ async def list_source_documents(session_id: str):
         raise HTTPException(status_code=500, detail=f"Error listing documents: {str(e)}")
 
 
-@router.get(
+@router.post(
     "/data/{session_id}",
     response_model=PaginatedData,
     summary="Get data by unit",
-    description="Get paginated data optionally filtered by observation unit"
+    description="Get paginated data optionally filtered/searched/sorted, grouped by observation unit"
 )
 async def get_unit_data(
     session_id: str,
     units: Optional[str] = Query(None, description="Comma-separated unit names to filter by"),
     page: int = Query(0, ge=0, description="Page number (0-indexed)"),
-    page_size: int = Query(50, ge=1, le=1000, description="Items per page")
+    page_size: int = Query(50, ge=1, le=1000, description="Units per page"),
+    request: Optional[FilterSortRequest] = None,
 ):
     """
-    Get paginated data optionally filtered by observation unit(s).
+    Get paginated data grouped by observation unit.
 
-    When a units filter is provided, only rows belonging to those units are returned.
-    Rows are sorted by unit name for consistent grouping.
+    Search/filters/sort are applied at the row level across the full session
+    (so a match on any page surfaces in the result). Pagination is by unit;
+    units with zero matching rows drop out of the view.
     """
     session = session_manager.get_session(session_id)
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
 
-    # Parse comma-separated unit names
     unit_filter = [u.strip() for u in units.split(',') if u.strip()] if units else None
 
+    filters = None
+    sort = None
+    search = None
+    if request:
+        filters = [f.dict() for f in request.filters] if request.filters else None
+        sort = [s.dict() for s in request.sort] if request.sort else None
+        search = request.search
+
     try:
-        rows, total_unit_count, total_row_count = unit_view_service.get_unit_grouped_data(
+        rows, total_unit_count, filtered_unit_count, total_row_count = unit_view_service.get_unit_grouped_data(
             session_id=session_id,
             unit_filter=unit_filter,
             page=page,
-            page_size=page_size
+            page_size=page_size,
+            search=search,
+            filters=filters,
+            sort=sort,
         )
 
         # Convert to DataRow objects
@@ -155,13 +167,15 @@ async def get_unit_data(
                 )
             data_rows.append(data_row)
 
-        # Pagination is unit-based: total_count = number of units
-        has_more = (page + 1) * page_size < total_unit_count
+        # Pagination is unit-based: counts reflect units, not rows
+        any_filter_active = bool(unit_filter or search or filters)
+        effective_count = filtered_unit_count if any_filter_active else total_unit_count
+        has_more = (page + 1) * page_size < effective_count
 
         return PaginatedData(
             rows=data_rows,
             total_count=total_unit_count,
-            filtered_count=len(unit_filter) if unit_filter else None,
+            filtered_count=filtered_unit_count if any_filter_active else None,
             page=page,
             page_size=page_size,
             has_more=has_more

--- a/backend/app/api/routes/units.py
+++ b/backend/app/api/routes/units.py
@@ -13,7 +13,7 @@ from app.models.unit import (
 )
 from app.models.session import PaginatedData, DataRow, FilterSortRequest
 from app.services.unit_view_service import unit_view_service
-from app.services import session_manager
+from app.services import session_manager, pubmed_enrichment_service
 
 router = APIRouter()
 
@@ -77,10 +77,16 @@ async def list_source_documents(session_id: str):
                 url=meta.get("url"),
             ))
 
+        # Trigger background PubMed enrichment for documents missing URLs
+        doc_names = [d["name"] for d in documents]
+        enrichment_triggered = await pubmed_enrichment_service.enrich_missing(session_id, doc_names)
+        enrichment_active = enrichment_triggered or pubmed_enrichment_service.is_active(session_id)
+
         return DocumentListResponse(
             documents=doc_summaries,
             total_documents=len(documents),
             total_rows=total_rows,
+            enrichment_pending=enrichment_active,
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error listing documents: {str(e)}")

--- a/backend/app/models/unit.py
+++ b/backend/app/models/unit.py
@@ -50,6 +50,7 @@ class DocumentListResponse(BaseModel):
     documents: List[DocumentSummary]
     total_documents: int
     total_rows: int
+    enrichment_pending: bool = False  # True while background PubMed lookup is running
 
 
 class UnitSimilarity(BaseModel):

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -145,3 +145,8 @@ else:
     if not (GOOGLE_SERVICE_ACCOUNT_JSON or GOOGLE_SERVICE_ACCOUNT_FILE or GOOGLE_OAUTH_CREDENTIALS_JSON):
         _reasons.append("no Google credentials set (need GOOGLE_OAUTH_CREDENTIALS_JSON or GOOGLE_SERVICE_ACCOUNT_JSON)")
     logger.info("[data-collection] Disabled — %s", "; ".join(_reasons) if _reasons else "DATA_COLLECTION_ENABLED=False")
+
+# ── PubMed document enrichment (DOI link lookup) ──────────────────
+from app.services.pubmed_enrichment_service import PubMedEnrichmentService
+pubmed_enrichment_service = PubMedEnrichmentService(session_manager=session_manager)
+logger.info("[pubmed-enrichment] Service initialized")

--- a/backend/app/services/file_parser.py
+++ b/backend/app/services/file_parser.py
@@ -20,6 +20,7 @@ from app.models.upload import (
 )
 from app.models.session import ColumnInfo, DataStatistics, DataRow, PaginatedData, SchemaEvolution, SchemaSnapshot
 from app.core.config import DEFAULT_DATA_DIR, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
+from app.services import row_filtering
 
 _COLUMN_DISPLAY_NAMES = {
     '_row_name': 'Doc Name',
@@ -1096,199 +1097,14 @@ class FileParser:
         return rows
 
     def _apply_search(self, rows: List[Dict], search: str) -> List[Dict]:
-        """Apply global search term to all columns."""
-        search_lower = search.lower()
-        return [row for row in rows if self._row_matches_search(row, search_lower)]
-
-    def _row_matches_search(self, row: Dict, search_lower: str) -> bool:
-        """Check if any field in row matches search term."""
-        # Check row_name
-        if row.get('row_name') and search_lower in str(row['row_name']).lower():
-            return True
-        # Check data fields
-        data = row.get('data', row)
-        for value in data.values():
-            if self._value_contains_search(value, search_lower):
-                return True
-        return False
-
-    def _value_contains_search(self, value: Any, search_lower: str) -> bool:
-        """Check if a value contains the search term."""
-        if value is None:
-            return False
-        # Handle ScheMatiQ answer format
-        if isinstance(value, dict) and 'answer' in value:
-            value = value['answer']
-        return search_lower in str(value).lower()
+        return row_filtering.apply_search(rows, search)
 
     def _apply_filters(self, rows: List[Dict], filters: List[Dict]) -> List[Dict]:
-        """Apply filter rules to rows (AND logic)."""
-        for filter_rule in filters:
-            rows = [row for row in rows if self._row_matches_filter(row, filter_rule)]
-        return rows
-
-    def _row_matches_filter(self, row: Dict, filter_rule: Dict) -> bool:
-        """Evaluate a single filter rule against a row."""
-        column = filter_rule.get('column', '')
-        operator = filter_rule.get('operator', '')
-        filter_value = filter_rule.get('value')
-        case_sensitive = filter_rule.get('caseSensitive', False)
-
-        # Get cell value
-        if column == '_row_name':
-            cell_value = row.get('row_name')
-        elif column == '_papers':
-            cell_value = row.get('papers', [])
-        else:
-            data = row.get('data', row)
-            cell_value = data.get(column)
-
-        return self._evaluate_filter(cell_value, operator, filter_value, case_sensitive)
-
-    def _evaluate_filter(self, cell_value: Any, operator: str, filter_value: Any, case_sensitive: bool) -> bool:
-        """Evaluate filter operator against cell value."""
-        # Handle ScheMatiQ answer format
-        if isinstance(cell_value, dict) and 'answer' in cell_value:
-            cell_value = cell_value['answer']
-
-        # Null checks
-        is_empty = cell_value is None or cell_value == '' or cell_value == [] or cell_value == {}
-        if isinstance(cell_value, str) and cell_value.lower() in ['none', 'n/a', 'null']:
-            is_empty = True
-
-        if operator == 'isNull':
-            return is_empty
-        if operator == 'isNotNull':
-            return not is_empty
-
-        if is_empty:
-            return False
-
-        # Boolean operators
-        if operator == 'isTrue':
-            return cell_value in [True, 'true', 'True', '1', 1]
-        if operator == 'isFalse':
-            return cell_value in [False, 'false', 'False', '0', 0]
-
-        # Text operators
-        str_value = str(cell_value)
-        filter_str = str(filter_value or '')
-        if not case_sensitive:
-            str_value = str_value.lower()
-            filter_str = filter_str.lower()
-
-        if operator == 'contains':
-            return filter_str in str_value
-        if operator == 'equals':
-            return str_value == filter_str
-        if operator == 'startsWith':
-            return str_value.startswith(filter_str)
-        if operator == 'endsWith':
-            return str_value.endswith(filter_str)
-        if operator == 'regex':
-            try:
-                flags = 0 if case_sensitive else re.IGNORECASE
-                return bool(re.search(str(filter_value), str(cell_value), flags))
-            except:
-                return False
-
-        # Numeric operators
-        if operator in ['eq', 'gt', 'lt', 'gte', 'lte', 'between']:
-            try:
-                num_value = float(str(cell_value))
-                if operator == 'eq':
-                    return num_value == float(filter_value)
-                if operator == 'gt':
-                    return num_value > float(filter_value)
-                if operator == 'lt':
-                    return num_value < float(filter_value)
-                if operator == 'gte':
-                    return num_value >= float(filter_value)
-                if operator == 'lte':
-                    return num_value <= float(filter_value)
-                if operator == 'between' and isinstance(filter_value, list) and len(filter_value) >= 2:
-                    return float(filter_value[0]) <= num_value <= float(filter_value[1])
-            except:
-                return False
-
-        # Categorical operators
-        if operator == 'in':
-            allowed = filter_value if isinstance(filter_value, list) else [filter_value]
-            str_val_lower = str(cell_value).lower()
-            return any(str(v).lower() == str_val_lower for v in allowed)
-        if operator == 'notIn':
-            allowed = filter_value if isinstance(filter_value, list) else [filter_value]
-            str_val_lower = str(cell_value).lower()
-            return not any(str(v).lower() == str_val_lower for v in allowed)
-
-        return True
+        return row_filtering.apply_filters(rows, filters)
 
     def _apply_sort(self, rows: List[Dict], sort_columns: List[Dict]) -> List[Dict]:
-        """Apply multi-column sorting."""
-        if not sort_columns:
-            return rows
+        return row_filtering.apply_sort(rows, sort_columns)
 
-        # Sort by priority (lower = more important)
-        sorted_cols = sorted(sort_columns, key=lambda x: x.get('priority', 1))
-
-        def compare_rows(a: Dict, b: Dict) -> int:
-            for sort_col in sorted_cols:
-                column = sort_col.get('column', '')
-                direction = sort_col.get('direction', 'asc')
-
-                a_val = self._get_sortable_value(a, column)
-                b_val = self._get_sortable_value(b, column)
-
-                # Handle nulls - always last
-                a_null = a_val is None or a_val == ''
-                b_null = b_val is None or b_val == ''
-
-                if a_null and b_null:
-                    continue
-                if a_null:
-                    return 1  # a after b
-                if b_null:
-                    return -1  # b after a
-
-                # Compare values
-                if isinstance(a_val, (int, float)) and isinstance(b_val, (int, float)):
-                    cmp = (a_val > b_val) - (a_val < b_val)
-                else:
-                    cmp = (str(a_val).lower() > str(b_val).lower()) - \
-                          (str(a_val).lower() < str(b_val).lower())
-
-                if cmp != 0:
-                    return cmp if direction == 'asc' else -cmp
-
-            return 0
-
-        from functools import cmp_to_key
-        return sorted(rows, key=cmp_to_key(compare_rows))
-
-    def _get_sortable_value(self, row: Dict, column: str) -> Any:
-        """Extract a sortable value from a row."""
-        if column == '_row_name':
-            return row.get('row_name')
-        if column == '_papers':
-            papers = row.get('papers', [])
-            return papers[0] if papers else None
-
-        data = row.get('data', row)
-        value = data.get(column)
-
-        # Handle ScheMatiQ format
-        if isinstance(value, dict) and 'answer' in value:
-            value = value['answer']
-
-        # Try to parse as number
-        if isinstance(value, str):
-            try:
-                return float(value)
-            except:
-                pass
-
-        return value
-    
     async def validate_schema_file(self, file: UploadFile) -> SchemaValidationResult:
         """Validate ScheMatiQ schema file."""
         errors = []

--- a/backend/app/services/pubmed_enrichment_service.py
+++ b/backend/app/services/pubmed_enrichment_service.py
@@ -1,0 +1,196 @@
+"""Background service for enriching documents with PubMed/DOI links.
+
+When source documents are listed (GET /units/documents), any documents
+without URLs trigger a background EuropePMC lookup. Results are stored
+in session.metadata.document_metadata keyed by the exact source document
+name so the existing frontend rendering pipeline picks them up automatically.
+"""
+
+import asyncio
+import functools
+import logging
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+import requests
+
+from app.services.session_manager import SessionManager
+
+logger = logging.getLogger(__name__)
+
+
+def _clean_source_doc_to_title(source_doc: str) -> Optional[str]:
+    """Convert a source document name to a searchable paper title.
+
+    Handles two naming patterns:
+
+    1. Source document names from extraction (with observation-unit prefix):
+       'co-A Saturated FG-Repeat Hydrogel' -> 'A Saturated FG-Repeat Hydrogel'
+       'amb-Capturing directed molecular motion in' -> 'Capturing directed molecular motion in'
+
+    2. Raw uploaded filenames (underscore-separated with PMID):
+       'ATM_phosphorylates_PP2A_36434396_full.txt' -> 'ATM phosphorylates PP2A'
+    """
+    name = source_doc
+
+    # Strip observation-unit prefix (2-5 lowercase chars followed by dash)
+    name = re.sub(r"^[a-z]{2,5}-", "", name)
+
+    # Handle underscore-separated filenames (raw uploads)
+    if "_" in name:
+        name = Path(name).stem
+        name = re.sub(r"_full$", "", name)
+        name = re.sub(r"_\d{6,}$", "", name)  # trailing PMID (6+ digits)
+        name = re.sub(r"_\d{4}$", "", name)   # trailing 4-digit year
+        name = name.replace("_", " ")
+
+    # Strip file extension if present
+    name = re.sub(r"\.(txt|pdf|doc|docx|md|rtf)$", "", name, flags=re.IGNORECASE)
+
+    name = name.strip()
+    if len(name) < 10:
+        return None
+    return name
+
+
+def _title_matches(query_title: str, result_title: str, threshold: float = 0.8) -> bool:
+    """Check if the query title matches a PubMed result title.
+
+    Uses word-overlap rather than sequence matching because source
+    document names often truncate the real title.
+    """
+    q_words = set(re.findall(r"[a-z0-9]+", query_title.lower()))
+    r_words = set(re.findall(r"[a-z0-9]+", result_title.lower()))
+    if not q_words:
+        return False
+    overlap = len(q_words & r_words) / len(q_words)
+    return overlap >= threshold
+
+
+def _search_europepmc(title: str) -> Optional[Dict[str, str]]:
+    """Search EuropePMC for a paper matching the given title.
+
+    Returns {"url": "https://doi.org/...", "doi": "..."} or None.
+    If the full title yields no results, retries with the last word
+    dropped (source document names often truncate mid-word).
+    """
+    url = "https://www.ebi.ac.uk/europepmc/webservices/rest/search"
+
+    # Try full title first, then drop last word as fallback
+    queries = [title]
+    words = title.rsplit(" ", 1)
+    if len(words) == 2 and len(words[0]) >= 10:
+        queries.append(words[0])
+
+    for query_title in queries:
+        try:
+            params = {"query": f'TITLE:"{query_title}"', "format": "json", "pageSize": 3}
+            resp = requests.get(url, params=params, timeout=15)
+            resp.raise_for_status()
+            results = resp.json().get("resultList", {}).get("result", [])
+
+            for result in results:
+                doi = result.get("doi")
+                if doi and _title_matches(query_title, result.get("title", "")):
+                    return {"url": f"https://doi.org/{doi}", "doi": doi}
+        except Exception:
+            logger.warning("[pubmed-enrichment] Lookup failed for: %s", query_title[:60], exc_info=True)
+
+    return None
+
+
+class PubMedEnrichmentService:
+    """Fire-and-forget service that enriches documents with DOI links.
+
+    Triggered lazily when source documents are listed. Only searches for
+    documents that don't already have URLs in session metadata.
+    """
+
+    def __init__(self, session_manager: SessionManager):
+        self._session_manager = session_manager
+        self._active_tasks: Set[asyncio.Task] = set()
+        # Track sessions currently being enriched to avoid duplicate work
+        self._in_progress: Set[str] = set()
+
+    def is_active(self, session_id: str) -> bool:
+        """Check if enrichment is currently running for a session."""
+        return session_id in self._in_progress
+
+    async def enrich_missing(self, session_id: str, doc_names: List[str]) -> bool:
+        """Enrich documents that don't have URLs yet. Non-blocking, deduped.
+
+        Returns True if enrichment was triggered, False otherwise.
+        """
+        if session_id in self._in_progress:
+            return False
+
+        session = self._session_manager.get_session(session_id)
+        if not session:
+            return False
+
+        existing_metadata = getattr(session.metadata, "document_metadata", {}) or {}
+        missing = [name for name in doc_names if name not in existing_metadata]
+
+        if not missing:
+            return False
+
+        self._in_progress.add(session_id)
+        task = asyncio.create_task(self._enrich_documents(session_id, missing))
+        self._active_tasks.add(task)
+
+        def _on_done(t: asyncio.Task) -> None:
+            self._active_tasks.discard(t)
+            self._in_progress.discard(session_id)
+
+        task.add_done_callback(_on_done)
+        logger.info(
+            "[pubmed-enrichment] Started enrichment for %d/%d documents in session %s",
+            len(missing), len(doc_names), session_id[:8],
+        )
+        return True
+
+    async def _enrich_documents(self, session_id: str, doc_names: List[str]) -> None:
+        """Background coroutine: resolve each document name to a DOI URL."""
+        from app.services import schematiq_thread_pool
+
+        loop = asyncio.get_running_loop()
+        found = 0
+
+        try:
+            for doc_name in doc_names:
+                title = _clean_source_doc_to_title(doc_name)
+                if not title:
+                    continue
+
+                result = await loop.run_in_executor(
+                    schematiq_thread_pool,
+                    functools.partial(_search_europepmc, title),
+                )
+
+                if result:
+                    self._store_url(session_id, doc_name, result["url"])
+                    found += 1
+
+                # Rate limit: EuropePMC recommends max ~3 req/sec
+                await asyncio.sleep(0.4)
+
+            logger.info(
+                "[pubmed-enrichment] Finished session %s: %d/%d documents enriched",
+                session_id[:8], found, len(doc_names),
+            )
+        except Exception:
+            logger.warning(
+                "[pubmed-enrichment] Error enriching session %s",
+                session_id[:8], exc_info=True,
+            )
+
+    def _store_url(self, session_id: str, doc_name: str, url: str) -> None:
+        """Persist a DOI URL into session metadata."""
+        session = self._session_manager.get_session(session_id)
+        if not session:
+            return
+        if not session.metadata.document_metadata:
+            session.metadata.document_metadata = {}
+        session.metadata.document_metadata[doc_name] = {"url": url}
+        self._session_manager.update_session(session)

--- a/backend/app/services/row_filtering.py
+++ b/backend/app/services/row_filtering.py
@@ -1,0 +1,205 @@
+"""Row-level search, filter, and sort predicates.
+
+Shared by FileParser (flat-row views) and UnitViewService (unit-grouped views)
+so both apply identical semantics to the same row shape.
+"""
+
+import re
+from functools import cmp_to_key
+from typing import Any, Dict, List, Optional, Sequence
+
+
+def apply_search(
+    rows: List[Dict],
+    search: str,
+    extra_top_level_fields: Optional[Sequence[str]] = None,
+) -> List[Dict]:
+    """Filter rows by a global search term (case-insensitive substring).
+
+    Always checks ``row_name`` and every value in ``data``. Additional top-level
+    field names (e.g. ``_unit_name``, ``_source_document``) are checked when
+    supplied — lets unit-grouped callers search metadata that flat-row callers
+    don't expose.
+    """
+    search_lower = search.lower()
+    extras = tuple(extra_top_level_fields or ())
+    return [row for row in rows if _row_matches_search(row, search_lower, extras)]
+
+
+def _row_matches_search(row: Dict, search_lower: str, extras: tuple) -> bool:
+    if row.get('row_name') and search_lower in str(row['row_name']).lower():
+        return True
+    for field in extras:
+        value = row.get(field)
+        if value and search_lower in str(value).lower():
+            return True
+    data = row.get('data', row)
+    for value in data.values():
+        if _value_contains_search(value, search_lower):
+            return True
+    return False
+
+
+def _value_contains_search(value: Any, search_lower: str) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, dict) and 'answer' in value:
+        value = value['answer']
+    return search_lower in str(value).lower()
+
+
+def apply_filters(rows: List[Dict], filters: List[Dict]) -> List[Dict]:
+    """Apply filter rules to rows (AND logic across rules)."""
+    for filter_rule in filters:
+        rows = [row for row in rows if _row_matches_filter(row, filter_rule)]
+    return rows
+
+
+def _row_matches_filter(row: Dict, filter_rule: Dict) -> bool:
+    column = filter_rule.get('column', '')
+    operator = filter_rule.get('operator', '')
+    filter_value = filter_rule.get('value')
+    case_sensitive = filter_rule.get('caseSensitive', False)
+
+    if column == '_row_name':
+        cell_value = row.get('row_name')
+    elif column == '_papers':
+        cell_value = row.get('papers', [])
+    else:
+        data = row.get('data', row)
+        cell_value = data.get(column)
+
+    return _evaluate_filter(cell_value, operator, filter_value, case_sensitive)
+
+
+def _evaluate_filter(cell_value: Any, operator: str, filter_value: Any, case_sensitive: bool) -> bool:
+    if isinstance(cell_value, dict) and 'answer' in cell_value:
+        cell_value = cell_value['answer']
+
+    is_empty = cell_value is None or cell_value == '' or cell_value == [] or cell_value == {}
+    if isinstance(cell_value, str) and cell_value.lower() in ['none', 'n/a', 'null']:
+        is_empty = True
+
+    if operator == 'isNull':
+        return is_empty
+    if operator == 'isNotNull':
+        return not is_empty
+
+    if is_empty:
+        return False
+
+    if operator == 'isTrue':
+        return cell_value in [True, 'true', 'True', '1', 1]
+    if operator == 'isFalse':
+        return cell_value in [False, 'false', 'False', '0', 0]
+
+    str_value = str(cell_value)
+    filter_str = str(filter_value or '')
+    if not case_sensitive:
+        str_value = str_value.lower()
+        filter_str = filter_str.lower()
+
+    if operator == 'contains':
+        return filter_str in str_value
+    if operator == 'equals':
+        return str_value == filter_str
+    if operator == 'startsWith':
+        return str_value.startswith(filter_str)
+    if operator == 'endsWith':
+        return str_value.endswith(filter_str)
+    if operator == 'regex':
+        try:
+            flags = 0 if case_sensitive else re.IGNORECASE
+            return bool(re.search(str(filter_value), str(cell_value), flags))
+        except Exception:
+            return False
+
+    if operator in ['eq', 'gt', 'lt', 'gte', 'lte', 'between']:
+        try:
+            num_value = float(str(cell_value))
+            if operator == 'eq':
+                return num_value == float(filter_value)
+            if operator == 'gt':
+                return num_value > float(filter_value)
+            if operator == 'lt':
+                return num_value < float(filter_value)
+            if operator == 'gte':
+                return num_value >= float(filter_value)
+            if operator == 'lte':
+                return num_value <= float(filter_value)
+            if operator == 'between' and isinstance(filter_value, list) and len(filter_value) >= 2:
+                return float(filter_value[0]) <= num_value <= float(filter_value[1])
+        except Exception:
+            return False
+
+    if operator == 'in':
+        allowed = filter_value if isinstance(filter_value, list) else [filter_value]
+        str_val_lower = str(cell_value).lower()
+        return any(str(v).lower() == str_val_lower for v in allowed)
+    if operator == 'notIn':
+        allowed = filter_value if isinstance(filter_value, list) else [filter_value]
+        str_val_lower = str(cell_value).lower()
+        return not any(str(v).lower() == str_val_lower for v in allowed)
+
+    return True
+
+
+def apply_sort(rows: List[Dict], sort_columns: List[Dict]) -> List[Dict]:
+    """Apply multi-column sorting (priority ascending = higher importance)."""
+    if not sort_columns:
+        return rows
+
+    sorted_cols = sorted(sort_columns, key=lambda x: x.get('priority', 1))
+
+    def compare_rows(a: Dict, b: Dict) -> int:
+        for sort_col in sorted_cols:
+            column = sort_col.get('column', '')
+            direction = sort_col.get('direction', 'asc')
+
+            a_val = _get_sortable_value(a, column)
+            b_val = _get_sortable_value(b, column)
+
+            a_null = a_val is None or a_val == ''
+            b_null = b_val is None or b_val == ''
+
+            if a_null and b_null:
+                continue
+            if a_null:
+                return 1
+            if b_null:
+                return -1
+
+            if isinstance(a_val, (int, float)) and isinstance(b_val, (int, float)):
+                cmp = (a_val > b_val) - (a_val < b_val)
+            else:
+                cmp = (str(a_val).lower() > str(b_val).lower()) - \
+                      (str(a_val).lower() < str(b_val).lower())
+
+            if cmp != 0:
+                return cmp if direction == 'asc' else -cmp
+
+        return 0
+
+    return sorted(rows, key=cmp_to_key(compare_rows))
+
+
+def _get_sortable_value(row: Dict, column: str) -> Any:
+    if column == '_row_name':
+        return row.get('row_name')
+    if column == '_papers':
+        papers = row.get('papers', [])
+        return papers[0] if papers else None
+
+    data = row.get('data', row)
+    value = data.get(column)
+
+    if isinstance(value, dict) and 'answer' in value:
+        value = value['answer']
+
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            pass
+
+    return value

--- a/backend/app/services/unit_view_service.py
+++ b/backend/app/services/unit_view_service.py
@@ -19,6 +19,7 @@ from app.models.unit import (
 )
 from app.models.session import DataRow
 from app.core.config import DEFAULT_DATA_DIR
+from app.services import row_filtering
 
 logger = logging.getLogger(__name__)
 
@@ -268,53 +269,78 @@ class UnitViewService:
         session_id: str,
         unit_filter: Optional[List[str]] = None,
         page: int = 0,
-        page_size: int = 50
-    ) -> Tuple[List[Dict], int, int]:
+        page_size: int = 50,
+        search: Optional[str] = None,
+        filters: Optional[List[Dict]] = None,
+        sort: Optional[List[Dict]] = None,
+    ) -> Tuple[List[Dict], int, int, int]:
         """
         Get data grouped by observation unit with pagination applied per unit.
 
-        Pagination is applied to units (not individual rows), so expanding any
-        unit on the current page will always show all of its rows.
+        Search and filters run at the row level across the full dataset; units
+        with zero surviving rows drop out of the view. Sort runs at the row
+        level too, then rows are regrouped under their unit so each unit's
+        rows remain contiguous.
 
         Args:
             session_id: The session ID
-            unit_filter: Optional list of unit names to filter by
+            unit_filter: Optional list of unit names to restrict to
             page: Page number (0-indexed)
             page_size: Number of units per page
+            search: Optional global search term (case-insensitive substring)
+            filters: Optional list of filter rules (AND logic)
+            sort: Optional list of sort columns
 
         Returns:
-            Tuple of (rows, total_unit_count, total_row_count)
+            Tuple of (rows, total_unit_count, filtered_unit_count, total_row_count)
         """
         rows = self._load_all_rows(session_id)
         total_row_count = len(rows)
 
-        # Filter by units if specified
+        # Total units in the session (before any filtering) — stable across searches
+        total_unit_count = len({self._get_unit_name(r) or '' for r in rows})
+
         if unit_filter:
             unit_filter_set = set(unit_filter)
             rows = [r for r in rows if self._get_unit_name(r) in unit_filter_set]
 
-        # Group rows by unit name
+        if search and search.strip():
+            rows = row_filtering.apply_search(
+                rows,
+                search.strip(),
+                extra_top_level_fields=('_unit_name', 'unit_name', '_source_document', 'source_document'),
+            )
+
+        if filters:
+            rows = row_filtering.apply_filters(rows, filters)
+
+        if sort:
+            rows = row_filtering.apply_sort(rows, sort)
+
+        # Group (preserve row order from sort so within-unit sort is honored)
         unit_groups: Dict[str, List[Dict]] = defaultdict(list)
         for row in rows:
             unit_name = self._get_unit_name(row) or ''
             unit_groups[unit_name].append(row)
 
-        # Sort unit names alphabetically
         sorted_unit_names = sorted(unit_groups.keys(), key=str.lower)
-        total_unit_count = len(sorted_unit_names)
+        filtered_unit_count = len(sorted_unit_names)
 
-        # Paginate by units
         start_idx = page * page_size
         end_idx = start_idx + page_size
         paginated_unit_names = sorted_unit_names[start_idx:end_idx]
 
-        # Collect all rows for the paginated units, sorted within each unit
-        paginated_rows = []
+        paginated_rows: List[Dict] = []
         for unit_name in paginated_unit_names:
-            unit_rows = sorted(unit_groups[unit_name], key=lambda r: r.get('row_name', ''))
-            paginated_rows.extend(unit_rows)
+            # When no sort is provided, fall back to row_name for stable ordering
+            if sort:
+                paginated_rows.extend(unit_groups[unit_name])
+            else:
+                paginated_rows.extend(
+                    sorted(unit_groups[unit_name], key=lambda r: r.get('row_name', ''))
+                )
 
-        return paginated_rows, total_unit_count, total_row_count
+        return paginated_rows, total_unit_count, filtered_unit_count, total_row_count
 
     def merge_units(self, session_id: str, request: MergeUnitsRequest) -> MergeUnitsResponse:
         """

--- a/frontend/src/components/DataTable/UnitGroupedTable.tsx
+++ b/frontend/src/components/DataTable/UnitGroupedTable.tsx
@@ -66,7 +66,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { ToastAction } from '@/components/ui/toast';
 import { getEditableValue } from './EditableCell';
 import { formatColumnName } from '../../utils/formatting';
-import { buildColumnMetadata, applyFilters, applySort, parsePythonString, extractDisplayValue, getDefaultColumnOrder } from './utils';
+import { buildColumnMetadata, parsePythonString, extractDisplayValue, getDefaultColumnOrder } from './utils';
 import { FilterOperator, FilterValue, ColumnMetadata, FilterRule, SortColumn } from './types/filters';
 import { useTableSort } from './hooks/useTableSort';
 import { useTableFilter } from './hooks/useTableFilter';
@@ -288,11 +288,23 @@ export const UnitGroupedTable: React.FC<UnitGroupedTableProps> = ({
   }, [selectedUnits]);
 
   const { data: unitData, isLoading: dataLoading, refetch: refetchData } = useQuery(
-    ['unitData', sessionId, selectedUnits, page, pageSize],
+    [
+      'unitData',
+      sessionId,
+      selectedUnits,
+      page,
+      pageSize,
+      searchTerm,
+      JSON.stringify(filterState.rules),
+      JSON.stringify(sortState.columns),
+    ],
     () => unitsAPI.getData(sessionId, {
       units: effectiveUnitFilter,
       page,
       pageSize,
+      search: searchTerm.trim() || undefined,
+      filters: filterState.rules.length > 0 ? filterState.rules : undefined,
+      sort: sortState.columns.length > 0 ? sortState.columns : undefined,
     }),
     {
       enabled: !!sessionId && unitListResponse !== null,
@@ -310,10 +322,11 @@ export const UnitGroupedTable: React.FC<UnitGroupedTableProps> = ({
     setPage(0);
   }, []);
 
-  // Reset to first page when unit filter changes
+  // Reset to first page when any server-side filter/search/sort changes,
+  // otherwise we may land on an empty page outside the new filtered range.
   useEffect(() => {
     setPage(0);
-  }, [selectedUnits]);
+  }, [selectedUnits, searchTerm, filterState.rules, sortState.columns]);
 
   // Total pages calculation — use filtered_count when a unit filter is active
   const displayedRowCount = unitData?.filtered_count ?? unitData?.total_count ?? 0;
@@ -416,47 +429,22 @@ export const UnitGroupedTable: React.FC<UnitGroupedTableProps> = ({
     });
   }, [suggestions, dismissedSuggestions]);
 
-  // Apply client-side search, filters, and sorting
+  // Server applies search/filters/sort across the full dataset before paginating
+  // by unit. We only re-stable-sort by unit name so visual grouping survives
+  // any per-row sort the server applied within a unit.
   const processedRows = useMemo(() => {
     if (!unitData?.rows) return [];
 
-    let rows = unitData.rows;
-
-    // Apply search filter across all column values
-    if (searchTerm.trim()) {
-      const term = searchTerm.toLowerCase();
-      rows = rows.filter(row => {
-        // Check unit name
-        if (row._unit_name?.toLowerCase().includes(term)) return true;
-        if (row.row_name?.toLowerCase().includes(term)) return true;
-        if (row._source_document?.toLowerCase().includes(term)) return true;
-        // Check all data columns
-        return Object.values(row.data).some(val => {
-          if (val === null || val === undefined) return false;
-          const str = typeof val === 'string' ? val : JSON.stringify(val);
-          return str.toLowerCase().includes(term);
-        });
-      });
-    }
-
-    // Apply column filters
-    rows = applyFilters(rows, filterState);
-
-    // Apply sorting
-    rows = applySort(rows, sortState);
-
-    // Stable-sort by unit name to ensure contiguous groups for visual merging
+    const rows = unitData.rows;
     const indexMap = new Map(rows.map((r, i) => [r, i]));
-    rows = [...rows].sort((a, b) => {
+    return [...rows].sort((a, b) => {
       const unitA = (a._unit_name || '').toLowerCase();
       const unitB = (b._unit_name || '').toLowerCase();
       const cmp = unitA.localeCompare(unitB);
       if (cmp !== 0) return cmp;
       return (indexMap.get(a) ?? 0) - (indexMap.get(b) ?? 0);
     });
-
-    return rows;
-  }, [unitData?.rows, searchTerm, filterState, sortState]);
+  }, [unitData?.rows]);
 
   // Row selection - compute pageRowIds from filtered/sorted rows
   const pageRowIds = useMemo(() => {

--- a/frontend/src/pages/Visualize.tsx
+++ b/frontend/src/pages/Visualize.tsx
@@ -100,6 +100,15 @@ const Visualize = () => {
     { enabled: !!sessionId }
   );
 
+  // Poll for document URL enrichment until all links are resolved
+  useEffect(() => {
+    if (!documentListResponse?.enrichmentPending) return;
+    const timer = setInterval(() => {
+      queryClient.invalidateQueries(['documentList', sessionId]);
+    }, 3000);
+    return () => clearInterval(timer);
+  }, [documentListResponse?.enrichmentPending, sessionId, queryClient]);
+
   // Document filter state
   const [selectedDocuments, setSelectedDocuments] = useState<string[]>([]);
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -880,7 +880,8 @@ export const unitsAPI = {
   },
 
   /**
-   * Get paginated data optionally filtered by observation unit(s).
+   * Get paginated data grouped by observation unit, with optional
+   * search/filters/sort applied at the row level across the full session.
    */
   getData: async (
     sessionId: string,
@@ -888,14 +889,25 @@ export const unitsAPI = {
       units?: string[];
       page?: number;
       pageSize?: number;
+      filters?: FilterRule[];
+      sort?: SortColumn[];
+      search?: string;
     }
   ): Promise<PaginatedData> => {
-    const params = new URLSearchParams();
-    if (options?.units && options.units.length > 0) params.append('units', options.units.join(','));
-    if (options?.page !== undefined) params.append('page', options.page.toString());
-    if (options?.pageSize !== undefined) params.append('page_size', options.pageSize.toString());
+    const params: Record<string, any> = {};
+    if (options?.units && options.units.length > 0) params.units = options.units.join(',');
+    if (options?.page !== undefined) params.page = options.page;
+    if (options?.pageSize !== undefined) params.page_size = options.pageSize;
 
-    const response = await api.get(`/units/data/${sessionId}?${params.toString()}`);
+    const response = await api.post(
+      `/units/data/${sessionId}`,
+      {
+        filters: options?.filters && options.filters.length > 0 ? options.filters : null,
+        sort: options?.sort && options.sort.length > 0 ? options.sort : null,
+        search: options?.search || null,
+      },
+      { params }
+    );
     return response.data;
   },
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -925,6 +925,7 @@ export const unitsAPI = {
       })),
       totalDocuments: data.total_documents,
       totalRows: data.total_rows,
+      enrichmentPending: data.enrichment_pending ?? false,
     };
   },
 

--- a/frontend/src/types/unit.ts
+++ b/frontend/src/types/unit.ts
@@ -78,4 +78,5 @@ export interface DocumentListResponse {
   documents: DocumentSummary[];
   totalDocuments: number;
   totalRows: number;
+  enrichmentPending: boolean;
 }


### PR DESCRIPTION
## Summary
- Add `PubMedEnrichmentService` that searches EuropePMC for document titles and stores DOI URLs in session metadata
- Trigger enrichment lazily from `GET /units/documents` endpoint for documents missing URLs
- Frontend polls every 3s while `enrichment_pending` is true, so links appear automatically without page refresh
- Handles observation-unit prefixes (`co-`, `amb-`, `en-`), truncated titles, and underscore-separated filenames

## Test plan
- [ ] Load a JSON file with `document_metadata` → links should appear immediately
- [ ] Upload raw documents with academic paper filenames → links should appear within seconds
- [ ] Verify no UI slowdown during enrichment (fire-and-forget background task)
- [ ] Check backend logs for `[pubmed-enrichment]` messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)