### PR TITLE
Batch large schemas for controlled generation, set extraction temp=0, remove AFC

### DIFF
--- a/schematiq-lib/schematiq/core/llm_backends.py
+++ b/schematiq-lib/schematiq/core/llm_backends.py
@@ -631,9 +631,6 @@ class GeminiLLM(LLMInterface):
             "max_output_tokens": kwargs.get("max_output_tokens", self.max_output_tokens),
             "temperature": kwargs.get("temperature", self.temperature),
             "safety_settings": self.safety_settings,
-            "automatic_function_calling": self.types.AutomaticFunctionCallingConfig(
-                disable=True
-            ),
         }
         # Add system instruction
         if system_instruction:
@@ -810,9 +807,6 @@ class GeminiLLM(LLMInterface):
             "temperature": kwargs.get("temperature", self.temperature),
             "safety_settings": self.safety_settings,
             "cached_content": cache.name,
-            "automatic_function_calling": self.types.AutomaticFunctionCallingConfig(
-                disable=True
-            ),
         }
         if kwargs.get("response_schema") is not None:
             config_kwargs["response_mime_type"] = "application/json"

--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -115,6 +115,13 @@ class PaperProcessor:
         if not ENABLE_CONTROLLED_GENERATION or not self._is_gemini_backend():
             return None, {}
         schema, key_map = build_extraction_response_schema(columns)
+        if schema is not None:
+            logging.info(
+                "[controlled-gen] ACTIVE — %d columns, %d sanitized key(s): %s",
+                len(columns),
+                len(key_map),
+                list(key_map.items()) if key_map else "none",
+            )
         return schema, key_map
 
     @staticmethod
@@ -370,7 +377,7 @@ class PaperProcessor:
             safety_margins=SAFETY_MARGIN_SINGLE_MODE,
             context_window_size=max_ctx,
         )
-        raw = self._generate(trimmed, **self._gemini_kwargs(thinking_budget=0))
+        raw = self._generate(trimmed, temperature=0, **self._gemini_kwargs(thinking_budget=0))
         # Check stop immediately after LLM call returns
         if self._check_stop_requested():
             print(f"🛑 Stop requested after LLM call, returning empty")
@@ -472,6 +479,7 @@ class PaperProcessor:
         resp_schema, key_map = self._build_response_schema(columns)
         raw = self._generate(
             trimmed,
+            temperature=0,
             response_schema=resp_schema,
             **self._gemini_kwargs(thinking_budget=0),
         )
@@ -597,6 +605,7 @@ class PaperProcessor:
             resp_schema, key_map = self._build_response_schema([col])
             raw = self._generate(
                 trimmed,
+                temperature=0,
                 response_schema=resp_schema,
                 **self._gemini_kwargs(thinking_budget=0),
             )
@@ -628,63 +637,87 @@ class PaperProcessor:
                 return {}
 
         if mode == "all":
-            # joint retrieval + one call
-            eff = _retrieve_effective_text(list(schema.columns))
-            msgs = self.prompt_builder.build_val_messages(
-                schema.query,
-                paper_title,
-                eff,
-                [c.to_dict() for c in schema.columns],
-                mode="all",
-                strict=False,
+            from schematiq.value_extraction.utils.schema_builder import (
+                _MAX_COLUMNS_FOR_CONTROLLED_GENERATION,
             )
-            # Skip truncation for long context models
+
+            eff = _retrieve_effective_text(list(schema.columns))
             should_truncate = not self._should_skip_truncation()
             max_ctx = getattr(self.llm, "context_window_size", None) or 8192
-            trimmed = utils.fit_prompt(
-                msgs,
-                truncate=should_truncate,
-                max_new=max_new_tokens,
-                safety_margins=SAFETY_MARGIN_ALL_MODE,
-                context_window_size=max_ctx,
+
+            all_columns = list(schema.columns)
+            col_batches = list(
+                _chunk_list(all_columns, _MAX_COLUMNS_FOR_CONTROLLED_GENERATION)
             )
-            resp_schema, key_map = self._build_response_schema(list(schema.columns))
-            raw = self._generate(
-                trimmed,
-                response_schema=resp_schema,
-                **self._gemini_kwargs(thinking_budget=0),
-            )
-            # Check stop immediately after LLM call returns
-            if self._check_stop_requested():
-                print(
-                    f"🛑 Stop requested after all-mode LLM call, returning partial results"
+            if len(col_batches) > 1:
+                logging.info(
+                    "[extract_values_for_paper] %d columns → %d batches of ≤%d for %r",
+                    len(all_columns),
+                    len(col_batches),
+                    _MAX_COLUMNS_FOR_CONTROLLED_GENERATION,
+                    paper_title,
                 )
-                return cleaned  # Return what we have so far
-            try:
-                parsed = self._remap_response_keys(self.json_parser.parse_response(raw), key_map)
-            except Exception as e:
-                print(f"⚠️  parse failure for {paper_title}: {e}")
-                parsed = {}
 
-            requested = [c.name for c in schema.columns]
-            # Build allowed_values dict for postprocessing
-            column_allowed_values = {
-                c.name: c.allowed_values for c in schema.columns if c.allowed_values
-            }
-            cleaned, unmatched = self.json_parser.postprocess(
-                parsed, requested, column_allowed_values
-            )
+            for batch_idx, col_batch in enumerate(col_batches):
+                if self._check_stop_requested():
+                    print(
+                        "🛑 Stop requested during all-mode batches, returning partial results"
+                    )
+                    return cleaned
 
-            # Track unmatched values for schema evolution
-            self._track_unmatched_values(unmatched, paper_title)
+                msgs = self.prompt_builder.build_val_messages(
+                    schema.query,
+                    paper_title,
+                    eff,
+                    [c.to_dict() for c in col_batch],
+                    mode="all",
+                    strict=False,
+                )
+                trimmed = utils.fit_prompt(
+                    msgs,
+                    truncate=should_truncate,
+                    max_new=max_new_tokens,
+                    safety_margins=SAFETY_MARGIN_ALL_MODE,
+                    context_window_size=max_ctx,
+                )
+                resp_schema, key_map = self._build_response_schema(col_batch)
+                raw = self._generate(
+                    trimmed,
+                    temperature=0,
+                    response_schema=resp_schema,
+                    **self._gemini_kwargs(thinking_budget=0),
+                )
+                if self._check_stop_requested():
+                    print(
+                        "🛑 Stop requested after all-mode LLM call, returning partial results"
+                    )
+                    return cleaned
+                try:
+                    parsed = self._remap_response_keys(
+                        self.json_parser.parse_response(raw), key_map
+                    )
+                except Exception as e:
+                    print(f"⚠️  parse failure for {paper_title} (batch {batch_idx + 1}/{len(col_batches)}): {e}")
+                    parsed = {}
 
-            # Attach source filename to excerpts
-            cleaned = self._attach_source_to_excerpts(cleaned, paper_title)
+                requested = [c.name for c in col_batch]
+                column_allowed_values = {
+                    c.name: c.allowed_values
+                    for c in col_batch
+                    if c.allowed_values
+                }
+                batch_cleaned, unmatched = self.json_parser.postprocess(
+                    parsed, requested, column_allowed_values
+                )
+                self._track_unmatched_values(unmatched, paper_title)
+                batch_cleaned = self._attach_source_to_excerpts(
+                    batch_cleaned, paper_title
+                )
+                cleaned.update(batch_cleaned)
 
-            # Notify callback for each extracted column (streaming to UI)
-            if row_name:
-                for col_name, col_value in cleaned.items():
-                    self._notify_value_extracted(row_name, col_name, col_value)
+                if row_name:
+                    for col_name, col_value in batch_cleaned.items():
+                        self._notify_value_extracted(row_name, col_name, col_value)
 
             # Column-reordered second pass: re-extract missing columns in reversed
             # order to counteract LLM positional attention bias.
@@ -721,6 +754,7 @@ class PaperProcessor:
                 resp_schema_re, key_map_re = self._build_response_schema(reordered)
                 raw_re = self._generate(
                     trimmed_re,
+                    temperature=0,
                     response_schema=resp_schema_re,
                     **self._gemini_kwargs(thinking_budget=0),
                 )
@@ -1339,84 +1373,103 @@ class PaperProcessor:
         """
         Extract values for a single observation unit using its relevant passages.
 
-        Args:
-            unit_name: Name of the observation unit (e.g., "GPT-4 on MMLU")
-            relevant_passages: Passages specific to this unit
-            schema: Schema with columns to extract
-            max_new_tokens: Max tokens for LLM response
-            paper_title: Source document title
-
-        Returns:
-            Dict of column values for this unit
+        When the schema has more columns than Gemini's controlled-generation
+        limit, the columns are split into batches so each call still gets a
+        valid response_schema.  Results are merged across batches.
         """
-        # Combine relevant passages
-        eff = "\n\n--- RELEVANT PASSAGE ---\n\n".join(relevant_passages)
-
-        # Build prompt with unit context
-        system_prompt = SYSTEM_PROMPT_VAL_WITH_UNIT.format(unit_name=unit_name)
-
-        msgs = self.prompt_builder.build_val_messages(
-            schema.query,
-            f"{paper_title} - {unit_name}",
-            eff,
-            [c.to_dict() for c in schema.columns],
-            mode="all",
-            strict=False,
+        from schematiq.value_extraction.utils.schema_builder import (
+            _MAX_COLUMNS_FOR_CONTROLLED_GENERATION,
         )
 
-        # Replace the system prompt with unit-aware version
-        msgs[0]["content"] = system_prompt
+        columns = list(schema.columns)
+        eff = "\n\n--- RELEVANT PASSAGE ---\n\n".join(relevant_passages)
+        system_prompt = SYSTEM_PROMPT_VAL_WITH_UNIT.format(unit_name=unit_name)
 
-        # Fit to context and generate, using task-specific token budget
         should_truncate = not self._should_skip_truncation()
         max_ctx = getattr(self.llm, "context_window_size", None) or 8192
         task_tokens = self.llm.max_tokens_for_task("value_extraction")
         effective_max = (
             min(max_new_tokens, task_tokens) if max_new_tokens else task_tokens
         )
-        trimmed = utils.fit_prompt(
-            msgs,
-            truncate=should_truncate,
-            max_new=effective_max,
-            safety_margins=SAFETY_MARGIN_ALL_MODE,
-            context_window_size=max_ctx,
+
+        all_cleaned: Dict[str, Any] = {}
+
+        batches = list(
+            _chunk_list(columns, _MAX_COLUMNS_FOR_CONTROLLED_GENERATION)
         )
-
-        resp_schema, key_map = self._build_response_schema(list(schema.columns))
-        raw = self._generate(
-            trimmed,
-            max_output_tokens=effective_max,
-            response_schema=resp_schema,
-            **self._gemini_kwargs(thinking_budget=0),
-        )
-
-        if self._check_stop_requested():
-            return {}
-
-        try:
-            parsed = self._remap_response_keys(self.json_parser.parse_response(raw), key_map)
-            requested = [c.name for c in schema.columns]
-            column_allowed_values = {
-                c.name: c.allowed_values for c in schema.columns if c.allowed_values
-            }
-            cleaned, unmatched = self.json_parser.postprocess(
-                parsed, requested, column_allowed_values
+        if len(batches) > 1:
+            logging.info(
+                "[extract_values_for_unit] %d columns → %d batches of ≤%d for unit %r",
+                len(columns),
+                len(batches),
+                _MAX_COLUMNS_FOR_CONTROLLED_GENERATION,
+                unit_name,
             )
 
-            # Track unmatched values
-            self._track_unmatched_values(unmatched, paper_title)
+        for batch_idx, col_batch in enumerate(batches):
+            if self._check_stop_requested():
+                return all_cleaned
 
-            # Attach source to excerpts
-            cleaned = self._attach_source_to_excerpts(cleaned, paper_title)
-
-            return cleaned
-
-        except Exception as e:
-            logging.warning(
-                "[%s] Error extracting values for unit '%s': %s\nRaw response was:\n%s",
-                paper_title, unit_name, e, raw,
+            msgs = self.prompt_builder.build_val_messages(
+                schema.query,
+                f"{paper_title} - {unit_name}",
+                eff,
+                [c.to_dict() for c in col_batch],
+                mode="all",
+                strict=False,
             )
-            return {}
+            msgs[0]["content"] = system_prompt
+
+            trimmed = utils.fit_prompt(
+                msgs,
+                truncate=should_truncate,
+                max_new=effective_max,
+                safety_margins=SAFETY_MARGIN_ALL_MODE,
+                context_window_size=max_ctx,
+            )
+
+            resp_schema, key_map = self._build_response_schema(col_batch)
+            raw = self._generate(
+                trimmed,
+                max_output_tokens=effective_max,
+                temperature=0,
+                response_schema=resp_schema,
+                **self._gemini_kwargs(thinking_budget=0),
+            )
+
+            if self._check_stop_requested():
+                return all_cleaned
+
+            try:
+                parsed = self._remap_response_keys(
+                    self.json_parser.parse_response(raw), key_map
+                )
+                requested = [c.name for c in col_batch]
+                column_allowed_values = {
+                    c.name: c.allowed_values
+                    for c in col_batch
+                    if c.allowed_values
+                }
+                cleaned, unmatched = self.json_parser.postprocess(
+                    parsed, requested, column_allowed_values
+                )
+                self._track_unmatched_values(unmatched, paper_title)
+                cleaned = self._attach_source_to_excerpts(cleaned, paper_title)
+                all_cleaned.update(cleaned)
+
+            except Exception as e:
+                logging.warning(
+                    "[%s] Error extracting values for unit '%s' (batch %d/%d): %s\n"
+                    "Raw response was:\n%s",
+                    paper_title,
+                    unit_name,
+                    batch_idx + 1,
+                    len(batches),
+                    e,
+                    raw,
+                )
+
+        return all_cleaned
 
     def extract_values_for_paper_with_units(
         self,

--- a/schematiq-lib/schematiq/value_extraction/utils/schema_builder.py
+++ b/schematiq-lib/schematiq/value_extraction/utils/schema_builder.py
@@ -1,14 +1,23 @@
 """Build Gemini response_schema for controlled generation during value extraction."""
 
+import logging
 import re
 from typing import Dict, Optional, Tuple
 
-# Gemini response_schema property names must match this pattern.
-# Names with hyphens, spaces, or other special characters cause a 400 INVALID_ARGUMENT.
-_GEMINI_PROP_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+logger = logging.getLogger(__name__)
 
-# Characters not allowed in Gemini property names, replaced with underscore.
+# Characters not allowed in Gemini response_schema property names → replaced with '_'.
 _SANITIZE_RE = re.compile(r"[^a-zA-Z0-9_]")
+
+# Gemini rejects response_schema with 400 INVALID_ARGUMENT when total schema
+# complexity is too high.  Each column is an OBJECT with 3 sub-fields (answer,
+# excerpts, suggested_for_allowed_values), so N columns ≈ 4N schema properties.
+# Empirically on gemini-3.1-flash-lite-preview the limit is ~48 columns with
+# typical property names; 40 provides a safe margin for longer names.
+# Callers (extract_values_for_unit, extract_values_for_paper) pre-batch columns
+# into chunks of this size so every call gets controlled generation.  The check
+# inside build_extraction_response_schema acts as a safety net.
+_MAX_COLUMNS_FOR_CONTROLLED_GENERATION = 40
 
 
 def _sanitize_name(name: str) -> str:
@@ -18,27 +27,44 @@ def _sanitize_name(name: str) -> str:
 
 def build_extraction_response_schema(
     columns,
-) -> Tuple[dict, Dict[str, str]]:
+) -> Tuple[Optional[dict], Dict[str, str]]:
     """Build Gemini response_schema for value extraction output.
 
+    Returns (None, {}) when the number of columns exceeds the safe limit for
+    Gemini controlled generation.  Callers should skip controlled generation
+    when None is returned and let the model output free-form JSON.
+
     Sanitizes column names that contain characters Gemini rejects as property
-    keys (e.g. hyphens in "IssueCourt-1" → "IssueCourt_1") so controlled
-    generation always works.  Returns the schema together with a reverse mapping
-    from sanitized name → original name so callers can restore the original keys
-    after parsing the response.
+    keys (e.g. hyphens in "IssueCourt-1" → "IssueCourt_1") and returns a
+    reverse key_map so callers can restore original names after parsing.
 
     Args:
         columns: List of Column objects with .name attribute.
 
     Returns:
-        (schema_dict, key_map) where:
-          - schema_dict is suitable for Gemini's response_schema parameter.
-          - key_map maps each sanitized property name back to the original
-            column name.  Empty when no sanitization was needed.
+        (schema_dict, key_map) where schema_dict is None when too many columns,
+        or a dict suitable for Gemini's response_schema parameter otherwise.
+        key_map maps sanitized names back to original column names.
     """
+    if len(columns) > _MAX_COLUMNS_FOR_CONTROLLED_GENERATION:
+        logger.warning(
+            "Controlled generation disabled: %d columns exceeds limit of %d",
+            len(columns),
+            _MAX_COLUMNS_FOR_CONTROLLED_GENERATION,
+        )
+        return None, {}
+
     key_map: Dict[str, str] = {}
+    sanitized_to_original: Dict[str, str] = {}
     for col in columns:
         sanitized = _sanitize_name(col.name)
+        if sanitized in sanitized_to_original and sanitized_to_original[sanitized] != col.name:
+            logger.warning(
+                "Controlled generation disabled: %r and %r both sanitize to %r",
+                sanitized_to_original[sanitized], col.name, sanitized,
+            )
+            return None, {}
+        sanitized_to_original[sanitized] = col.name
         if sanitized != col.name:
             key_map[sanitized] = col.name
 
@@ -59,6 +85,5 @@ def build_extraction_response_schema(
     schema = {
         "type": "OBJECT",
         "properties": properties,
-        # No "required" key — all columns are optional so the model can omit unfound ones
     }
     return schema, key_map


### PR DESCRIPTION
## Summary
- **Schema batching**: Gemini rejects `response_schema` when total complexity exceeds ~48 nested OBJECT properties. Instead of falling back to free-form JSON, columns are now split into batches of ≤40 — each batch gets its own controlled-generation call and results are merged. For a 74-column schema this means 2 batches (40+34), both with structured output.
- **Temperature=0**: All value extraction `_generate` calls now pass `temperature=0` for deterministic output.
- **Remove AFC disable**: Removed explicit `AutomaticFunctionCallingConfig(disable=True)` from both `generate` and `generate_with_cache` — the SDK default is fine.
- **Collision detection**: `schema_builder` now detects when two column names sanitize to the same string and falls back gracefully.

## Test plan
- [x] Verified with actual 74-column ISCD schema that batches of 40 pass Gemini API
- [x] Confirmed unit identification still works (no response_schema)
- [ ] Run full extraction pipeline with ISCD dataset

Made with [Cursor](https://cursor.com)