### PR TITLE
feat(debug): add SCHEMATIQ_DEBUG_DIR extraction dump

### DIFF
--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+import os
+import time
 from pathlib import Path
 from typing import Dict, Any, Set, Callable, Optional, List, Iterator
 from schematiq.core.schema import Schema, Column, ObservationUnit, _embed
@@ -9,6 +11,14 @@ from schematiq.core.llm_backends import LLMInterface
 from sentence_transformers import util as st_util
 from schematiq.core.llm_call_tracker import LLMCallTracker
 from schematiq.core import utils
+
+# Set SCHEMATIQ_DEBUG_DIR to a directory path to save LLM inputs/outputs per pass.
+_DEBUG_DIR: Optional[Path] = None
+_debug_env = os.environ.get("SCHEMATIQ_DEBUG_DIR")
+if _debug_env:
+    _DEBUG_DIR = Path(_debug_env)
+    _DEBUG_DIR.mkdir(parents=True, exist_ok=True)
+    logging.info("Debug dump enabled -> %s", _DEBUG_DIR)
 
 from .llm_cache import LLMCache
 from .json_parser import JSONResponseParser
@@ -109,6 +119,50 @@ class PaperProcessor:
             if ans:
                 flat[col_name] = str(ans)
         return flat
+
+    @staticmethod
+    def _debug_dump(
+        pass_name: str,
+        paper_title: str,
+        batch_idx: int,
+        columns_requested: List[str],
+        prompt_msgs: List[Dict[str, str]],
+        raw_response: str,
+        parsed: Dict[str, Any],
+        cleaned: Dict[str, Any],
+        already_extracted: Dict[str, str] | None = None,
+    ) -> None:
+        """Save a debug snapshot of one LLM call to SCHEMATIQ_DEBUG_DIR.
+
+        Set the SCHEMATIQ_DEBUG_DIR environment variable to a directory path
+        to enable. Each call writes a JSON file named:
+          <title>__<pass>__batch<n>__<timestamp_ms>.json
+        No-op when the env var is not set.
+        """
+        if _DEBUG_DIR is None:
+            return
+        safe_title = "".join(c if c.isalnum() or c in "-_ " else "_" for c in paper_title)[:60]
+        ts = int(time.time() * 1000)
+        fname = f"{safe_title}__{pass_name}__batch{batch_idx}__{ts}.json"
+        payload = {
+            "pass": pass_name,
+            "paper_title": paper_title,
+            "batch_idx": batch_idx,
+            "columns_requested": columns_requested,
+            "columns_filled": list(cleaned.keys()),
+            "columns_missing": [c for c in columns_requested if c not in cleaned],
+            "prompt_system": prompt_msgs[0]["content"][:500] + "..." if prompt_msgs else None,
+            "prompt_user_len": len(prompt_msgs[1]["content"]) if len(prompt_msgs) > 1 else 0,
+            "raw_response": raw_response[:5000] if raw_response else None,
+            "parsed": {k: v for k, v in (parsed or {}).items()},
+            "cleaned": {k: v for k, v in (cleaned or {}).items()},
+        }
+        if already_extracted:
+            payload["already_extracted_context"] = already_extracted
+        try:
+            (_DEBUG_DIR / fname).write_text(json.dumps(payload, ensure_ascii=False, indent=2, default=str))
+        except Exception as e:
+            logging.warning("Debug dump failed: %s", e)
 
     def _check_stop_requested(self) -> bool:
         """Check if stop was requested. Returns True if should stop."""
@@ -521,6 +575,18 @@ class PaperProcessor:
             # Track unmatched values for schema evolution
             self._track_unmatched_values(unmatched, paper_title)
 
+            self._debug_dump(
+                pass_name="pass3_batch_fallback",
+                paper_title=paper_title,
+                batch_idx=0,
+                columns_requested=requested,
+                prompt_msgs=msgs,
+                raw_response=raw,
+                parsed=parsed,
+                cleaned=cleaned,
+                already_extracted=already_extracted,
+            )
+
             return cleaned
         except Exception as e:
             print(
@@ -632,6 +698,18 @@ class PaperProcessor:
                     self._track_unmatched_values(unmatched_re, paper_title)
                     cleaned_re = self._attach_source_to_excerpts(
                         cleaned_re, paper_title
+                    )
+
+                    self._debug_dump(
+                        pass_name="pass2_reordered",
+                        paper_title=paper_title,
+                        batch_idx=p2_batch_idx,
+                        columns_requested=[c.name for c in p2_batch],
+                        prompt_msgs=reorder_msgs,
+                        raw_response=raw_re,
+                        parsed=parsed_re,
+                        cleaned=cleaned_re,
+                        already_extracted=already_flat,
                     )
 
                     for col_name, col_val in cleaned_re.items():
@@ -949,6 +1027,17 @@ class PaperProcessor:
                 self._track_unmatched_values(unmatched, paper_title)
                 batch_cleaned = self._attach_source_to_excerpts(
                     batch_cleaned, paper_title
+                )
+
+                self._debug_dump(
+                    pass_name="pass1_paper",
+                    paper_title=paper_title,
+                    batch_idx=batch_idx,
+                    columns_requested=requested,
+                    prompt_msgs=msgs,
+                    raw_response=raw,
+                    parsed=parsed,
+                    cleaned=batch_cleaned,
                 )
 
                 cleaned.update(batch_cleaned)
@@ -1536,6 +1625,17 @@ class PaperProcessor:
                 )
                 self._track_unmatched_values(unmatched, paper_title)
                 cleaned = self._attach_source_to_excerpts(cleaned, paper_title)
+
+                self._debug_dump(
+                    pass_name="pass1_unit",
+                    paper_title=f"{paper_title} - {unit_name}",
+                    batch_idx=batch_idx,
+                    columns_requested=requested,
+                    prompt_msgs=msgs,
+                    raw_response=raw,
+                    parsed=parsed,
+                    cleaned=cleaned,
+                )
 
                 all_cleaned.update(cleaned)
 


### PR DESCRIPTION
## What this does

Adds optional debug logging for value extraction. When `SCHEMATIQ_DEBUG_DIR` is set to a directory path, each LLM call writes a JSON snapshot file with:

- Pass name (pass1_paper, pass1_unit, pass2_reordered, pass3_batch_fallback)
- Columns requested, filled, and still missing
- System prompt prefix and user prompt length
- Raw LLM response (truncated to 5000 chars)
- Parsed and cleaned output
- Already-extracted context (pass 2 only)

## Usage

```bash
SCHEMATIQ_DEBUG_DIR=/tmp/schematiq_debug uvicorn app.main:app --reload
```

## Notes

- Zero-cost no-op in production (env var not set = nothing runs)
- Useful for diagnosing extraction quality, counting LLM calls, and inspecting what the model sees
- This PR is draft -- the tooling was used to find and fix the null-handling bug in #118. Merge when/if the team wants this as a permanent dev tool.

Made with [Cursor](https://cursor.com)