### PR TITLE
fix(ui): document names clickable live after PubMed enrichment

### DIFF
--- a/frontend/src/pages/Visualize.tsx
+++ b/frontend/src/pages/Visualize.tsx
@@ -287,6 +287,7 @@ const Visualize = () => {
               queryClient.refetchQueries({ queryKey: ['session', sessionId], exact: false });
               queryClient.refetchQueries({ queryKey: ['data', sessionId], exact: false });
               queryClient.refetchQueries({ queryKey: ['unitData', sessionId], exact: false });
+              queryClient.invalidateQueries(['documentList', sessionId]);
               refreshUnits();
               setTimeout(() => {
                 if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
@@ -372,6 +373,7 @@ const Visualize = () => {
               queryClient.refetchQueries({ queryKey: ['session', sessionId], exact: false });
               queryClient.refetchQueries({ queryKey: ['data', sessionId], exact: false });
               queryClient.refetchQueries({ queryKey: ['unitData', sessionId], exact: false });
+              queryClient.invalidateQueries(['documentList', sessionId]);
               refreshUnits();
               break;
 
@@ -394,6 +396,7 @@ const Visualize = () => {
               queryClient.refetchQueries({ queryKey: ['session', sessionId], exact: false });
               queryClient.refetchQueries({ queryKey: ['data', sessionId], exact: false });
               queryClient.refetchQueries({ queryKey: ['unitData', sessionId], exact: false });
+              queryClient.invalidateQueries(['documentList', sessionId]);
               refreshUnits();
               break;
             case 'continue_discovery_stopped':
@@ -630,6 +633,7 @@ const Visualize = () => {
                 queryClient.refetchQueries({ queryKey: ['session', sessionId], exact: false });
                 queryClient.refetchQueries({ queryKey: ['data', sessionId], exact: false });
                 queryClient.refetchQueries({ queryKey: ['unitData', sessionId], exact: false });
+                queryClient.invalidateQueries(['documentList', sessionId]);
                 refreshUnits();
                 setTimeout(() => {
                   if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
@@ -724,6 +728,7 @@ const Visualize = () => {
                 queryClient.refetchQueries({ queryKey: ['session', sessionId], exact: false });
                 queryClient.refetchQueries({ queryKey: ['data', sessionId], exact: false });
                 queryClient.refetchQueries({ queryKey: ['unitData', sessionId], exact: false });
+                queryClient.invalidateQueries(['documentList', sessionId]);
                 refreshUnits();
                 break;
 
@@ -746,6 +751,7 @@ const Visualize = () => {
                 queryClient.refetchQueries({ queryKey: ['session', sessionId], exact: false });
                 queryClient.refetchQueries({ queryKey: ['data', sessionId], exact: false });
                 queryClient.refetchQueries({ queryKey: ['unitData', sessionId], exact: false });
+                queryClient.invalidateQueries(['documentList', sessionId]);
                 refreshUnits();
                 // Note: don't clear continueDiscoveryActive yet — extraction may follow
                 break;


### PR DESCRIPTION
## Summary
- Three WebSocket completion handlers (`completed`, `continue_discovery_completed`, `stopped`) in both handler blocks of `Visualize.tsx` were missing the `documentList` query invalidation that commit 97b3fd4 added to their siblings.
- Result: after backend's fire-and-forget PubMed enrichment finished, the source-document column kept rendering plain text until the user refreshed.
- Adds 6 one-line `queryClient.invalidateQueries(['documentList', sessionId])` calls — one per missed handler — matching the proven pattern from `row_completed` / `reextraction_completed` / `incremental_extraction_completed`.

## Why this works
Backend awaits `broadcast_*` then immediately awaits `enrich_session()`. `PubMedEnrichmentService.enrich_missing()` flips `_in_progress = True` synchronously (before its first true `await`), so by the time the frontend's WS-triggered refetch round-trips back, the GET sees `is_active(session_id) = True` → response carries `enrichment_pending: true` → existing 3s polling `useEffect` activates and runs until URLs resolve.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Verified end-to-end: source-document links populate live after a ScheMatiQ run, after Add More Documents (continue discovery), and after a partial stop — no manual refresh needed
- [x] Regression: incremental extraction and re-extraction paths still populate links live (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)