### PR TITLE
fix: partial data after stop, status race, upload stop/LLM

### DIFF
--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -2170,25 +2170,29 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         schema_completed = session.metadata.schema_discovery_completed
         columns_discovered = len(session.columns) if session.columns else 0
 
-        if is_running:
+        # Terminal persisted states win over the in-memory running flag. The runner
+        # sets STOPPED/COMPLETED/ERROR on the session before the asyncio task leaves
+        # running_sessions; reporting "processing" until then cleared the Data tab
+        # (streaming cells cleared, data query still keyed off status).
+        if session.status == SessionStatus.COMPLETED:
+            status = "completed"
+            progress = 1.0
+        elif session.status == SessionStatus.ERROR:
+            status = "error"
+            progress = 0.0
+        elif session.status == SessionStatus.STOPPED:
+            status = "stopped"
+            progress = 1.0
+        elif is_running:
             status = "processing"
             progress = 0.5  # Mock progress
         else:
-            if session.status == SessionStatus.COMPLETED:
-                status = "completed"
-                progress = 1.0
-            elif session.status == SessionStatus.DOCUMENTS_UPLOADED:
+            if session.status == SessionStatus.DOCUMENTS_UPLOADED:
                 status = "documents_uploaded"
                 progress = 1.0
             elif session.status == SessionStatus.PROCESSING_DOCUMENTS:
                 status = "processing_documents"
                 progress = 0.5
-            elif session.status == SessionStatus.ERROR:
-                status = "error"
-                progress = 0.0
-            elif session.status == SessionStatus.STOPPED:
-                status = "stopped"
-                progress = 1.0  # Stopped is a final state
             elif session.status == SessionStatus.OBSERVATION_UNIT_REVIEW:
                 status = "observation_unit_review"
                 progress = 0.3  # Partway through the pipeline

--- a/backend/app/services/upload_document_processor.py
+++ b/backend/app/services/upload_document_processor.py
@@ -280,14 +280,18 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                             logger.warning("Failed to merge partial data after stop: %s", e)
 
                     session = self.session_manager.get_session(session_id)
-                    await self.broadcast_stopped(
-                        session_id,
-                        {
-                            "schema_saved": True,
-                            "data_rows_saved": session.metadata.additional_rows_added or 0,
-                            "message": "Document processing stopped by user",
-                        },
-                    )
+                    try:
+                        await self.broadcast_stopped(
+                            session_id,
+                            {
+                                "schema_saved": True,
+                                "data_rows_saved": session.metadata.additional_rows_added or 0,
+                                "message": "Document processing stopped by user",
+                            },
+                        )
+                    except Exception as e:
+                        logger.warning("broadcast_stopped failed (WebSocket may have closed): %s", e)
+                    logger.info("Upload processing stopped for session %s (%d rows saved)", session_id, rows_merged)
                     return
 
                 # Check output file for progress tracking only
@@ -371,14 +375,18 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                         logger.warning("Failed to merge partial data after stop (post-task): %s", e)
 
                 session = self.session_manager.get_session(session_id)
-                await self.broadcast_stopped(
-                    session_id,
-                    {
-                        "schema_saved": True,
-                        "data_rows_saved": session.metadata.additional_rows_added or 0,
-                        "message": "Document processing stopped by user",
-                    },
-                )
+                try:
+                    await self.broadcast_stopped(
+                        session_id,
+                        {
+                            "schema_saved": True,
+                            "data_rows_saved": session.metadata.additional_rows_added or 0,
+                            "message": "Document processing stopped by user",
+                        },
+                    )
+                except Exception as e:
+                    logger.warning("broadcast_stopped failed after task completion (WebSocket may have closed): %s", e)
+                logger.info("Upload processing stopped (post-task) for session %s (%d rows saved)", session_id, rows_merged)
                 return
 
             # Merge additional extracted data into main data file

--- a/backend/app/services/upload_document_processor.py
+++ b/backend/app/services/upload_document_processor.py
@@ -25,6 +25,9 @@ from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
 from app.services import schematiq_thread_pool, concurrency_limiter
 from app.core.config import DEFAULT_TEMPERATURE, DEFAULT_RETRIEVAL_K, PROGRESS_CHECK_INTERVAL, DEVELOPER_MODE, RELEASE_CONFIG
+
+# Max seconds to wait for build_table_jsonl to observe should_stop() after user stop
+MAX_UPLOAD_EXTRACTION_STOP_WAIT = 120.0
 from app.core.logging_utils import set_session_context
 
 logger = logging.getLogger(__name__)
@@ -191,10 +194,15 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             # on_value_extracted streams individual cell values for live table updates.
             on_value_extracted, on_document_started = self._create_callbacks(session_id, loop, total_docs)
 
-            # Create should_stop callback that checks for stop requests
+            # Create should_stop callback that checks for stop requests.
+            # When running_sessions entry is removed (finally), we must still signal stop —
+            # otherwise .get(..., True) falsely reports "running" and the worker resumes LLM calls.
             def should_stop():
                 with self._state_lock:
-                    return not self.running_sessions.get(session_id, True)
+                    state = self.running_sessions.get(session_id)
+                    if state is None:
+                        return True
+                    return not state
 
             def run_extraction():
                 logger.info(f"EXTRACTION STARTING for session {session_id}")
@@ -233,14 +241,26 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             while not extraction_task.done():
                 # Check for stop request
                 with self._state_lock:
-                    stop_requested = not self.running_sessions.get(session_id, True)
+                    run_state = self.running_sessions.get(session_id)
+                stop_requested = run_state is False
                 if stop_requested:
-                    logger.info(f"Stop requested for session {session_id}, cancelling extraction...")
-                    extraction_task.cancel()
-                    try:
-                        await extraction_task
-                    except asyncio.CancelledError:
-                        logger.info(f"Extraction task cancelled for session {session_id}")
+                    logger.info(
+                        "Stop requested for session %s — waiting for extraction to observe should_stop()",
+                        session_id,
+                    )
+                    deadline = time.time() + MAX_UPLOAD_EXTRACTION_STOP_WAIT
+                    while not extraction_task.done() and time.time() < deadline:
+                        await asyncio.sleep(0.3)
+                    if not extraction_task.done():
+                        logger.warning(
+                            "Graceful stop timed out after %ss — cancelling executor task wrapper",
+                            MAX_UPLOAD_EXTRACTION_STOP_WAIT,
+                        )
+                        extraction_task.cancel()
+                        try:
+                            await extraction_task
+                        except (asyncio.CancelledError, Exception):
+                            pass
 
                     # Update session with partial results
                     session = self.session_manager.get_session(session_id)
@@ -248,30 +268,26 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                     session.metadata.last_modified = datetime.now()
                     self.session_manager.update_session(session)
 
-                    # Merge any partial data that was extracted
+                    rows_merged = 0
                     if output_path.exists():
                         try:
                             current_session = self.session_manager.get_session(session_id)
-                            rows_added = await self._merge_extracted_data(session_id, current_session)
-                            session.metadata.additional_rows_added = rows_added
+                            rows_merged = await self._merge_extracted_data(session_id, current_session)
+                            session = self.session_manager.get_session(session_id)
+                            session.metadata.additional_rows_added = rows_merged
                             self.session_manager.update_session(session)
                         except Exception as e:
-                            logger.warning(f"Failed to merge partial data after stop: {e}")
+                            logger.warning("Failed to merge partial data after stop: %s", e)
 
-                    # Broadcast stopped message
-                    await self.broadcast_message(session_id, {
-                        "type": "stopped",
-                        "data": {
+                    session = self.session_manager.get_session(session_id)
+                    await self.broadcast_stopped(
+                        session_id,
+                        {
+                            "schema_saved": True,
+                            "data_rows_saved": session.metadata.additional_rows_added or 0,
                             "message": "Document processing stopped by user",
-                            "processed_documents": session.metadata.processed_documents or 0,
-                            "total_documents": total_docs,
-                            "data_rows_saved": session.metadata.additional_rows_added or 0
-                        }
-                    })
-
-                    # Clean up and return
-                    with self._state_lock:
-                        self.running_sessions.pop(session_id, None)
+                        },
+                    )
                     return
 
                 # Check output file for progress tracking only

--- a/backend/app/services/upload_document_processor.py
+++ b/backend/app/services/upload_document_processor.py
@@ -347,7 +347,40 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             
             # Wait for completion
             await extraction_task
-            
+
+            # If stop was requested while we were waiting for the last document to finish,
+            # the while loop may have exited because the task completed — not because we
+            # hit the explicit stop_requested branch above. Treat this as a stop.
+            with self._state_lock:
+                run_state_after = self.running_sessions.get(session_id)
+            if run_state_after is False:
+                session = self.session_manager.get_session(session_id)
+                session.status = SessionStatus.STOPPED
+                session.metadata.last_modified = datetime.now()
+                self.session_manager.update_session(session)
+
+                rows_merged = 0
+                if output_path.exists():
+                    try:
+                        current_session = self.session_manager.get_session(session_id)
+                        rows_merged = await self._merge_extracted_data(session_id, current_session)
+                        session = self.session_manager.get_session(session_id)
+                        session.metadata.additional_rows_added = rows_merged
+                        self.session_manager.update_session(session)
+                    except Exception as e:
+                        logger.warning("Failed to merge partial data after stop (post-task): %s", e)
+
+                session = self.session_manager.get_session(session_id)
+                await self.broadcast_stopped(
+                    session_id,
+                    {
+                        "schema_saved": True,
+                        "data_rows_saved": session.metadata.additional_rows_added or 0,
+                        "message": "Document processing stopped by user",
+                    },
+                )
+                return
+
             # Merge additional extracted data into main data file
             await self.broadcast_progress(session_id, "Merging extracted data", 0.95, "processing_documents")
             current_session = self.session_manager.get_session(session_id)

--- a/frontend/src/pages/Visualize.tsx
+++ b/frontend/src/pages/Visualize.tsx
@@ -262,7 +262,8 @@ const Visualize = () => {
                 });
               }
               setNewlyAddedRows(prev => new Set(Array.from(prev).concat(message.data.row_index)));
-              queryClient.invalidateQueries(['data', sessionId]);
+              queryClient.invalidateQueries({ queryKey: ['data', sessionId], exact: false });
+              queryClient.refetchQueries({ queryKey: ['data', sessionId], exact: false });
               queryClient.invalidateQueries(['session', sessionId]);
               queryClient.invalidateQueries({ queryKey: ['unitData', sessionId], exact: false });
               queryClient.invalidateQueries(['documentList', sessionId]);
@@ -514,15 +515,22 @@ const Visualize = () => {
         session?.status === 'completed' ||
         session?.status === 'stopped' ||
         session?.status === 'processing_documents' ||
-        session?.status === 'documents_uploaded'
+        session?.status === 'documents_uploaded' ||
+        // ScheMatiQ writes each finished document to extracted_data.jsonl; poll so the
+        // Data tab can show partial rows while extraction runs (and after stop).
+        (mode === 'schematiq' && session?.status === 'processing')
       ),
       refetchInterval: () => {
-        // Don't poll if WebSocket is connected - rely on real-time updates
+        // Don't poll if WebSocket is connected — row_completed / cell events drive refetch
         if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
           return false;
         }
         // Fallback polling when WebSocket is not connected
-        return session?.status === 'processing_documents' ? PROCESSING_REFRESH_INTERVAL : false;
+        if (session?.status === 'processing_documents') return PROCESSING_REFRESH_INTERVAL;
+        if (mode === 'schematiq' && session?.status === 'processing') {
+          return PROCESSING_REFRESH_INTERVAL;
+        }
+        return false;
       },
       keepPreviousData: true,
     }
@@ -608,7 +616,8 @@ const Visualize = () => {
                   });
                 }
                 setNewlyAddedRows(prev => new Set(Array.from(prev).concat(message.data.row_index)));
-                queryClient.invalidateQueries(['data', sessionId]);
+                queryClient.invalidateQueries({ queryKey: ['data', sessionId], exact: false });
+                queryClient.refetchQueries({ queryKey: ['data', sessionId], exact: false });
                 queryClient.invalidateQueries(['session', sessionId]);
                 queryClient.invalidateQueries({ queryKey: ['unitData', sessionId], exact: false });
               queryClient.invalidateQueries(['documentList', sessionId]);
@@ -1342,7 +1351,10 @@ const Visualize = () => {
 
         {/* Data Tab */}
         <TabsContent value="data" className="mt-4">
-          {(isCompleted || isEnhancedUploadProcessing || isScheMatiQRunning || isScheMatiQStopped || session?.status === 'documents_uploaded') && (dataResponse || streamingCells.size > 0) ? (
+          {(isCompleted || isEnhancedUploadProcessing || isScheMatiQRunning || isScheMatiQStopped || session?.status === 'documents_uploaded') &&
+            (dataResponse ||
+              streamingCells.size > 0 ||
+              (mode === 'schematiq' && session?.status === 'processing' && dataLoading)) ? (
             <div className="relative" data-table-container>
               {/* View mode toggle (only when observation units exist) */}
               {((unitListResponse && unitListResponse.totalUnits > 0) || hasUnitColumn) && (
@@ -1549,7 +1561,16 @@ const Visualize = () => {
           ) : (
             <Alert variant="info">
               <AlertDescription>
-                {isScheMatiQRunning ? 'Data will be available when ScheMatiQ processing completes' : 'No data available'}
+                {isScheMatiQStopped && dataLoading
+                  ? 'Loading extracted rows…'
+                  : isScheMatiQStopped &&
+                      dataResponse !== undefined &&
+                      (dataResponse.total_count ?? 0) === 0 &&
+                      streamingCells.size === 0
+                    ? 'No table rows were saved before you stopped. Run again and let at least one document finish, or stop after partial rows appear in the Data tab.'
+                    : isScheMatiQRunning
+                      ? 'Rows from each finished document appear here as they are written. Open this tab during a run to see partial results, or use the Monitor for live progress.'
+                      : 'No data available'}
               </AlertDescription>
             </Alert>
           )}

--- a/frontend/src/pages/Visualize.tsx
+++ b/frontend/src/pages/Visualize.tsx
@@ -1199,6 +1199,9 @@ const Visualize = () => {
 
   const isScheMatiQRunning = mode === 'schematiq' && session?.status === 'processing';
   const isScheMatiQStopped = mode === 'schematiq' && session?.status === 'stopped';
+  // isStopped covers both ScheMatiQ and upload (load) sessions that were stopped mid-run.
+  // isScheMatiQStopped is kept for backward compat; use isStopped for any mode-agnostic check.
+  const isStopped = session?.status === 'stopped';
   const isSchemaReady = ['schema_ready', 'schema_extracted', 'documents_uploaded', 'processing_documents', 'completed', 'stopped'].includes(session?.status || '') ||
     (mode === 'schematiq' && session?.status === 'processing' && (session?.columns?.length ?? 0) > 0);
   const isCompleted = session?.status === 'completed';
@@ -1212,7 +1215,7 @@ const Visualize = () => {
     isEnhancedUploadProcessing,
     isScheMatiQRunning,
     isScheMatiQStopped,
-    dataTabDisabled: !isCompleted && !isEnhancedUploadProcessing && !isScheMatiQRunning && !isScheMatiQStopped && session?.status !== 'documents_uploaded'
+    dataTabDisabled: !isCompleted && !isEnhancedUploadProcessing && !isScheMatiQRunning && !isStopped && session?.status !== 'documents_uploaded'
   });
 
   const getStatusBadge = () => {
@@ -1258,7 +1261,7 @@ const Visualize = () => {
 
           <div className="flex items-center gap-2">
             {getStatusBadge()}
-            {(isCompleted || isScheMatiQStopped) && (
+            {(isCompleted || isStopped) && (
               <Button
                 variant="ghost"
                 size="icon"
@@ -1269,12 +1272,12 @@ const Visualize = () => {
                 <HelpCircle className="h-5 w-5" />
               </Button>
             )}
-            {(isCompleted || isEnhancedUploadProcessing || isScheMatiQStopped) && (
+            {(isCompleted || isEnhancedUploadProcessing || isStopped) && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button variant="outline" size="sm">
                     <Download className="h-4 w-4 mr-2" />
-                    Export{isScheMatiQStopped ? ' Current Results' : ''}
+                    Export{isStopped && !isCompleted ? ' Current Results' : ''}
                     <ChevronDown className="h-3 w-3 ml-1" />
                   </Button>
                 </DropdownMenuTrigger>
@@ -1335,8 +1338,8 @@ const Visualize = () => {
         <TabsList>
           <TabsTrigger
             value="data"
-            disabled={sessionLoading || (!isCompleted && !isEnhancedUploadProcessing && !isScheMatiQRunning && !isScheMatiQStopped && session?.status !== 'documents_uploaded')}
-            title={(!isCompleted && !isEnhancedUploadProcessing && !isScheMatiQRunning && !isScheMatiQStopped && session?.status !== 'documents_uploaded') ? 'Data will appear once processing starts' : undefined}
+            disabled={sessionLoading || (!isCompleted && !isEnhancedUploadProcessing && !isScheMatiQRunning && !isStopped && session?.status !== 'documents_uploaded')}
+            title={(!isCompleted && !isEnhancedUploadProcessing && !isScheMatiQRunning && !isStopped && session?.status !== 'documents_uploaded') ? 'Data will appear once processing starts' : undefined}
           >
             Data
           </TabsTrigger>
@@ -1349,8 +1352,8 @@ const Visualize = () => {
           </TabsTrigger>
           <TabsTrigger
             value="stats"
-            disabled={sessionLoading || (!isCompleted && !isScheMatiQStopped)}
-            title={(!isCompleted && !isScheMatiQStopped) ? 'Statistics will appear once processing completes' : undefined}
+            disabled={sessionLoading || (!isCompleted && !isStopped)}
+            title={(!isCompleted && !isStopped) ? 'Statistics will appear once processing completes' : undefined}
           >
             Statistics
           </TabsTrigger>
@@ -1372,7 +1375,7 @@ const Visualize = () => {
 
         {/* Data Tab */}
         <TabsContent value="data" className="mt-4">
-          {(isCompleted || isEnhancedUploadProcessing || isScheMatiQRunning || isScheMatiQStopped || session?.status === 'documents_uploaded') &&
+          {(isCompleted || isEnhancedUploadProcessing || isScheMatiQRunning || isStopped || session?.status === 'documents_uploaded') &&
             (dataResponse ||
               streamingCells.size > 0 ||
               (mode === 'schematiq' && session?.status === 'processing' && dataLoading)) ? (
@@ -1582,9 +1585,9 @@ const Visualize = () => {
           ) : (
             <Alert variant="info">
               <AlertDescription>
-                {isScheMatiQStopped && dataLoading
+                {isStopped && dataLoading
                   ? 'Loading extracted rows…'
-                  : isScheMatiQStopped &&
+                  : isStopped &&
                       dataResponse !== undefined &&
                       (dataResponse.total_count ?? 0) === 0 &&
                       streamingCells.size === 0

--- a/frontend/src/pages/Visualize.tsx
+++ b/frontend/src/pages/Visualize.tsx
@@ -547,6 +547,27 @@ const Visualize = () => {
     }
   }, [mode, session?.status]);
 
+  // When session status transitions to a terminal state (stopped/completed) without a
+  // WebSocket event (e.g. WebSocket closed before "stopped" arrived), the data query may
+  // still hold a stale empty result from when status was "processing_documents".
+  // Explicitly refetch data and units whenever status settles into stopped/completed so
+  // merged rows from _merge_extracted_data are shown immediately.
+  const prevStatusRef = React.useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const prev = prevStatusRef.current;
+    const current = session?.status;
+    prevStatusRef.current = current;
+    if (
+      prev !== undefined &&
+      prev !== current &&
+      (current === 'stopped' || current === 'completed')
+    ) {
+      queryClient.refetchQueries({ queryKey: ['data', sessionId], exact: false });
+      queryClient.refetchQueries({ queryKey: ['unitData', sessionId], exact: false });
+      queryClient.invalidateQueries(['documentList', sessionId]);
+    }
+  }, [session?.status, sessionId, queryClient]);
+
   // Fallback check for observation units in table data
   // This allows showing the "By Unit" toggle even when the API doesn't detect unit names
   // Check for _unit_name metadata field OR columns with "unit"/"observation" in the name


### PR DESCRIPTION
## Summary

Fixes ScheMatiQ and **upload document processing** behavior when users stop mid-run: the Data tab can show saved rows, status APIs match persisted state, and upload stop no longer crashes or leaves the extractor calling the LLM.

## Changes

### 1. `get_status` terminal state precedence (`schematiq_runner.py`)
The runner persists `stopped` / `completed` / `error` on the session **before** the asyncio task is removed from `running_sessions`. `get_status` used to always return `processing` while the task was registered, so the Visualize session briefly stayed on `processing` after stop: streaming cells were cleared, the data query stayed disabled, and the Data tab looked empty while Schema still loaded.

**Fix:** Resolve persisted terminal session statuses before applying the `is_running → processing` shortcut.

### 2. Partial table data in the UI (`Visualize.tsx`)
- Enable the table data query while ScheMatiQ status is `processing` so `extracted_data.jsonl` is read as documents complete (not only after stop/complete).
- Fallback polling for that query when the WebSocket is disconnected.
- On `row_completed`, refetch data queries so the parent query and DataTable stay in sync.
- Allow the Data tab shell to show while the first fetch is loading during processing.
- Clearer empty-state copy for running vs stopped with no rows.

### 3. Upload processing stop: WebSocket + LLM (`upload_document_processor.py`)
- **Bug:** Stop path called non-existent `broadcast_message`, causing an exception and no proper `stopped` event for the UI.
- **Bug:** `finally` popped `running_sessions` while `should_stop` used `.get(session_id, True)`. After the key was removed, the callback returned **false** (“keep running”), so the executor thread kept issuing Gemini requests after stop.
- **Fix:** Use `broadcast_stopped` from `WebSocketBroadcasterMixin`. Redefine `should_stop` so a missing entry means stop. Align the main-loop stop check with `run_state is False`. On user stop, wait up to 120s for graceful shutdown (`should_stop`) before cancelling the asyncio wrapper; remove the premature `pop` on the stop path (cleanup remains in `finally`).

## Notes
- An in-flight single HTTP `generateContent` call may still complete after stop; further batches should stop once the worker observes `should_stop`.

## Commits
- `fix(schematiq): prefer persisted terminal status over running flag in get_status`
- `feat(visualize): load and show partial table rows during ScheMatiQ extraction`
- `fix(upload): stop broadcast + should_stop so LLM halts after user stop`

Made with [Cursor](https://cursor.com)