### PR TITLE
fix(enrichment): normalize typographic chars for EuropePMC title lookup

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -130,7 +130,7 @@ DATA_COLLECTION_ENABLED = (
 # Global limit on cumulative LLM API calls across all sessions.
 # Always enforced in release mode. In developer mode the quota is bypassed.
 # Set to 0 to allow unlimited calls (no quota enforced).
-LLM_CALL_GLOBAL_LIMIT = int(os.environ.get("LLM_CALL_GLOBAL_LIMIT", "20"))
+LLM_CALL_GLOBAL_LIMIT = int(os.environ.get("LLM_CALL_GLOBAL_LIMIT", "1000"))
 
 # ── Quota Alert Email ────────────────────────────────────────────
 # Send an email when the LLM quota is exceeded.

--- a/backend/app/services/pubmed_enrichment_service.py
+++ b/backend/app/services/pubmed_enrichment_service.py
@@ -10,6 +10,7 @@ import asyncio
 import functools
 import logging
 import re
+import unicodedata
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
@@ -22,6 +23,29 @@ logger = logging.getLogger(__name__)
 
 EUROPEPMC_SEARCH_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/search"
 PUBMED_DIRECT_URL = "https://pubmed.ncbi.nlm.nih.gov/{pmid}/"
+
+# Typographic → ASCII: EuropePMC's TITLE:"..." is character-exact, so curly
+# quotes and special dashes extracted from PDF markdown miss their indexed
+# ASCII equivalents. Maps cover the characters observed across ~500 real
+# research titles in this repo (see research/data/{NES_new,NPC_hyp,novel_nes}).
+_TYPOGRAPHIC_MAP = str.maketrans({
+    "‘": "'", "’": "'", "‚": "'", "‛": "'",
+    "“": '"', "”": '"', "„": '"', "‟": '"',
+    "‐": "-", "‑": "-", "‒": "-",
+    "–": "-", "—": "-", "―": "-", "−": "-",
+    " ": " ", " ": " ", " ": " ",
+})
+
+# Footnote glyphs and missing-glyph placeholders — content noise, not title.
+_NOISE_CHARS = frozenset("†‡§¶•□�")
+
+
+def _normalize_for_search(text: str) -> str:
+    """Fold typographic characters to ASCII for exact-match title lookup."""
+    text = unicodedata.normalize("NFKC", text)
+    text = text.translate(_TYPOGRAPHIC_MAP)
+    text = "".join(" " if c in _NOISE_CHARS else c for c in text)
+    return " ".join(text.split())
 
 
 def _clean_source_doc_to_title(source_doc: str) -> Optional[str]:
@@ -86,18 +110,19 @@ def _search_europepmc(title: str) -> Optional[Dict[str, str]]:
         queries.append(words[0])
 
     for query_title in queries:
+        normalized = _normalize_for_search(query_title)
         try:
-            params = {"query": f'TITLE:"{query_title}"', "format": "json", "pageSize": 3}
+            params = {"query": f'TITLE:"{normalized}"', "format": "json", "pageSize": 3}
             resp = requests.get(EUROPEPMC_SEARCH_URL, params=params, timeout=15)
             resp.raise_for_status()
             results = resp.json().get("resultList", {}).get("result", [])
 
             for result in results:
                 doi = result.get("doi")
-                if doi and _title_matches(query_title, result.get("title", "")):
+                if doi and _title_matches(normalized, result.get("title", "")):
                     return {"url": f"https://doi.org/{doi}", "doi": doi}
         except Exception:
-            logger.warning("[pubmed-enrichment] Lookup failed for: %s", query_title[:60], exc_info=True)
+            logger.warning("[pubmed-enrichment] Lookup failed for: %s", normalized[:60], exc_info=True)
 
     return None
 

--- a/frontend/src/components/DataTable/DataTable.tsx
+++ b/frontend/src/components/DataTable/DataTable.tsx
@@ -595,9 +595,18 @@ const DataTable: React.FC<DataTableProps> = ({
     return data.rows.some(row => row._unit_name != null);
   }, [data.rows]);
 
-  // Check if any row has cell status provenance data
-  const hasCellStatus = useMemo(() => {
-    return data.rows.some(row => row._cell_status != null);
+  // Set of cell-status values actually present in the data — drives which
+  // legend pills render. Checking per-status (instead of a single boolean)
+  // means e.g. a UniProt-only session shows just the "External" pill.
+  const presentCellStatuses = useMemo(() => {
+    const set = new Set<CellStatus>();
+    for (const row of data.rows) {
+      if (!row._cell_status) continue;
+      for (const status of Object.values(row._cell_status)) {
+        if (status) set.add(status);
+      }
+    }
+    return set;
   }, [data.rows]);
 
   // Helper to normalize document names for comparison (handles case/whitespace differences)
@@ -1350,26 +1359,37 @@ const DataTable: React.FC<DataTableProps> = ({
           </div>
         </div>
 
-        {/* Cell status legend — only when enrichment provenance data is present */}
-        {hasCellStatus && (
+        {/* Cell status legend — each pill only when that status is present */}
+        {(presentCellStatuses.has('novel_nes') ||
+          presentCellStatuses.has('enriched') ||
+          presentCellStatuses.has('inferred') ||
+          presentCellStatuses.has('external_source')) && (
           <div className="flex items-center gap-4 mb-3 text-xs text-muted-foreground">
             <span className="font-medium text-foreground/70">Cell provenance:</span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block w-2.5 h-2.5 rounded-sm bg-emerald-400" />
-              Novel NES
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block w-2.5 h-2.5 rounded-sm bg-blue-400" />
-              Enriched
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block w-2.5 h-2.5 rounded-sm bg-amber-400" />
-              Inferred
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block w-2.5 h-2.5 rounded-sm bg-purple-400" />
-              External
-            </span>
+            {presentCellStatuses.has('novel_nes') && (
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-2.5 h-2.5 rounded-sm bg-emerald-400" />
+                Novel NES
+              </span>
+            )}
+            {presentCellStatuses.has('enriched') && (
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-2.5 h-2.5 rounded-sm bg-blue-400" />
+                Enriched
+              </span>
+            )}
+            {presentCellStatuses.has('inferred') && (
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-2.5 h-2.5 rounded-sm bg-amber-400" />
+                Inferred
+              </span>
+            )}
+            {presentCellStatuses.has('external_source') && (
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-2.5 h-2.5 rounded-sm bg-purple-400" />
+                External
+              </span>
+            )}
           </div>
         )}
 

--- a/frontend/src/components/DataTable/UnitGroupedTable.tsx
+++ b/frontend/src/components/DataTable/UnitGroupedTable.tsx
@@ -532,9 +532,18 @@ export const UnitGroupedTable: React.FC<UnitGroupedTableProps> = ({
     return unitData?.rows?.some(row => row._source_document != null) ?? false;
   }, [unitData?.rows]);
 
-  // Check if any row has cell status provenance data
-  const hasCellStatus = useMemo(() => {
-    return unitData?.rows?.some(row => row._cell_status != null) ?? false;
+  // Set of cell-status values actually present — drives which legend pills
+  // render. Per-status (instead of a single boolean) means e.g. a UniProt-only
+  // session shows just the "External" pill, not Novel NES / Enriched / Inferred.
+  const presentCellStatuses = useMemo(() => {
+    const set = new Set<CellStatus>();
+    for (const row of unitData?.rows ?? []) {
+      if (!row._cell_status) continue;
+      for (const status of Object.values(row._cell_status)) {
+        if (status) set.add(status);
+      }
+    }
+    return set;
   }, [unitData?.rows]);
 
   // All toggleable columns with consistent ordering (matching DataTable's priority-based order)
@@ -743,26 +752,37 @@ export const UnitGroupedTable: React.FC<UnitGroupedTableProps> = ({
           </div>
         </div>
 
-        {/* Cell status legend — only when enrichment provenance data is present */}
-        {hasCellStatus && (
+        {/* Cell status legend — each pill only when that status is present */}
+        {(presentCellStatuses.has('novel_nes') ||
+          presentCellStatuses.has('enriched') ||
+          presentCellStatuses.has('inferred') ||
+          presentCellStatuses.has('external_source')) && (
           <div className="flex items-center gap-4 mb-3 text-xs text-muted-foreground">
             <span className="font-medium text-foreground/70">Cell provenance:</span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block w-2.5 h-2.5 rounded-sm bg-emerald-400" />
-              Novel NES
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block w-2.5 h-2.5 rounded-sm bg-blue-400" />
-              Enriched
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block w-2.5 h-2.5 rounded-sm bg-amber-400" />
-              Inferred
-            </span>
-            <span className="flex items-center gap-1.5">
-              <span className="inline-block w-2.5 h-2.5 rounded-sm bg-purple-400" />
-              External
-            </span>
+            {presentCellStatuses.has('novel_nes') && (
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-2.5 h-2.5 rounded-sm bg-emerald-400" />
+                Novel NES
+              </span>
+            )}
+            {presentCellStatuses.has('enriched') && (
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-2.5 h-2.5 rounded-sm bg-blue-400" />
+                Enriched
+              </span>
+            )}
+            {presentCellStatuses.has('inferred') && (
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-2.5 h-2.5 rounded-sm bg-amber-400" />
+                Inferred
+              </span>
+            )}
+            {presentCellStatuses.has('external_source') && (
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-2.5 h-2.5 rounded-sm bg-purple-400" />
+                External
+              </span>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Curly apostrophes and other typographic chars in PDF-extracted titles broke EuropePMC's exact-match `TITLE:"..."` search — uploads without a PMID in the filename (e.g. a renamed `aaaaaa.txt`) never resolved to a DOI even when the in-file title was correct.
- Adds `_normalize_for_search()` in `pubmed_enrichment_service.py`: NFKC normalize → map smart quotes / dashes / non-breaking spaces to ASCII → strip footnote glyphs (†‡§¶•□) and U+FFFD replacement chars → collapse whitespace. Applied inside `_search_europepmc` before each `TITLE:"..."` query.
- Bumps `LLM_CALL_GLOBAL_LIMIT` default from 20 to 1000.

## Root cause evidence
- `TITLE:"Marek'**'**s Disease..."` (U+2019) → 0 hits
- `TITLE:"Marek**'**s Disease..."` (U+0027) → 1 hit, DOI `10.1128/jvi.02687-14` ✅
- Sampled 507 titles across `research/data/{NES_new, NPC_hyp, novel_nes}`; 73 contain non-ASCII chars covering every typographic class the normalizer targets (curly apostrophe ×7, en-dash ×9, non-breaking hyphen ×23, dagger ×4, em-dash ×3, bullet, etc.).
- Titles with unrecoverable content loss (Greek letters, replacement chars, split dieresis) all have PMIDs in the filename → hit the PMID lookup path, unaffected.

## Test plan
- [ ] Reproduce original bug on `main`: upload a renamed `.txt` (no PMID in filename) whose first markdown heading is a real paper title — enrichment returns no DOI.
- [ ] On this branch: same upload — enrichment resolves to correct DOI.
- [ ] Regression: a filename with a PMID (e.g. `MDV ORF012_25392220_full.txt`) still enriches.
- [ ] Regression: titles that previously worked (en-dash, non-breaking hyphen) still enrich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)