### PR TITLE
feat: trigger PubMed enrichment at all completion points

### DIFF
--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -34,9 +34,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 # Module-level singleton (same pattern as schematiq_runner, reextraction_service, etc.)
+from app.services import pubmed_enrichment_service
 upload_processor = UploadDocumentProcessor(
     websocket_manager=websocket_manager,
-    session_manager=session_manager
+    session_manager=session_manager,
+    pubmed_enrichment_service=pubmed_enrichment_service,
 )
 
 

--- a/backend/app/api/routes/schema.py
+++ b/backend/app/api/routes/schema.py
@@ -31,12 +31,15 @@ router = APIRouter(tags=["schema"])
 schema_manager = SchemaManager(websocket_manager, session_manager)
 
 # Create reextraction service instance
+from app.services import pubmed_enrichment_service
 reextraction_service = ReextractionService(websocket_manager, session_manager,
-                                           data_collection_service=data_collection_service)
+                                           data_collection_service=data_collection_service,
+                                           pubmed_enrichment_service=pubmed_enrichment_service)
 
 # Create continue discovery service instance
 continue_discovery_service = ContinueDiscoveryService(websocket_manager, session_manager,
-                                                      data_collection_service=data_collection_service)
+                                                      data_collection_service=data_collection_service,
+                                                      pubmed_enrichment_service=pubmed_enrichment_service)
 
 # Create data editor instance
 data_editor = DataEditor()

--- a/backend/app/api/routes/schematiq.py
+++ b/backend/app/api/routes/schematiq.py
@@ -25,8 +25,10 @@ from schematiq.core.cost_estimator import estimate_from_config
 
 router = APIRouter()
 # Create shared ScheMatiQ runner instance with shared managers
+from app.services import pubmed_enrichment_service
 schematiq_runner = ScheMatiQRunner(websocket_manager=websocket_manager, session_manager=session_manager,
-                         data_collection_service=data_collection_service)
+                         data_collection_service=data_collection_service,
+                         pubmed_enrichment_service=pubmed_enrichment_service)
 # Create data editor instance
 data_editor = DataEditor()
 

--- a/backend/app/services/continue_discovery_service.py
+++ b/backend/app/services/continue_discovery_service.py
@@ -99,7 +99,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
     """Handles continued schema discovery operations."""
 
     def __init__(self, websocket_manager: WebSocketManager, session_manager: SessionManager,
-                 data_collection_service=None):
+                 data_collection_service=None, pubmed_enrichment_service=None):
         super().__init__(websocket_manager)
         self.session_manager = session_manager
         self.active_operations: Dict[str, ContinueDiscoveryOperation] = {}
@@ -107,6 +107,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
         self._tasks: Dict[str, asyncio.Task] = {}
         self._state_lock = threading.Lock()
         self._data_collection_service = data_collection_service
+        self._pubmed_enrichment_service = pubmed_enrichment_service
 
     def is_stop_requested(self, operation_id: str) -> bool:
         """Check if stop was requested for an operation."""
@@ -1250,6 +1251,10 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     operation.session_id, "continue_discovery_completion"
                 )
 
+            # Enrich source documents with PubMed/DOI links (fire-and-forget)
+            if self._pubmed_enrichment_service:
+                await self._pubmed_enrichment_service.enrich_session(operation.session_id)
+
             # Cleanup config files
             config_file.unlink(missing_ok=True)
             llm_config_file.unlink(missing_ok=True)
@@ -1628,6 +1633,10 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                 await self._data_collection_service.trigger_archive(
                     operation.session_id, "continue_discovery_extraction"
                 )
+
+            # Enrich source documents with PubMed/DOI links (fire-and-forget)
+            if self._pubmed_enrichment_service:
+                await self._pubmed_enrichment_service.enrich_session(operation.session_id)
 
         except Exception as e:
             logger.error(f"Incremental extraction FAILED: {e}", exc_info=True)

--- a/backend/app/services/pubmed_enrichment_service.py
+++ b/backend/app/services/pubmed_enrichment_service.py
@@ -117,6 +117,20 @@ class PubMedEnrichmentService:
         """Check if enrichment is currently running for a session."""
         return session_id in self._in_progress
 
+    async def enrich_session(self, session_id: str) -> None:
+        """Enrich all source documents in a session. Called at pipeline completion."""
+        from app.services.unit_view_service import unit_view_service
+        try:
+            documents = unit_view_service.get_source_documents(session_id)
+            doc_names = [d["name"] for d in documents]
+            if doc_names:
+                await self.enrich_missing(session_id, doc_names)
+        except Exception:
+            logger.warning(
+                "[pubmed-enrichment] Failed to enrich session %s",
+                session_id[:8], exc_info=True,
+            )
+
     async def enrich_missing(self, session_id: str, doc_names: List[str]) -> bool:
         """Enrich documents that don't have URLs yet. Non-blocking, deduped.
 

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -72,7 +72,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
     }
 
     def __init__(self, websocket_manager: WebSocketManager, session_manager: SessionManager,
-                 data_collection_service=None):
+                 data_collection_service=None, pubmed_enrichment_service=None):
         super().__init__(websocket_manager)
         self.session_manager = session_manager
         self.active_operations: Dict[str, ReextractionOperation] = {}
@@ -80,6 +80,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
         self._extraction_tasks: Dict[str, asyncio.Task] = {}  # operation_id -> task
         self._state_lock = threading.Lock()
         self._data_collection_service = data_collection_service
+        self._pubmed_enrichment_service = pubmed_enrichment_service
 
     @classmethod
     def get_cached_retriever(cls):
@@ -1258,6 +1259,10 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 await self._data_collection_service.trigger_archive(
                     operation.session_id, "reextraction_completion"
                 )
+
+            # Enrich source documents with PubMed/DOI links (fire-and-forget)
+            if self._pubmed_enrichment_service:
+                await self._pubmed_enrichment_service.enrich_session(operation.session_id)
 
         except Exception as e:
             logger.error(f"Re-extraction FAILED for operation {operation_id}: {e}", exc_info=True)

--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -126,7 +126,7 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
     """Handles ScheMatiQ execution and integration."""
     
     def __init__(self, work_dir: str = "./schematiq_work", websocket_manager=None, session_manager=None,
-                 data_collection_service=None):
+                 data_collection_service=None, pubmed_enrichment_service=None):
         # Use provided managers or create new ones
         if websocket_manager is not None:
             self.websocket_manager = websocket_manager
@@ -145,6 +145,7 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         self.work_dir.mkdir(exist_ok=True)
         self.running_sessions: Dict[str, asyncio.Task] = {}
         self._data_collection_service = data_collection_service
+        self._pubmed_enrichment_service = pubmed_enrichment_service
         self.stop_flags: Dict[str, bool] = {}  # Track stop requests per session
         self._state_lock = threading.Lock()
         self._global_usage = GlobalLLMUsageTracker(self.work_dir / "global_llm_usage.json")
@@ -1173,6 +1174,8 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
                 # Archive partial results for research (fire-and-forget)
                 if self._data_collection_service and rows_saved > 0:
                     await self._data_collection_service.trigger_archive(session_id, "schematiq_stopped_partial")
+                if self._pubmed_enrichment_service and rows_saved > 0:
+                    await self._pubmed_enrichment_service.enrich_session(session_id)
                 return
 
             # Step 7: Finalize
@@ -1241,6 +1244,10 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
             # Archive session data for research (fire-and-forget)
             if self._data_collection_service:
                 await self._data_collection_service.trigger_archive(session_id, "schematiq_completion")
+
+            # Enrich source documents with PubMed/DOI links (fire-and-forget)
+            if self._pubmed_enrichment_service:
+                await self._pubmed_enrichment_service.enrich_session(session_id)
 
             # Move processed documents from pending_documents/ to documents/
             # Prevents stale files from being re-picked up by continue discovery

--- a/backend/app/services/upload_document_processor.py
+++ b/backend/app/services/upload_document_processor.py
@@ -36,9 +36,11 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
     # Metadata columns that should not be sent to LLM for extraction
     METADATA_COLUMNS = {'papers', 'document_directory', 'row_name', '_row_name', '_papers', '_metadata'}
 
-    def __init__(self, websocket_manager: WebSocketManager, session_manager: SessionManager):
+    def __init__(self, websocket_manager: WebSocketManager, session_manager: SessionManager,
+                 pubmed_enrichment_service=None):
         super().__init__(websocket_manager)
         self.session_manager = session_manager
+        self._pubmed_enrichment_service = pubmed_enrichment_service
         self.running_sessions: Dict[str, bool] = {}
         self._state_lock = threading.Lock()
 
@@ -384,7 +386,11 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                 "Document processing completed successfully", completion_data)
 
             logger.info(f"Document processing completed and broadcast sent for session {session_id}")
-            
+
+            # Enrich source documents with PubMed/DOI links (fire-and-forget)
+            if self._pubmed_enrichment_service:
+                await self._pubmed_enrichment_service.enrich_session(session_id)
+
         except Exception as e:
             # Update session with error
             session = self.session_manager.get_session(session_id)

--- a/frontend/src/components/DataTable/UnitGroupedTable.tsx
+++ b/frontend/src/components/DataTable/UnitGroupedTable.tsx
@@ -209,6 +209,7 @@ export const UnitGroupedTable: React.FC<UnitGroupedTableProps> = ({
   onColumnReorder,
   documentUrlMap,
 }) => {
+
   // Unit data hooks
   const { units: unitListResponse, loading: unitsLoading, error: unitsError, refresh: refreshUnits } = useUnits(sessionId);
   const { merge, loading: mergeLoading, error: mergeError, clearError: clearMergeError } = useMergeUnits(sessionId);

--- a/frontend/src/pages/Visualize.tsx
+++ b/frontend/src/pages/Visualize.tsx
@@ -97,14 +97,14 @@ const Visualize = () => {
   const { data: documentListResponse } = useQuery(
     ['documentList', sessionId],
     () => unitsAPI.getDocuments(sessionId!),
-    { enabled: !!sessionId }
+    { enabled: !!sessionId, structuralSharing: false }
   );
 
   // Poll for document URL enrichment until all links are resolved
   useEffect(() => {
     if (!documentListResponse?.enrichmentPending) return;
     const timer = setInterval(() => {
-      queryClient.invalidateQueries(['documentList', sessionId]);
+      queryClient.refetchQueries(['documentList', sessionId]);
     }, 3000);
     return () => clearInterval(timer);
   }, [documentListResponse?.enrichmentPending, sessionId, queryClient]);
@@ -113,13 +113,15 @@ const Visualize = () => {
   const [selectedDocuments, setSelectedDocuments] = useState<string[]>([]);
 
   // Build document URL lookup map (document name -> safe external URL)
-  const documentUrlMap = useMemo(() => {
+  // Uses useState (not useMemo) to guarantee re-render propagation to child components.
+  const [documentUrlMap, setDocumentUrlMap] = useState<Map<string, string>>(new Map());
+  useEffect(() => {
     const map = new Map<string, string>();
     documentListResponse?.documents.forEach(d => {
       if (d.url && isSafeUrl(d.url)) map.set(d.name, d.url);
     });
-    return map;
-  }, [documentListResponse?.documents]);
+    setDocumentUrlMap(map);
+  }, [documentListResponse]);
 
   // Enhanced upload document management state
   const [uploadedDocuments, setUploadedDocuments] = useState<File[]>([]);
@@ -263,6 +265,7 @@ const Visualize = () => {
               queryClient.invalidateQueries(['data', sessionId]);
               queryClient.invalidateQueries(['session', sessionId]);
               queryClient.invalidateQueries({ queryKey: ['unitData', sessionId], exact: false });
+              queryClient.invalidateQueries(['documentList', sessionId]);
               setTimeout(() => {
                 setNewlyAddedRows(prev => {
                   const newSet = new Set(Array.from(prev));
@@ -332,6 +335,7 @@ const Visualize = () => {
               queryClient.invalidateQueries(['session', sessionId, mode]);
               queryClient.invalidateQueries(['data', sessionId, mode]);
               queryClient.invalidateQueries({ queryKey: ['unitData', sessionId], exact: false });
+              queryClient.invalidateQueries(['documentList', sessionId]);
               refreshUnits();
               break;
             case 'reextraction_stopped':
@@ -427,6 +431,7 @@ const Visualize = () => {
               queryClient.invalidateQueries(['session', sessionId, mode]);
               queryClient.invalidateQueries(['data', sessionId, mode]);
               queryClient.invalidateQueries({ queryKey: ['unitData', sessionId], exact: false });
+              queryClient.invalidateQueries(['documentList', sessionId]);
               refreshUnits();
               break;
           }
@@ -603,6 +608,7 @@ const Visualize = () => {
                 queryClient.invalidateQueries(['data', sessionId]);
                 queryClient.invalidateQueries(['session', sessionId]);
                 queryClient.invalidateQueries({ queryKey: ['unitData', sessionId], exact: false });
+              queryClient.invalidateQueries(['documentList', sessionId]);
                 setTimeout(() => {
                   setNewlyAddedRows(prev => {
                     const newSet = new Set(Array.from(prev));
@@ -779,6 +785,7 @@ const Visualize = () => {
                 queryClient.invalidateQueries(['session', sessionId, mode]);
                 queryClient.invalidateQueries(['data', sessionId, mode]);
                 queryClient.invalidateQueries({ queryKey: ['unitData', sessionId], exact: false });
+              queryClient.invalidateQueries(['documentList', sessionId]);
                 refreshUnits();
                 break;
             }
@@ -1355,6 +1362,7 @@ const Visualize = () => {
                     queryClient.invalidateQueries(['session', sessionId, mode]);
                     queryClient.invalidateQueries(['data', sessionId, mode]);
                     queryClient.invalidateQueries({ queryKey: ['unitData', sessionId], exact: false });
+              queryClient.invalidateQueries(['documentList', sessionId]);
                     refreshUnits();
                   }}
                   processingColumns={processingColumns}
@@ -1389,6 +1397,7 @@ const Visualize = () => {
                     queryClient.invalidateQueries(['session', sessionId, mode]);
                     queryClient.invalidateQueries(['data', sessionId, mode]);
                     queryClient.invalidateQueries({ queryKey: ['unitData', sessionId], exact: false });
+              queryClient.invalidateQueries(['documentList', sessionId]);
                     refreshUnits();
                   }}
                   columnInfo={session?.columns?.map(col => ({ name: col.name, definition: col.definition, allowed_values: col.allowed_values ?? undefined }))}


### PR DESCRIPTION
## Summary
- Add `enrich_session()` convenience method to `PubMedEnrichmentService` that reads source documents from data and enriches any missing URLs
- Wire enrichment service into all 4 pipeline services (`ScheMatiQRunner`, `UploadDocumentProcessor`, `ContinueDiscoveryService`, `ReextractionService`) via constructor injection
- Trigger enrichment at 6 completion points (same fire-and-forget pattern as `data_collection_service.trigger_archive`)
- Fix document links not appearing without page refresh: use `useState`+`useEffect` instead of `useMemo` for `documentUrlMap`, and add `documentList` query invalidation at all completion handlers

## Test plan
- [ ] Load a JSON with existing `document_metadata` → links appear immediately
- [ ] Upload new documents to a session → after processing, links appear automatically without refresh
- [ ] Run a ScheMatiQ session → after completion, document links appear
- [ ] Check backend logs for `[pubmed-enrichment]` at each completion point
- [ ] Verify no regressions in "By Unit" and "By Document" table views

🤖 Generated with [Claude Code](https://claude.com/claude-code)