### PR TITLE
fix: resolve Gemini 400 errors and output truncation in value extraction

### DIFF
--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -75,7 +75,6 @@ class PaperProcessor:
         on_value_extracted: Optional[OnValueExtractedCallback] = None,
         should_stop: Optional[ShouldStopCallback] = None,
         on_warning: Optional[OnWarningCallback] = None,
-        on_document_started: Optional[Callable[[str], None]] = None,
     ):
         self.llm = llm
         self.cache = cache or LLMCache()
@@ -87,7 +86,6 @@ class PaperProcessor:
         self.on_value_extracted = on_value_extracted
         self.should_stop = should_stop
         self.on_warning = on_warning
-        self.on_document_started = on_document_started
         # Schema evolution tracking: {column_name: {value: [list of documents]}}
         self.suggested_values: Dict[str, Dict[str, list]] = {}
         # Cache for fallback retriever (created on-demand, reused across papers)
@@ -108,21 +106,32 @@ class PaperProcessor:
         return getattr(self.llm, "_provider", "") == "gemini"
 
     def _build_response_schema(self, columns):
-        """Build response_schema for Gemini controlled generation, or None."""
+        """Build (response_schema, key_map) for Gemini controlled generation.
+
+        Returns (None, {}) when controlled generation is disabled or unavailable.
+        key_map maps sanitized property names back to original column names and
+        is non-empty only when column names required sanitization (e.g. hyphens).
+        """
         if not ENABLE_CONTROLLED_GENERATION or not self._is_gemini_backend():
-            return None
-        return build_extraction_response_schema(columns)
+            return None, {}
+        schema, key_map = build_extraction_response_schema(columns)
+        return schema, key_map
+
+    @staticmethod
+    def _remap_response_keys(parsed: dict, key_map: dict) -> dict:
+        """Restore original column names in a parsed response dict.
+
+        When controlled generation sanitized column names (e.g. "IssueCourt-1"
+        → "IssueCourt_1"), the model returns sanitized keys.  This swaps them
+        back to the originals before postprocessing, which expects original names.
+        """
+        if not key_map:
+            return parsed
+        return {key_map.get(k, k): v for k, v in parsed.items()}
 
     def _gemini_kwargs(self, thinking_budget: int = 0) -> dict:
-        """Build Gemini-specific kwargs (thinking_budget). Returns empty dict for non-Gemini.
-
-        Omits thinking_budget entirely for models that don't support thinking_config
-        (e.g. lite models), since sending it alongside response_schema causes a
-        400 INVALID_ARGUMENT error from the Gemini API.
-        """
+        """Build Gemini-specific kwargs (thinking_budget). Returns empty dict for non-Gemini."""
         if not self._is_gemini_backend():
-            return {}
-        if not getattr(self.llm, "supports_thinking", False):
             return {}
         return {"thinking_budget": thinking_budget}
 
@@ -460,9 +469,10 @@ class PaperProcessor:
             safety_margins=SAFETY_MARGIN_ALL_MODE,
             context_window_size=max_ctx,
         )
+        resp_schema, key_map = self._build_response_schema(columns)
         raw = self._generate(
             trimmed,
-            response_schema=self._build_response_schema(columns),
+            response_schema=resp_schema,
             **self._gemini_kwargs(thinking_budget=0),
         )
         # Check stop immediately after LLM call returns
@@ -471,7 +481,7 @@ class PaperProcessor:
             return {}
 
         try:
-            parsed = self.json_parser.parse_response(raw)
+            parsed = self._remap_response_keys(self.json_parser.parse_response(raw), key_map)
             requested = [c.name for c in columns]
             # Build allowed_values dict for postprocessing
             column_allowed_values = {
@@ -584,9 +594,10 @@ class PaperProcessor:
                 safety_margins=SAFETY_MARGIN_SINGLE_MODE,
                 context_window_size=max_ctx,
             )
+            resp_schema, key_map = self._build_response_schema([col])
             raw = self._generate(
                 trimmed,
-                response_schema=self._build_response_schema([col]),
+                response_schema=resp_schema,
                 **self._gemini_kwargs(thinking_budget=0),
             )
             # Check stop immediately after LLM call returns
@@ -596,7 +607,7 @@ class PaperProcessor:
                 )
                 return {}
             try:
-                parsed = self.json_parser.parse_response(raw)
+                parsed = self._remap_response_keys(self.json_parser.parse_response(raw), key_map)
                 # Build allowed_values dict for postprocessing
                 column_allowed_values = (
                     {col.name: col.allowed_values} if col.allowed_values else {}
@@ -637,9 +648,10 @@ class PaperProcessor:
                 safety_margins=SAFETY_MARGIN_ALL_MODE,
                 context_window_size=max_ctx,
             )
+            resp_schema, key_map = self._build_response_schema(list(schema.columns))
             raw = self._generate(
                 trimmed,
-                response_schema=self._build_response_schema(list(schema.columns)),
+                response_schema=resp_schema,
                 **self._gemini_kwargs(thinking_budget=0),
             )
             # Check stop immediately after LLM call returns
@@ -649,7 +661,7 @@ class PaperProcessor:
                 )
                 return cleaned  # Return what we have so far
             try:
-                parsed = self.json_parser.parse_response(raw)
+                parsed = self._remap_response_keys(self.json_parser.parse_response(raw), key_map)
             except Exception as e:
                 print(f"⚠️  parse failure for {paper_title}: {e}")
                 parsed = {}
@@ -706,14 +718,17 @@ class PaperProcessor:
                     safety_margins=SAFETY_MARGIN_ALL_MODE,
                     context_window_size=max_ctx,
                 )
+                resp_schema_re, key_map_re = self._build_response_schema(reordered)
                 raw_re = self._generate(
                     trimmed_re,
-                    response_schema=self._build_response_schema(reordered),
+                    response_schema=resp_schema_re,
                     **self._gemini_kwargs(thinking_budget=0),
                 )
                 if not self._check_stop_requested():
                     try:
-                        parsed_re = self.json_parser.parse_response(raw_re)
+                        parsed_re = self._remap_response_keys(
+                            self.json_parser.parse_response(raw_re), key_map_re
+                        )
                         reorder_allowed = {
                             c.name: c.allowed_values
                             for c in reordered
@@ -1140,7 +1155,7 @@ class PaperProcessor:
         )
 
         raw_response = self.llm.generate(
-            trimmed, max_output_tokens=task_tokens, **self._gemini_kwargs(thinking_budget=512)
+            trimmed, max_output_tokens=task_tokens, **self._gemini_kwargs(thinking_budget=1024)
         )
 
         # Log raw response for diagnostics (truncated for readability)
@@ -1367,10 +1382,11 @@ class PaperProcessor:
             context_window_size=max_ctx,
         )
 
+        resp_schema, key_map = self._build_response_schema(list(schema.columns))
         raw = self._generate(
             trimmed,
             max_output_tokens=effective_max,
-            response_schema=self._build_response_schema(list(schema.columns)),
+            response_schema=resp_schema,
             **self._gemini_kwargs(thinking_budget=0),
         )
 
@@ -1378,7 +1394,7 @@ class PaperProcessor:
             return {}
 
         try:
-            parsed = self.json_parser.parse_response(raw)
+            parsed = self._remap_response_keys(self.json_parser.parse_response(raw), key_map)
             requested = [c.name for c in schema.columns]
             column_allowed_values = {
                 c.name: c.allowed_values for c in schema.columns if c.allowed_values

--- a/schematiq-lib/schematiq/value_extraction/utils/schema_builder.py
+++ b/schematiq-lib/schematiq/value_extraction/utils/schema_builder.py
@@ -1,50 +1,46 @@
 """Build Gemini response_schema for controlled generation during value extraction."""
 
-import logging
 import re
-from typing import Optional
-
-logger = logging.getLogger(__name__)
+from typing import Dict, Optional, Tuple
 
 # Gemini response_schema property names must match this pattern.
 # Names with hyphens, spaces, or other special characters cause a 400 INVALID_ARGUMENT.
 _GEMINI_PROP_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
-
-def _all_names_valid(columns) -> bool:
-    """Return True if every column name is a valid Gemini response_schema property name."""
-    return all(_GEMINI_PROP_NAME_RE.match(col.name) for col in columns)
+# Characters not allowed in Gemini property names, replaced with underscore.
+_SANITIZE_RE = re.compile(r"[^a-zA-Z0-9_]")
 
 
-def build_extraction_response_schema(columns) -> Optional[dict]:
+def _sanitize_name(name: str) -> str:
+    """Replace characters invalid for Gemini response_schema property names with '_'."""
+    return _SANITIZE_RE.sub("_", name)
+
+
+def build_extraction_response_schema(
+    columns,
+) -> Tuple[dict, Dict[str, str]]:
     """Build Gemini response_schema for value extraction output.
 
-    Creates a JSON Schema-compatible dict where each column is an optional
-    top-level property containing answer (STRING) and excerpts (ARRAY).
-
-    Returns None if any column name contains characters that Gemini rejects as
-    response_schema property keys (e.g. hyphens like "IssueCourt-1"), which
-    would cause a 400 INVALID_ARGUMENT error. Callers should skip controlled
-    generation when None is returned and let the model output free-form JSON.
+    Sanitizes column names that contain characters Gemini rejects as property
+    keys (e.g. hyphens in "IssueCourt-1" → "IssueCourt_1") so controlled
+    generation always works.  Returns the schema together with a reverse mapping
+    from sanitized name → original name so callers can restore the original keys
+    after parsing the response.
 
     Args:
         columns: List of Column objects with .name attribute.
 
     Returns:
-        Dict suitable for Gemini's response_schema parameter, or None if any
-        column name is invalid for use as a Gemini schema property.
+        (schema_dict, key_map) where:
+          - schema_dict is suitable for Gemini's response_schema parameter.
+          - key_map maps each sanitized property name back to the original
+            column name.  Empty when no sanitization was needed.
     """
-    if not _all_names_valid(columns):
-        invalid = [col.name for col in columns if not _GEMINI_PROP_NAME_RE.match(col.name)]
-        # Column names with hyphens or other special characters (e.g. "IssueCourt-1")
-        # cause Gemini to return 400 INVALID_ARGUMENT. Fall back to free-form JSON output.
-        logger.warning(
-            "⚠️  Controlled generation disabled: %d column name(s) contain characters "
-            "not allowed in Gemini response_schema properties: %s. "
-            "Falling back to free-form JSON output.",
-            len(invalid), invalid,
-        )
-        return None
+    key_map: Dict[str, str] = {}
+    for col in columns:
+        sanitized = _sanitize_name(col.name)
+        if sanitized != col.name:
+            key_map[sanitized] = col.name
 
     column_schema = {
         "type": "OBJECT",
@@ -58,10 +54,11 @@ def build_extraction_response_schema(columns) -> Optional[dict]:
 
     properties = {}
     for col in columns:
-        properties[col.name] = column_schema
+        properties[_sanitize_name(col.name)] = column_schema
 
-    return {
+    schema = {
         "type": "OBJECT",
         "properties": properties,
         # No "required" key — all columns are optional so the model can omit unfound ones
     }
+    return schema, key_map


### PR DESCRIPTION
- schema_builder: sanitize column names for Gemini response_schema instead of disabling controlled generation; replaces invalid characters (e.g. hyphens in "IssueCourt-1") with underscores and returns a key_map for remapping sanitized keys back to original names after parsing
- paper_processor: _build_response_schema now returns (schema, key_map); all six call sites unpack the tuple and call _remap_response_keys before postprocessing so original column names are preserved end-to-end
- model_specs: add supports_thinking flag to ModelSpec; all current Gemini models support thinking_config, _default does not
- llm_backends: gate thinking_config on supports_thinking to prevent 400s; disable automatic function calling (AFC) on all Gemini calls; upgrade MAX_TOKENS finish_reason to a WARNING log with model and token limit value
- constants: double DEFAULT_MAX_NEW_TOKENS from 2048 to 4096 to prevent truncation when extracting large schemas (74+ columns)
- paper_processor: include raw response in the parse-failure warning log

Made-with: Cursor