### PR TITLE
feat: auto-enrich protein rows with UniProt data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ ScheMatiQ/
 - **Continue Discovery**: Extends schema after initial convergence by processing more documents. Managed by `ContinueDiscoveryService`.
 - **Reextraction**: Re-runs value extraction with current/edited schema. Managed by `ReextractionService`.
 - **Cost Estimation**: Estimates API costs before expensive LLM ops. `schematiq.core.cost_estimator` → `/api/schematiq/cost-estimate` endpoint.
+- **Runtime row format**: `schematiq_work/{id}/extracted_data.jsonl` stores rows **flat** — cells at top level (`row[col_name]`), metadata under `_`-prefixed keys (`_unit_name`, `_source_document`, `_cell_status`, `_papers`). Cell values are often dict-wrapped as `{"answer": ..., "excerpts": [...], "normalized_to_allowed": ...}`; use an `extract_value()`-style helper when reading. Do **not** assume a nested `row["data"]` wrapper — that shape appears only in offline/research JSON artifacts.
+- **Enrichment**: Fire-and-forget post-completion augmentation via services like `PubMedEnrichmentService` (doc DOI links) and `UniProtEnrichmentService` (protein rows). Pattern: `enrich_session(session_id)` on a DI-injected singleton, hooked into all four runners (`schematiq_runner`, `continue_discovery_service`, `reextraction_service`, `upload_document_processor`) right after each completion broadcast. Row-level enrichments mark cells with `_cell_status: "external_source"` — the frontend DataTable styles these with a blue border.
 
 ## Development Commands
 

--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -34,11 +34,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 # Module-level singleton (same pattern as schematiq_runner, reextraction_service, etc.)
-from app.services import pubmed_enrichment_service
+from app.services import pubmed_enrichment_service, uniprot_enrichment_service
 upload_processor = UploadDocumentProcessor(
     websocket_manager=websocket_manager,
     session_manager=session_manager,
     pubmed_enrichment_service=pubmed_enrichment_service,
+    uniprot_enrichment_service=uniprot_enrichment_service,
 )
 
 

--- a/backend/app/api/routes/schema.py
+++ b/backend/app/api/routes/schema.py
@@ -31,15 +31,17 @@ router = APIRouter(tags=["schema"])
 schema_manager = SchemaManager(websocket_manager, session_manager)
 
 # Create reextraction service instance
-from app.services import pubmed_enrichment_service
+from app.services import pubmed_enrichment_service, uniprot_enrichment_service
 reextraction_service = ReextractionService(websocket_manager, session_manager,
                                            data_collection_service=data_collection_service,
-                                           pubmed_enrichment_service=pubmed_enrichment_service)
+                                           pubmed_enrichment_service=pubmed_enrichment_service,
+                                           uniprot_enrichment_service=uniprot_enrichment_service)
 
 # Create continue discovery service instance
 continue_discovery_service = ContinueDiscoveryService(websocket_manager, session_manager,
                                                       data_collection_service=data_collection_service,
-                                                      pubmed_enrichment_service=pubmed_enrichment_service)
+                                                      pubmed_enrichment_service=pubmed_enrichment_service,
+                                                      uniprot_enrichment_service=uniprot_enrichment_service)
 
 # Create data editor instance
 data_editor = DataEditor()

--- a/backend/app/api/routes/schematiq.py
+++ b/backend/app/api/routes/schematiq.py
@@ -25,10 +25,11 @@ from schematiq.core.cost_estimator import estimate_from_config
 
 router = APIRouter()
 # Create shared ScheMatiQ runner instance with shared managers
-from app.services import pubmed_enrichment_service
+from app.services import pubmed_enrichment_service, uniprot_enrichment_service
 schematiq_runner = ScheMatiQRunner(websocket_manager=websocket_manager, session_manager=session_manager,
                          data_collection_service=data_collection_service,
-                         pubmed_enrichment_service=pubmed_enrichment_service)
+                         pubmed_enrichment_service=pubmed_enrichment_service,
+                         uniprot_enrichment_service=uniprot_enrichment_service)
 # Create data editor instance
 data_editor = DataEditor()
 

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -150,3 +150,8 @@ else:
 from app.services.pubmed_enrichment_service import PubMedEnrichmentService
 pubmed_enrichment_service = PubMedEnrichmentService(session_manager=session_manager)
 logger.info("[pubmed-enrichment] Service initialized")
+
+# ── UniProt row enrichment (protein data lookup) ───────────────────
+from app.services.uniprot_enrichment_service import UniProtEnrichmentService
+uniprot_enrichment_service = UniProtEnrichmentService(session_manager=session_manager)
+logger.info("[uniprot-enrichment] Service initialized")

--- a/backend/app/services/continue_discovery_service.py
+++ b/backend/app/services/continue_discovery_service.py
@@ -99,7 +99,8 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
     """Handles continued schema discovery operations."""
 
     def __init__(self, websocket_manager: WebSocketManager, session_manager: SessionManager,
-                 data_collection_service=None, pubmed_enrichment_service=None):
+                 data_collection_service=None, pubmed_enrichment_service=None,
+                 uniprot_enrichment_service=None):
         super().__init__(websocket_manager)
         self.session_manager = session_manager
         self.active_operations: Dict[str, ContinueDiscoveryOperation] = {}
@@ -108,6 +109,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
         self._state_lock = threading.Lock()
         self._data_collection_service = data_collection_service
         self._pubmed_enrichment_service = pubmed_enrichment_service
+        self._uniprot_enrichment_service = uniprot_enrichment_service
 
     def is_stop_requested(self, operation_id: str) -> bool:
         """Check if stop was requested for an operation."""
@@ -1255,6 +1257,10 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             if self._pubmed_enrichment_service:
                 await self._pubmed_enrichment_service.enrich_session(operation.session_id)
 
+            # Enrich protein rows with UniProt data (fire-and-forget, protein units only)
+            if self._uniprot_enrichment_service:
+                await self._uniprot_enrichment_service.enrich_session(operation.session_id)
+
             # Cleanup config files
             config_file.unlink(missing_ok=True)
             llm_config_file.unlink(missing_ok=True)
@@ -1637,6 +1643,10 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
             # Enrich source documents with PubMed/DOI links (fire-and-forget)
             if self._pubmed_enrichment_service:
                 await self._pubmed_enrichment_service.enrich_session(operation.session_id)
+
+            # Enrich protein rows with UniProt data (fire-and-forget, protein units only)
+            if self._uniprot_enrichment_service:
+                await self._uniprot_enrichment_service.enrich_session(operation.session_id)
 
         except Exception as e:
             logger.error(f"Incremental extraction FAILED: {e}", exc_info=True)

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -72,7 +72,8 @@ class ReextractionService(WebSocketBroadcasterMixin):
     }
 
     def __init__(self, websocket_manager: WebSocketManager, session_manager: SessionManager,
-                 data_collection_service=None, pubmed_enrichment_service=None):
+                 data_collection_service=None, pubmed_enrichment_service=None,
+                 uniprot_enrichment_service=None):
         super().__init__(websocket_manager)
         self.session_manager = session_manager
         self.active_operations: Dict[str, ReextractionOperation] = {}
@@ -81,6 +82,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
         self._state_lock = threading.Lock()
         self._data_collection_service = data_collection_service
         self._pubmed_enrichment_service = pubmed_enrichment_service
+        self._uniprot_enrichment_service = uniprot_enrichment_service
 
     @classmethod
     def get_cached_retriever(cls):
@@ -1263,6 +1265,10 @@ class ReextractionService(WebSocketBroadcasterMixin):
             # Enrich source documents with PubMed/DOI links (fire-and-forget)
             if self._pubmed_enrichment_service:
                 await self._pubmed_enrichment_service.enrich_session(operation.session_id)
+
+            # Enrich protein rows with UniProt data (fire-and-forget, protein units only)
+            if self._uniprot_enrichment_service:
+                await self._uniprot_enrichment_service.enrich_session(operation.session_id)
 
         except Exception as e:
             logger.error(f"Re-extraction FAILED for operation {operation_id}: {e}", exc_info=True)

--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -126,7 +126,8 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
     """Handles ScheMatiQ execution and integration."""
     
     def __init__(self, work_dir: str = "./schematiq_work", websocket_manager=None, session_manager=None,
-                 data_collection_service=None, pubmed_enrichment_service=None):
+                 data_collection_service=None, pubmed_enrichment_service=None,
+                 uniprot_enrichment_service=None):
         # Use provided managers or create new ones
         if websocket_manager is not None:
             self.websocket_manager = websocket_manager
@@ -146,6 +147,7 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         self.running_sessions: Dict[str, asyncio.Task] = {}
         self._data_collection_service = data_collection_service
         self._pubmed_enrichment_service = pubmed_enrichment_service
+        self._uniprot_enrichment_service = uniprot_enrichment_service
         self.stop_flags: Dict[str, bool] = {}  # Track stop requests per session
         self._state_lock = threading.Lock()
         self._global_usage = GlobalLLMUsageTracker(self.work_dir / "global_llm_usage.json")
@@ -1176,6 +1178,8 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
                     await self._data_collection_service.trigger_archive(session_id, "schematiq_stopped_partial")
                 if self._pubmed_enrichment_service and rows_saved > 0:
                     await self._pubmed_enrichment_service.enrich_session(session_id)
+                if self._uniprot_enrichment_service and rows_saved > 0:
+                    await self._uniprot_enrichment_service.enrich_session(session_id)
                 return
 
             # Step 7: Finalize
@@ -1248,6 +1252,10 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
             # Enrich source documents with PubMed/DOI links (fire-and-forget)
             if self._pubmed_enrichment_service:
                 await self._pubmed_enrichment_service.enrich_session(session_id)
+
+            # Enrich protein rows with UniProt data (fire-and-forget, protein units only)
+            if self._uniprot_enrichment_service:
+                await self._uniprot_enrichment_service.enrich_session(session_id)
 
             # Move processed documents from pending_documents/ to documents/
             # Prevents stale files from being re-picked up by continue discovery

--- a/backend/app/services/uniprot_enrichment_service.py
+++ b/backend/app/services/uniprot_enrichment_service.py
@@ -1,0 +1,261 @@
+"""Background service for enriching protein rows with UniProt data.
+
+Triggered at the same completion points as PubMedEnrichmentService (end of
+value extraction, continue-discovery, re-extraction, document upload). For any
+session whose observation unit looks protein-like, every row missing a UniProt
+accession is resolved against the UniProt REST API and the row is augmented
+with 10 columns (accession, url, gene symbol, GO terms, PDB IDs, AlphaFold URL,
+etc.) plus per-cell `_cell_status: "external_source"` provenance — which the
+frontend DataTable already styles with a blue border.
+
+Rows already carrying a `uniprot_accession` are left untouched, so adding new
+documents to an enriched session only triggers lookups for the new rows.
+"""
+
+import asyncio
+import functools
+import json
+import logging
+from pathlib import Path
+from typing import Set
+
+from app.services.session_manager import SessionManager
+from app.services.uniprot_lookup import (
+    EXTERNAL,
+    NO_CHANGE,
+    UNIPROT_SCHEMA_COLUMNS,
+    extract_value,
+    find_input_columns,
+    is_protein_like_unit,
+    lookup_protein,
+    parse_hit,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class UniProtEnrichmentService:
+    """Fire-and-forget service that enriches rows with UniProt data."""
+
+    def __init__(self, session_manager: SessionManager):
+        self._session_manager = session_manager
+        self._active_tasks: Set[asyncio.Task] = set()
+        self._in_progress: Set[str] = set()
+
+    def is_active(self, session_id: str) -> bool:
+        return session_id in self._in_progress
+
+    async def enrich_session(self, session_id: str) -> None:
+        """Enrich unprocessed rows in a session. Fire-and-forget; never raises."""
+        if session_id in self._in_progress:
+            return
+        try:
+            session = self._session_manager.get_session(session_id)
+            if not session:
+                return
+
+            unit = session.observation_unit
+            if not unit or not is_protein_like_unit(unit.name, unit.definition):
+                logger.info(
+                    "[uniprot-enrichment] Skipping session %s: observation unit %r is not protein-like",
+                    session_id[:8], getattr(unit, "name", None),
+                )
+                return
+
+            jsonl_path = _find_session_data_file(session_id)
+            if jsonl_path is None:
+                return
+
+            # Peek at the first row to decide if we have a usable protein column.
+            # Runtime jsonl stores cells at the row top level (ScheMatiQ flat format).
+            first_row = _read_first_row(jsonl_path)
+            if first_row is None:
+                return
+            pcol, _ocol, _acol = find_input_columns(first_row)
+            if not pcol:
+                logger.warning(
+                    "[uniprot-enrichment] Skipping session %s: no protein-name column found",
+                    session_id[:8],
+                )
+                return
+
+            self._in_progress.add(session_id)
+            task = asyncio.create_task(self._enrich_rows(session_id, jsonl_path))
+            self._active_tasks.add(task)
+
+            def _on_done(t: asyncio.Task) -> None:
+                self._active_tasks.discard(t)
+                self._in_progress.discard(session_id)
+
+            task.add_done_callback(_on_done)
+        except Exception:
+            self._in_progress.discard(session_id)
+            logger.warning(
+                "[uniprot-enrichment] Failed to schedule enrichment for %s",
+                session_id[:8], exc_info=True,
+            )
+
+    async def _enrich_rows(self, session_id: str, jsonl_path: Path) -> None:
+        """Background coroutine: resolve each pending row against UniProt."""
+        from app.services import schematiq_thread_pool
+
+        loop = asyncio.get_running_loop()
+
+        try:
+            rows = _load_jsonl(jsonl_path)
+            if not rows:
+                return
+
+            pcol, ocol, acol = find_input_columns(rows[0])
+            if not pcol:
+                return
+
+            pending_indices = [
+                i for i, r in enumerate(rows)
+                if not r.get("uniprot_accession")
+            ]
+            if not pending_indices:
+                logger.info(
+                    "[uniprot-enrichment] Session %s has no pending rows; nothing to do",
+                    session_id[:8],
+                )
+                return
+
+            logger.info(
+                "[uniprot-enrichment] Started enrichment for %d/%d rows in session %s",
+                len(pending_indices), len(rows), session_id[:8],
+            )
+
+            # Per-session cache so repeated proteins within a session skip HTTP.
+            cache: dict = {}
+            enriched = 0
+
+            for idx in pending_indices:
+                row = rows[idx]
+                status = row.setdefault("_cell_status", {})
+
+                protein = extract_value(row.get(pcol)) if pcol else None
+                if not protein:
+                    _fill_empty(row, status)
+                    continue
+
+                organism = row.get(ocol) if ocol else None
+                alt_names = row.get(acol) if acol else None
+
+                cache_key = (str(protein).strip().lower(), _cache_key_for_organism(organism))
+                if cache_key in cache:
+                    parsed = cache[cache_key]
+                else:
+                    hit, _tier, _err = await loop.run_in_executor(
+                        schematiq_thread_pool,
+                        functools.partial(lookup_protein, protein, organism, alt_names),
+                    )
+                    parsed = parse_hit(hit) if hit else None
+                    cache[cache_key] = parsed
+                    await asyncio.sleep(0.2)  # UniProt rate limit
+
+                if parsed:
+                    enriched += 1
+                    for col, _defn, _dtype in UNIPROT_SCHEMA_COLUMNS:
+                        val = parsed.get(col)
+                        row[col] = val
+                        status[col] = EXTERNAL if val is not None else NO_CHANGE
+                else:
+                    _fill_empty(row, status)
+
+            _write_jsonl_atomic(jsonl_path, rows)
+            self._ensure_columns_on_session(session_id)
+
+            logger.info(
+                "[uniprot-enrichment] Finished session %s: %d/%d rows enriched",
+                session_id[:8], enriched, len(pending_indices),
+            )
+        except Exception:
+            logger.warning(
+                "[uniprot-enrichment] Error enriching session %s",
+                session_id[:8], exc_info=True,
+            )
+
+    def _ensure_columns_on_session(self, session_id: str) -> None:
+        """Register the 10 UniProt columns on the session if they aren't already."""
+        from app.models.session import ColumnInfo
+        session = self._session_manager.get_session(session_id)
+        if not session:
+            return
+        existing = {c.name for c in session.columns}
+        added = False
+        for name, definition, data_type in UNIPROT_SCHEMA_COLUMNS:
+            if name not in existing:
+                session.columns.append(ColumnInfo(
+                    name=name,
+                    definition=definition,
+                    data_type=data_type,
+                    source_document="__uniprot_enrichment__",
+                ))
+                added = True
+        if added:
+            self._session_manager.update_session(session)
+
+
+# ── module-private helpers ───────────────────────────────────────────
+
+def _find_session_data_file(session_id: str):
+    """Locate the primary extracted-data jsonl for a session.
+
+    Imported lazily because app.services.__init__ imports this module.
+    """
+    from app.services import find_session_data_file
+    return find_session_data_file(session_id)
+
+
+def _read_first_row(jsonl_path: Path):
+    try:
+        with jsonl_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    return json.loads(line)
+    except Exception:
+        return None
+    return None
+
+
+def _load_jsonl(jsonl_path: Path):
+    rows = []
+    with jsonl_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return rows
+
+
+def _write_jsonl_atomic(jsonl_path: Path, rows) -> None:
+    """Write rows to a sibling .tmp file and atomically replace the target."""
+    tmp = jsonl_path.with_suffix(jsonl_path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False))
+            f.write("\n")
+    tmp.replace(jsonl_path)
+
+
+def _fill_empty(row: dict, status: dict) -> None:
+    for col, _defn, _dtype in UNIPROT_SCHEMA_COLUMNS:
+        if col not in row:
+            row[col] = None
+        status[col] = NO_CHANGE
+
+
+def _cache_key_for_organism(organism):
+    """Produce a stable, hashable cache token for an organism cell."""
+    val = extract_value(organism)
+    if val is None:
+        return None
+    if isinstance(val, list):
+        return tuple(sorted(str(x).strip().lower() for x in val if x))
+    return str(val).strip().lower()

--- a/backend/app/services/uniprot_lookup.py
+++ b/backend/app/services/uniprot_lookup.py
@@ -1,0 +1,386 @@
+"""Stateless UniProt lookup primitives.
+
+Ported from research/experiments/schematiq/NES_expand/enrichment/enrich_from_uniprot.py.
+Uses only Python stdlib (urllib) so no new dependencies are added.
+
+The public surface for callers:
+- lookup_protein(name, organism, alt_names) -> (hit|None, tier, error|None)
+- parse_hit(hit) -> dict of UniProt enrichment columns
+- extract_value(cell) -> plain value from a polymorphic cell
+- is_protein_like_unit(unit_name, unit_definition) -> bool
+- find_input_columns(row_data) -> (protein_col, organism_col, alt_names_col)
+- UNIPROT_SCHEMA_COLUMNS -> [(name, definition, data_type), ...]
+"""
+
+import re
+import urllib.parse
+import urllib.request
+from typing import Optional
+
+UNIPROT_SEARCH_URL = "https://rest.uniprot.org/uniprotkb/search"
+UNIPROT_FIELDS = "accession,gene_names,cc_subcellular_location,xref_pdb,go_p,go_f,go_c,length,sequence"
+
+# Cell status markers (match the existing _cell_status vocabulary styled by the frontend)
+EXTERNAL = "external_source"
+NO_CHANGE = "no_change"
+
+# Common organism -> NCBI taxon ID mapping
+TAXON_MAP = {
+    "homo sapiens": 9606,
+    "human": 9606,
+    "mus musculus": 10090,
+    "mouse": 10090,
+    "rattus norvegicus": 10116,
+    "rat": 10116,
+    "saccharomyces cerevisiae": 559292,
+    "baker's yeast": 559292,
+    "schizosaccharomyces pombe": 4896,
+    "fission yeast": 4896,
+    "drosophila melanogaster": 7227,
+    "fruit fly": 7227,
+    "arabidopsis thaliana": 3702,
+    "gallus gallus": 9031,
+    "chicken": 9031,
+    "xenopus laevis": 8355,
+    "xenopus": 8355,
+    "caenorhabditis elegans": 6239,
+    "canis familiaris": 9615,
+    "dog": 9615,
+    "sus scrofa": 9823,
+    "pig": 9823,
+    "macaca mulatta": 9544,
+    "aspergillus nidulans": 162425,
+    "oryza sativa": 4530,
+    "rice": 4530,
+    "danio rerio": 7955,
+    "zebrafish": 7955,
+    "bos taurus": 9913,
+    "oryctolagus cuniculus": 9986,
+    "rabbit": 9986,
+}
+
+VIRAL_KEYWORDS = [
+    "virus", "viral", "herpes", "hiv", "htlv", "adenovirus", "papillomavirus",
+    "influenza", "sars", "coronavirus", "ebola", "hepatitis", "parvovirus",
+    "baculovirus", "torovirus", "retrovirus", "lentivirus", "densovirus",
+    "newcastle", "sendai", "paramyxo", "chikungunya", "tilapia",
+]
+
+# Columns added by UniProt enrichment, with schema metadata for session registration.
+UNIPROT_SCHEMA_COLUMNS = [
+    ("uniprot_accession", "UniProt accession ID for the protein.", "string"),
+    ("uniprot_url", "Direct URL to the UniProt entry page.", "string"),
+    ("gene_symbol", "Primary gene symbol from UniProt (e.g., NPM1, TP53).", "string"),
+    ("subcellular_localization", "Subcellular localization annotation from UniProt.", "string"),
+    ("protein_length", "Full protein length in amino acids from UniProt.", "number"),
+    ("go_biological_process", "Gene Ontology biological process terms from UniProt.", "string"),
+    ("go_molecular_function", "Gene Ontology molecular function terms from UniProt.", "string"),
+    ("go_cellular_component", "Gene Ontology cellular component terms from UniProt.", "string"),
+    ("pdb_ids", "PDB structure IDs cross-referenced from UniProt.", "array"),
+    ("alphafold_url", "AlphaFold predicted structure URL.", "string"),
+]
+
+UNIPROT_COLUMNS = [c[0] for c in UNIPROT_SCHEMA_COLUMNS]
+
+
+# Keyword allowlist for observation-unit detection. Conservative by design:
+# matches entities UniProt can actually resolve.
+PROTEIN_LIKE_UNIT_KEYWORDS = {
+    "protein", "proteins", "enzyme", "enzymes", "kinase", "kinases",
+    "phosphatase", "phosphatases", "receptor", "receptors",
+    "transcription factor", "antibody", "gene product",
+    "nes protein", "nuclear export signal",
+}
+
+
+def is_protein_like_unit(unit_name: Optional[str], unit_definition: Optional[str] = None) -> bool:
+    """Return True if the observation unit is plausibly resolvable in UniProt.
+
+    Uses a keyword allowlist against the unit name; falls back to the definition
+    only when the name misses and the definition strongly implies a protein
+    context (mentions 'protein' alongside 'sequence' / 'uniprot' / 'gene').
+    """
+    if not unit_name:
+        return False
+    name = unit_name.lower().strip()
+    if name in PROTEIN_LIKE_UNIT_KEYWORDS:
+        return True
+    if any(kw in name for kw in PROTEIN_LIKE_UNIT_KEYWORDS):
+        return True
+    defn = (unit_definition or "").lower()
+    return "protein" in defn and ("sequence" in defn or "uniprot" in defn or "gene" in defn)
+
+
+def find_input_columns(row: dict):
+    """Resolve the row columns carrying protein name, organism, and alt names.
+
+    Handles ScheMatiQ's flat runtime jsonl: cells live at the row top level
+    (e.g. `row['protein_name']`) and metadata keys are `_`-prefixed. Matches
+    columns by normalized name with exact-preference, falling back to a
+    substring match for organism/alt-names (so `protein_species` resolves as
+    organism). Returns (protein_col, organism_col, alt_names_col); protein_col
+    is None when no protein-identifier column exists, in which case the service
+    should skip enrichment.
+    """
+    cols = [k for k in row.keys() if not str(k).startswith("_")]
+    norm = {re.sub(r"[^a-z0-9]", "", str(k).lower()): k for k in cols}
+
+    # Exact-normalized match first. protein_name is kept strict (common English
+    # words like 'name' or 'protein' alone would match too many unrelated cols).
+    exact_aliases = {
+        "protein_name": ["proteinname", "proteinofinterest"],
+        "organism": ["organism", "species", "taxon"],
+        "alternative_names": ["alternativenames", "altnames", "synonyms", "aliases", "genenames"],
+    }
+    # Substring fallback for cases like `protein_species`, `host_organism`.
+    substr_aliases = {
+        "protein_name": [],
+        "organism": ["species", "organism", "taxon"],
+        "alternative_names": ["synonym", "alias", "altname"],
+    }
+
+    def match(target: str) -> Optional[str]:
+        for kw in exact_aliases[target]:
+            if kw in norm:
+                return norm[kw]
+        for kw in substr_aliases[target]:
+            for n, orig in norm.items():
+                if kw in n:
+                    return orig
+        return None
+
+    p = match("protein_name")
+    if not p:
+        return None, None, None
+    return p, match("organism"), match("alternative_names")
+
+
+def extract_value(v):
+    """Extract plain value from a cell (str, dict with 'answer', list, or None)."""
+    if v is None:
+        return None
+    if isinstance(v, str):
+        return v.strip() if v.strip() else None
+    if isinstance(v, dict):
+        ans = v.get("answer")
+        if isinstance(ans, str):
+            return ans.strip() if ans.strip() else None
+        return ans
+    return str(v)
+
+
+def normalize_organism(organism_field):
+    """Extract organism string, taxon id, and viral flag from a polymorphic field."""
+    if organism_field is None:
+        return None, None, False
+
+    if isinstance(organism_field, str):
+        org_str = organism_field.strip()
+    elif isinstance(organism_field, list):
+        for o in organism_field:
+            s = extract_value(o) if isinstance(o, dict) else (o.strip() if isinstance(o, str) else None)
+            if s and "human" in s.lower():
+                org_str = s
+                break
+        else:
+            org_str = extract_value(organism_field[0]) if organism_field else None
+            if not org_str and len(organism_field) > 0:
+                org_str = str(organism_field[0]).strip()
+    elif isinstance(organism_field, dict):
+        org_str = extract_value(organism_field)
+    else:
+        org_str = str(organism_field).strip()
+
+    if isinstance(org_str, list):
+        human = next((o for o in org_str if isinstance(o, str) and "human" in o.lower()), None)
+        org_str = human or (org_str[0] if org_str else None)
+
+    if not org_str or not isinstance(org_str, str):
+        return None, None, False
+
+    org_lower = org_str.lower()
+    is_viral = any(kw in org_lower for kw in VIRAL_KEYWORDS)
+
+    clean = re.sub(r"\s*\(.*?\)\s*", " ", org_str).strip().lower()
+    paren_match = re.search(r"\(([^)]+)\)", org_str)
+    paren_name = paren_match.group(1).strip().lower() if paren_match else None
+
+    taxon_id = TAXON_MAP.get(clean)
+    if taxon_id is None and paren_name:
+        taxon_id = TAXON_MAP.get(paren_name)
+    if taxon_id is None:
+        words = clean.split()
+        if len(words) >= 2:
+            taxon_id = TAXON_MAP.get(f"{words[0]} {words[1]}")
+
+    return org_str, taxon_id, is_viral
+
+
+def extract_gene_symbols(alt_names_field):
+    """Extract likely gene symbols from an alternative-names cell."""
+    raw = extract_value(alt_names_field)
+    if not raw:
+        return []
+
+    if isinstance(raw, list):
+        parts = raw
+    else:
+        parts = re.split(r"[;,]\s*", str(raw))
+
+    symbols = []
+    for part in parts:
+        part = str(part).strip()
+        if re.match(r"^[A-Z][A-Z0-9]{1,11}$", part):
+            symbols.append(part)
+    return symbols
+
+
+def clean_protein_name(name):
+    """Remove paper-context suffixes like [paper_name...] from protein names."""
+    return re.sub(r"\s*\[.*?\]\s*$", "", name).strip()
+
+
+def query_uniprot(query_str, fields=UNIPROT_FIELDS, size=5):
+    """Query the UniProt REST API. Returns (rows_list, error_msg_or_None)."""
+    params = {
+        "query": query_str,
+        "fields": fields,
+        "format": "tsv",
+        "size": str(size),
+    }
+    url = f"{UNIPROT_SEARCH_URL}?{urllib.parse.urlencode(params)}"
+
+    req = urllib.request.Request(url)
+    req.add_header("User-Agent", "ScheMatiQ-Enrichment/1.0 (+https://github.com/shaharl6000/QueryDiscovery)")
+
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            text = resp.read().decode("utf-8")
+    except Exception as e:
+        return [], str(e)
+
+    lines = text.strip().split("\n")
+    if len(lines) < 2:
+        return [], None
+
+    headers = lines[0].split("\t")
+    results = []
+    for line in lines[1:]:
+        vals = line.split("\t")
+        row = dict(zip(headers, vals))
+        results.append(row)
+
+    return results, None
+
+
+def pick_best_hit(hits, protein_name):
+    """Pick the best UniProt hit; prefers exact name match, else first."""
+    if not hits:
+        return None
+    if len(hits) == 1:
+        return hits[0]
+
+    clean_name = clean_protein_name(protein_name).lower()
+    for hit in hits:
+        rec_name = hit.get("Protein names", "").lower()
+        if clean_name in rec_name:
+            return hit
+    return hits[0]
+
+
+def lookup_protein(protein_name, organism_field, alt_names_field):
+    """Three-tier UniProt lookup. Returns (hit|None, tier_used, error|None)."""
+    if not protein_name:
+        return None, "no_input", None
+
+    name = clean_protein_name(str(protein_name))
+    if not name:
+        return None, "no_input", None
+
+    org_str, taxon_id, is_viral = normalize_organism(organism_field)
+
+    # Tier 1: exact protein name + organism + reviewed
+    if taxon_id and not is_viral:
+        query = f'protein_name:"{name}" AND organism_id:{taxon_id} AND reviewed:true'
+        hits, _err = query_uniprot(query)
+        if hits:
+            return pick_best_hit(hits, name), "tier1_name", None
+        query = f'({name}) AND organism_id:{taxon_id} AND reviewed:true'
+        hits, _err = query_uniprot(query, size=3)
+        if hits:
+            return pick_best_hit(hits, name), "tier1_fuzzy", None
+
+    # Tier 2: gene symbol from alternative_names
+    gene_symbols = extract_gene_symbols(alt_names_field)
+    if gene_symbols and taxon_id:
+        for symbol in gene_symbols[:3]:
+            query = f"gene:{symbol} AND organism_id:{taxon_id} AND reviewed:true"
+            hits, _err = query_uniprot(query, size=3)
+            if hits:
+                return pick_best_hit(hits, name), "tier2_gene", None
+
+    # Tier 3: viral fallback
+    if is_viral and org_str:
+        virus_name = re.sub(r"\s*\(.*?\)\s*", " ", org_str).strip()
+        query = f'protein_name:"{name}" AND taxonomy_name:"{virus_name}"'
+        hits, _err = query_uniprot(query)
+        if hits:
+            return pick_best_hit(hits, name), "tier3_viral", None
+        if gene_symbols:
+            for symbol in gene_symbols[:2]:
+                query = f'gene:{symbol} AND taxonomy_name:"{virus_name}"'
+                hits, _err = query_uniprot(query, size=3)
+                if hits:
+                    return pick_best_hit(hits, name), "tier3_viral_gene", None
+
+    # Tier 3b: no-organism fallback
+    if not org_str or (not taxon_id and not is_viral):
+        query = f'protein_name:"{name}" AND reviewed:true'
+        hits, _err = query_uniprot(query, size=3)
+        if hits:
+            return pick_best_hit(hits, name), "tier3_no_org", None
+        if gene_symbols:
+            for symbol in gene_symbols[:2]:
+                query = f"gene:{symbol} AND reviewed:true"
+                hits, _err = query_uniprot(query, size=3)
+                if hits:
+                    return pick_best_hit(hits, name), "tier3_no_org_gene", None
+
+    return None, "no_match", None
+
+
+def parse_hit(hit):
+    """Parse a UniProt TSV hit into enrichment columns, or None if unparseable."""
+    accession = hit.get("Entry", "").strip()
+    if not accession:
+        return None
+
+    gene_names = hit.get("Gene Names", "").strip()
+    gene_symbol = gene_names.split()[0] if gene_names else None
+
+    subcel = hit.get("Subcellular location [CC]", "").strip()
+    subcel = re.sub(r"^SUBCELLULAR LOCATION:\s*", "", subcel)
+    subcel = subcel if subcel else None
+
+    pdb_raw = hit.get("PDB", "").strip()
+    pdb_ids = [p.strip() for p in pdb_raw.split(";") if p.strip()] if pdb_raw else None
+
+    go_p = hit.get("Gene Ontology (biological process)", "").strip() or None
+    go_f = hit.get("Gene Ontology (molecular function)", "").strip() or None
+    go_c = hit.get("Gene Ontology (cellular component)", "").strip() or None
+
+    length_str = hit.get("Length", "").strip()
+    length = int(length_str) if length_str.isdigit() else None
+
+    return {
+        "uniprot_accession": accession,
+        "uniprot_url": f"https://www.uniprot.org/uniprotkb/{accession}/entry",
+        "gene_symbol": gene_symbol,
+        "subcellular_localization": subcel,
+        "protein_length": length,
+        "go_biological_process": go_p,
+        "go_molecular_function": go_f,
+        "go_cellular_component": go_c,
+        "pdb_ids": pdb_ids,
+        "alphafold_url": f"https://alphafold.ebi.ac.uk/entry/{accession}",
+    }

--- a/backend/app/services/upload_document_processor.py
+++ b/backend/app/services/upload_document_processor.py
@@ -37,10 +37,11 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
     METADATA_COLUMNS = {'papers', 'document_directory', 'row_name', '_row_name', '_papers', '_metadata'}
 
     def __init__(self, websocket_manager: WebSocketManager, session_manager: SessionManager,
-                 pubmed_enrichment_service=None):
+                 pubmed_enrichment_service=None, uniprot_enrichment_service=None):
         super().__init__(websocket_manager)
         self.session_manager = session_manager
         self._pubmed_enrichment_service = pubmed_enrichment_service
+        self._uniprot_enrichment_service = uniprot_enrichment_service
         self.running_sessions: Dict[str, bool] = {}
         self._state_lock = threading.Lock()
 
@@ -390,6 +391,12 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             # Enrich source documents with PubMed/DOI links (fire-and-forget)
             if self._pubmed_enrichment_service:
                 await self._pubmed_enrichment_service.enrich_session(session_id)
+
+            # Enrich protein rows with UniProt data (fire-and-forget, protein units only).
+            # This is the "new rows after upload" hook — only rows without a uniprot_accession
+            # are processed, so existing enriched rows stay untouched.
+            if self._uniprot_enrichment_service:
+                await self._uniprot_enrichment_service.enrich_session(session_id)
 
         except Exception as e:
             # Update session with error


### PR DESCRIPTION
## Summary
- Ports the NES_expand research UniProt lookup (`research/experiments/schematiq/NES_expand/enrichment/enrich_from_uniprot.py`) into the backend as a fire-and-forget service modelled on `PubMedEnrichmentService`.
- Auto-detects protein-like observation units via a keyword allowlist (`protein`, `kinase`, `enzyme`, etc.) and skips silently otherwise. Requires a resolvable `protein_name`-like column (substring fallback handles variants like `protein_species` for organism).
- Row-level enrichment: adds 10 UniProt columns (`uniprot_accession`, `uniprot_url`, `gene_symbol`, `subcellular_localization`, `protein_length`, GO terms x3, `pdb_ids`, `alphafold_url`) and marks cells with `_cell_status: "external_source"` — the existing DataTable blue-border style renders provenance for free.
- Idempotent: only rows missing a `uniprot_accession` are processed, so adding documents to an already-enriched session enriches only the new rows and leaves existing ones untouched.
- Hooked into all four completion points already used by PubMed enrichment (schematiq runner partial + full, continue-discovery x2, reextraction, upload-document-processor), wired via DI from the schematiq/load/schema routes.

## Implementation notes
- `backend/app/services/uniprot_lookup.py` — stateless HTTP primitives (Python stdlib only, no new deps), plus `is_protein_like_unit()` and `find_input_columns()` with filter-`_`-prefixed + exact-then-substring column matching.
- `backend/app/services/uniprot_enrichment_service.py` — per-session orchestration with `_in_progress` dedup, per-session protein cache, atomic `.jsonl.tmp` + rename, column registration on the session.
- Reads/writes the flat runtime row shape (cells at row top level, `_`-prefixed metadata) — not the nested `{"data": {...}}` format of the offline research artifact. CLAUDE.md updated with this distinction so future work doesn't repeat the pitfall.

## Test plan
- [ ] Start backend + frontend, create a ScheMatiQ session on a protein-centric query (e.g. NES dataset). After extraction, confirm 10 new UniProt columns appear and cells render with the blue `external_source` border.
- [ ] Upload additional documents to that session. Verify log shows `pending = <N>` where N matches only the new rows; pre-existing UniProt values untouched.
- [ ] Create a session with a non-protein unit (e.g. "Model-Benchmark Evaluation"). Confirm log shows the detection gate skipping it.
- [ ] Hit Reextract on the enriched session. Confirm the hook re-fires but pending = 0 and UniProt columns are preserved.
- [ ] Visit `uniprot_url` and `alphafold_url` in the DataTable — if not clickable as-is, we may need a small `_url`-column rendering tweak on the frontend (not included in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)