### PR TITLE
refactor: decompose ScheMatiQRunner into focused pipeline modules

### DIFF
--- a/backend/app/services/continue_discovery_service.py
+++ b/backend/app/services/continue_discovery_service.py
@@ -30,6 +30,7 @@ from app.services import schematiq_thread_pool, concurrency_limiter
 from app.storage.factory import get_storage
 from app.core.config import DEVELOPER_MODE, RELEASE_CONFIG, MAX_DOCUMENTS
 from app.core.logging_utils import set_session_context
+from app.services.pipeline.llm_factory import enforce_release_llm_config as _enforce_release_llm_config
 
 # ScheMatiQ library imports
 from schematiq.core import schematiq as ScheMatiQ
@@ -42,28 +43,6 @@ from schematiq.core.llm_call_tracker import LLMCallTracker
 from schematiq.value_extraction.main import build_table_jsonl
 
 SCHEMATIQ_AVAILABLE = True
-
-
-def _enforce_release_llm_config(llm_config: dict, is_schema_creation: bool = False) -> dict:
-    """Override LLM config with release-mode defaults if not in developer mode.
-
-    Args:
-        llm_config: The original LLM configuration dict
-        is_schema_creation: True for schema creation LLM, False for value extraction
-
-    Returns:
-        The config dict, potentially with provider/model/temperature overridden
-    """
-    if DEVELOPER_MODE:
-        return llm_config  # No override in developer mode
-
-    # Force release-mode LLM settings
-    return {
-        **llm_config,
-        "provider": RELEASE_CONFIG["llm_provider"],
-        "model": RELEASE_CONFIG["schema_creation_model"] if is_schema_creation else RELEASE_CONFIG["value_extraction_model"],
-        "temperature": RELEASE_CONFIG["llm_temperature"],
-    }
 
 
 class ContinueDiscoveryOperation:
@@ -162,48 +141,8 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
 
     @staticmethod
     def _is_local_path(path: str) -> bool:
-        """
-        Check if a path looks like a local filesystem path rather than a cloud storage path.
-
-        Local paths typically look like:
-        - /app/backend/data/{uuid}/pending_documents
-        - ./data/{uuid}/pending_documents
-        - /Users/.../data/...
-
-        Cloud storage paths look like:
-        - NES_documents
-        - datasets/papers_CoT
-        - files
-        """
-        if not path:
-            return False
-
-        # Common indicators of local filesystem paths
-        local_indicators = [
-            '/app/',           # Docker/Railway container paths
-            '/data/',          # Generic data directory
-            '/backend/',       # Backend directory
-            'pending_documents',  # Upload staging directory
-            '/Users/',         # macOS user paths
-            '/home/',          # Linux home paths
-            'C:\\',            # Windows paths
-            'D:\\',            # Windows paths
-            './',              # Relative paths
-            '../',             # Relative paths
-            'schematiq_work/', # Local ScheMatiQ working directory
-            'qbsd_work/',      # Legacy QBSD working directory
-        ]
-
-        for indicator in local_indicators:
-            if indicator in path:
-                return True
-
-        # Also check if path starts with / and has multiple segments
-        # (cloud paths are typically simple folder names like "NES_documents")
-        if path.startswith('/') and path.count('/') > 2:
-            return True
-
-        return False
+        from app.services.data_utils import is_local_path
+        return is_local_path(path)
 
     # ==================== Statistics Computation ====================
 

--- a/backend/app/services/data_utils.py
+++ b/backend/app/services/data_utils.py
@@ -149,3 +149,20 @@ def normalize_row_data(row: dict) -> dict:
     Returns the dict containing column->value mappings.
     """
     return row.get('data', row)
+
+
+def is_local_path(path: str) -> bool:
+    """Check if a path looks like a local filesystem path rather than a cloud storage path."""
+    if not path:
+        return False
+    local_indicators = [
+        '/app/', '/data/', '/backend/', 'pending_documents',
+        '/Users/', '/home/', 'C:\\', 'D:\\', './', '../',
+        'schematiq_work/',
+    ]
+    for indicator in local_indicators:
+        if indicator in path:
+            return True
+    if path.startswith('/') and path.count('/') > 2:
+        return True
+    return False

--- a/backend/app/services/pipeline/__init__.py
+++ b/backend/app/services/pipeline/__init__.py
@@ -1,0 +1,26 @@
+"""Pipeline modules for ScheMatiQ execution."""
+
+from .llm_factory import build_llm_interface, enforce_release_llm_config
+from .callbacks import create_value_extracted_callback, create_warning_callback, start_heartbeat
+from .config_handler import validate_config, convert_config_to_schematiq_format, resolve_docs_paths
+from .schema_discovery import run_schema_discovery
+from .value_extraction import run_value_extraction, process_suggested_values
+from .data_query import compute_statistics, get_status, get_schema, get_data
+
+__all__ = [
+    "build_llm_interface",
+    "enforce_release_llm_config",
+    "create_value_extracted_callback",
+    "create_warning_callback",
+    "start_heartbeat",
+    "validate_config",
+    "convert_config_to_schematiq_format",
+    "resolve_docs_paths",
+    "run_schema_discovery",
+    "run_value_extraction",
+    "process_suggested_values",
+    "compute_statistics",
+    "get_status",
+    "get_schema",
+    "get_data",
+]

--- a/backend/app/services/pipeline/callbacks.py
+++ b/backend/app/services/pipeline/callbacks.py
@@ -1,0 +1,78 @@
+"""WebSocket callback factories and heartbeat for pipeline operations."""
+
+import asyncio
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def create_value_extracted_callback(ws_mixin, session_id: str, loop: asyncio.AbstractEventLoop):
+    """Create a callback that streams extracted cell values via WebSocket.
+
+    The callback bridges sync extraction code to async WebSocket broadcasting.
+    """
+    def on_value_extracted(row_name: str, column_name: str, value: Any):
+        try:
+            asyncio.run_coroutine_threadsafe(
+                ws_mixin.broadcast_cell_extracted(session_id, {
+                    "row_name": row_name,
+                    "column": column_name,
+                    "value": value
+                }),
+                loop
+            )
+        except Exception as e:
+            logger.warning("Failed to broadcast cell %s for %s: %s", column_name, row_name, e)
+
+    return on_value_extracted
+
+
+def create_warning_callback(ws_manager, session_id: str, loop: asyncio.AbstractEventLoop):
+    """Create a callback that broadcasts warnings via WebSocket.
+
+    The callback bridges sync extraction code to async WebSocket broadcasting.
+    Used to surface issues like observation unit parsing failures to the UI.
+    """
+    def on_warning(paper_title: str, warning_type: str, message: str):
+        try:
+            asyncio.run_coroutine_threadsafe(
+                ws_manager.broadcast_log(session_id, {
+                    "level": "warning",
+                    "message": f"[{paper_title}] {warning_type}: {message}",
+                    "paper_title": paper_title,
+                    "warning_type": warning_type,
+                    "details": message
+                }),
+                loop
+            )
+        except Exception as e:
+            logger.warning("Failed to broadcast warning for %s: %s", paper_title, e)
+
+    return on_warning
+
+
+async def start_heartbeat(ws_manager, session_id: str, interval: float = 15.0) -> asyncio.Task:
+    """Start a background heartbeat to keep WebSocket alive during long operations.
+
+    Args:
+        ws_manager: WebSocket manager instance
+        session_id: The session to send heartbeats to
+        interval: Seconds between heartbeat messages (default 15s)
+
+    Returns:
+        The heartbeat task (caller should cancel when done)
+    """
+    async def heartbeat_loop():
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                await ws_manager.broadcast_log(session_id, {
+                    "level": "info",
+                    "message": "Processing... (still working)"
+                })
+            except Exception as e:
+                logger.warning("Heartbeat failed: %s", e)
+                break
+
+    return asyncio.create_task(heartbeat_loop())

--- a/backend/app/services/pipeline/config_handler.py
+++ b/backend/app/services/pipeline/config_handler.py
@@ -1,0 +1,255 @@
+"""Configuration validation, conversion, and document path resolution."""
+
+import logging
+from typing import Dict, Any, Optional, List
+from pathlib import Path
+
+from app.core.config import MAX_DOCUMENTS, DEVELOPER_MODE
+from app.models.schematiq import ScheMatiQConfig
+from app.storage import get_storage
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
+
+
+async def download_supabase_dataset(dataset_name: str, session_dir: Path) -> Optional[str]:
+    """Download a Supabase dataset to local directory.
+
+    Returns:
+        Local path to downloaded dataset, or None if not a Supabase dataset
+    """
+    storage = get_storage()
+
+    try:
+        datasets = await storage.list_datasets()
+        dataset_names = [d.name for d in datasets]
+
+        if dataset_name in dataset_names:
+            local_dataset_dir = session_dir / "datasets" / dataset_name
+            local_dataset_dir.mkdir(parents=True, exist_ok=True)
+
+            logger.info("Downloading Supabase dataset '%s' to %s", dataset_name, local_dataset_dir)
+            downloaded_files = await storage.download_dataset_to_local(dataset_name, str(local_dataset_dir))
+            logger.info("Downloaded %d files from '%s'", len(downloaded_files), dataset_name)
+
+            return str(local_dataset_dir)
+    except Exception as e:
+        logger.warning("Error checking/downloading Supabase dataset '%s': %s", dataset_name, e)
+
+    return None
+
+
+async def resolve_docs_paths(config: ScheMatiQConfig, session_id: str, work_dir: Path) -> List[str]:
+    """Resolve document paths - download from Supabase if needed, or use uploaded files."""
+    session_dir = work_dir / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    # Check for uploaded documents in data/{session_id}/pending_documents/ directory
+    data_dir = Path("./data") / session_id / "pending_documents"
+    if data_dir.exists():
+        uploaded_files = [f for f in sorted(data_dir.iterdir())
+                        if f.is_file() and not f.name.startswith('.')]
+        if uploaded_files:
+            logger.info("Using %d uploaded documents from %s", len(uploaded_files), data_dir)
+            return [str(data_dir.absolute())]
+
+    # No uploaded files - resolve from config.docs_path
+    docs_paths = config.docs_path if isinstance(config.docs_path, list) else [config.docs_path]
+    docs_paths = [p for p in docs_paths if p]
+
+    if not docs_paths:
+        logger.warning("No document paths configured and no uploaded documents found")
+        return []
+
+    resolved_docs_paths = []
+
+    for path in docs_paths:
+        supabase_path = await download_supabase_dataset(path, session_dir)
+        if supabase_path:
+            resolved_docs_paths.append(supabase_path)
+            continue
+
+        doc_path = Path(path)
+        if not doc_path.is_absolute():
+            candidates = [
+                PROJECT_ROOT / path,
+                PROJECT_ROOT / "research" / "data" / Path(path).name,
+                PROJECT_ROOT / "test" / "files",
+                Path.cwd() / path,
+                Path.cwd().parent / path,
+            ]
+            for candidate in candidates:
+                if candidate.exists():
+                    resolved_docs_paths.append(str(candidate.absolute()))
+                    logger.info("Resolved document path: %s -> %s", path, candidate.absolute())
+                    break
+            else:
+                logger.warning("Document path not found: %s", path)
+                resolved_docs_paths.append(path)
+        else:
+            resolved_docs_paths.append(str(doc_path))
+
+    return resolved_docs_paths
+
+
+def convert_config_to_schematiq_format(
+    config: ScheMatiQConfig,
+    session_id: str,
+    work_dir: Path,
+    resolved_docs_paths: List[str]
+) -> Dict[str, Any]:
+    """Convert frontend config to ScheMatiQ format with pre-resolved paths."""
+    session_dir = work_dir / session_id
+
+    schematiq_config = {
+        "query": config.query,
+        "docs_path": resolved_docs_paths[0] if len(resolved_docs_paths) == 1 else resolved_docs_paths,
+        "max_keys_schema": config.max_keys_schema,
+        "documents_batch_size": config.documents_batch_size,
+        "output_path": str(session_dir / "discovered_schema.json"),
+        "document_randomization_seed": config.document_randomization_seed,
+        "skip_value_extraction": config.skip_value_extraction,
+        "convergence_threshold": config.convergence_threshold,
+        "schema_creation_backend": {
+            "provider": config.schema_creation_backend.provider,
+            "model": config.schema_creation_backend.model,
+            "max_output_tokens": config.schema_creation_backend.max_output_tokens,
+            "temperature": config.schema_creation_backend.temperature,
+            "context_window_size": config.schema_creation_backend.context_window_size,
+            "api_key": config.schema_creation_backend.api_key
+        },
+        "value_extraction_backend": {
+            "provider": config.value_extraction_backend.provider,
+            "model": config.value_extraction_backend.model,
+            "max_output_tokens": config.value_extraction_backend.max_output_tokens,
+            "temperature": config.value_extraction_backend.temperature,
+            "context_window_size": config.value_extraction_backend.context_window_size,
+            "api_key": config.value_extraction_backend.api_key
+        }
+    }
+
+    if config.retriever:
+        schematiq_config["retriever"] = {
+            "type": "embedding",
+            "model_name": config.retriever.model_name,
+            "k": config.retriever.k,
+            "passage_chars": config.retriever.passage_chars,
+            "overlap": config.retriever.overlap,
+            "enable_dynamic_k": config.retriever.enable_dynamic_k,
+            "dynamic_k_threshold": config.retriever.dynamic_k_threshold,
+            "dynamic_k_minimum": config.retriever.dynamic_k_minimum
+        }
+
+    if config.initial_schema:
+        schematiq_config["initial_schema"] = [
+            {
+                "name": col.name,
+                "definition": col.definition,
+                "rationale": col.rationale,
+                "allowed_values": col.allowed_values
+            }
+            for col in config.initial_schema
+        ]
+    elif config.initial_schema_path:
+        initial_schema_path = Path(config.initial_schema_path)
+        if not initial_schema_path.is_absolute():
+            initial_schema_path = (PROJECT_ROOT / initial_schema_path).resolve()
+        if initial_schema_path.exists():
+            schematiq_config["initial_schema_path"] = str(initial_schema_path)
+
+    if config.initial_observation_unit:
+        schematiq_config["initial_observation_unit"] = {
+            "name": config.initial_observation_unit.name,
+            "definition": config.initial_observation_unit.definition
+        }
+
+    schematiq_config["review_observation_unit"] = config.review_observation_unit
+
+    return schematiq_config
+
+
+async def validate_config(config: ScheMatiQConfig) -> Dict[str, Any]:
+    """Validate ScheMatiQ configuration.
+
+    Supports three modes:
+    - Standard: Both query and documents provided
+    - Document-only: Documents provided, no query
+    - Query-only: Query provided, no documents
+
+    At least one of query or documents must be provided.
+    """
+    errors = []
+    warnings = []
+
+    has_query = bool(config.query and config.query.strip())
+    docs_paths = config.docs_path if isinstance(config.docs_path, list) else [config.docs_path]
+    has_documents = bool(docs_paths and any(p for p in docs_paths if p)) or config.upload_pending
+
+    if not has_query and not has_documents:
+        errors.append("At least one of query or documents must be provided")
+
+    actual_paths = [p for p in docs_paths if p]
+    if actual_paths:
+        for path in actual_paths:
+            doc_path = Path(path)
+            logger.debug("Checking document path: %s -> %s", path, doc_path.absolute())
+
+            paths_to_try = [
+                doc_path,
+                Path("..") / path,
+                Path("../..") / path,
+                Path("../../..") / path,
+                Path("../../..") / "test" / "files",
+                PROJECT_ROOT / "test" / "files",
+                PROJECT_ROOT / "research" / "data" / "file",
+                Path("../test/files"),
+            ]
+
+            path_exists = False
+            actual_path = None
+            for try_path in paths_to_try:
+                if try_path.exists():
+                    path_exists = True
+                    actual_path = try_path.absolute()
+                    logger.debug("Found path at: %s", actual_path)
+                    try:
+                        if actual_path.is_dir():
+                            file_count = len(list(try_path.glob("*.txt"))) + len(list(try_path.glob("*.md")))
+                            if file_count == 0:
+                                warnings.append(f"Document path appears to be empty: {path} (no .txt or .md files)")
+                            else:
+                                logger.debug("Found %d document files", file_count)
+                    except Exception as e:
+                        warnings.append(f"Could not check document count in {path}: {e}")
+                    break
+
+            if not path_exists:
+                warnings.append(f"Document path does not exist: {path}. Try using 'test/files' which contains sample documents.")
+
+    if config.initial_schema_path:
+        schema_path = Path(config.initial_schema_path)
+        if not schema_path.is_absolute():
+            schema_path = (PROJECT_ROOT / schema_path).resolve()
+        if not schema_path.exists():
+            errors.append(f"Initial schema file does not exist: {config.initial_schema_path} (resolved: {schema_path})")
+
+    if not config.schema_creation_backend.provider:
+        errors.append("Schema creation LLM provider must be specified")
+
+    if not config.schema_creation_backend.model:
+        if config.schema_creation_backend.provider.lower() not in ["gemini"]:
+            errors.append("Schema creation LLM model must be specified (required for non-Gemini providers)")
+
+    if not config.value_extraction_backend.provider:
+        errors.append("Value extraction LLM provider must be specified")
+
+    if not config.value_extraction_backend.model:
+        if config.value_extraction_backend.provider.lower() not in ["gemini"]:
+            errors.append("Value extraction LLM model must be specified (required for non-Gemini providers)")
+
+    return {
+        "is_valid": len(errors) == 0,
+        "errors": errors,
+        "warnings": warnings
+    }

--- a/backend/app/services/pipeline/data_query.py
+++ b/backend/app/services/pipeline/data_query.py
@@ -1,0 +1,401 @@
+"""Data query, schema retrieval, status reporting, and statistics computation."""
+
+import json
+import logging
+import math
+from typing import Dict, Any, Optional, List
+from pathlib import Path
+
+from app.models.session import (
+    ColumnInfo, DataStatistics, DataRow, PaginatedData, SessionStatus,
+    SchemaEvolution, VisualizationSession
+)
+from app.models.schematiq import ScheMatiQStatus
+from app.core.config import DEVELOPER_MODE
+
+from schematiq.core.schema import Schema
+
+logger = logging.getLogger(__name__)
+
+
+def compute_statistics(
+    session_id: str,
+    schema: Schema,
+    schema_evolution: Optional[SchemaEvolution] = None,
+    skipped_documents: Optional[List[str]] = None,
+    work_dir: Path = None,
+) -> Optional[DataStatistics]:
+    """Compute statistics from extracted JSONL data."""
+    from app.services.data_utils import collect_all_data_rows, normalize_row_data
+
+    data_rows = collect_all_data_rows(session_id, work_dir=work_dir)
+
+    if not data_rows:
+        logger.warning("Statistics: No data found for session %s (schema-only mode)", session_id)
+        columns = []
+        for col in schema.columns:
+            col_info = ColumnInfo(
+                name=col.name,
+                definition=col.definition,
+                rationale=col.rationale,
+                data_type="object",
+                non_null_count=0,
+                unique_count=0,
+                source_document=col.source_document,
+                discovery_iteration=col.discovery_iteration,
+                allowed_values=col.allowed_values
+            )
+            columns.append(col_info)
+
+        return DataStatistics(
+            total_rows=0,
+            total_columns=len(schema.columns),
+            total_documents=0,
+            completeness=0.0,
+            column_stats=columns,
+            schema_evolution=schema_evolution,
+            skipped_documents=skipped_documents or []
+        )
+
+    # Count unique documents from papers field
+    unique_documents = set()
+    for row in data_rows:
+        papers = row.get('papers', row.get('_papers', []))
+        if isinstance(papers, list):
+            unique_documents.update(papers)
+        elif isinstance(papers, str) and papers:
+            unique_documents.add(papers)
+    total_documents = len(unique_documents) if unique_documents else len(data_rows)
+
+    columns = []
+    for col in schema.columns:
+        def is_valid_value(value):
+            if value is None:
+                return False
+            if isinstance(value, dict):
+                answer = value.get("answer")
+                if answer is None or answer == "None" or answer == "" or answer == "[]":
+                    return False
+                return True
+            return value != "None" and value != "" and value != "[]"
+
+        non_null_count = 0
+        unique_values = set()
+
+        for row in data_rows:
+            row_data = normalize_row_data(row)
+
+            if col.name in row_data:
+                value = row_data[col.name]
+                if is_valid_value(value):
+                    non_null_count += 1
+                canonical = value.get("answer") if isinstance(value, dict) else value
+                try:
+                    unique_values.add(json.dumps(canonical, sort_keys=True))
+                except (TypeError, ValueError):
+                    unique_values.add(str(canonical))
+        unique_count = len(unique_values)
+
+        source_document = None
+        if schema_evolution and col.name in schema_evolution.column_sources:
+            source_document = schema_evolution.column_sources[col.name]
+
+        col_info = ColumnInfo(
+            name=col.name,
+            definition=col.definition,
+            rationale=col.rationale,
+            data_type="object",
+            non_null_count=non_null_count,
+            unique_count=unique_count,
+            source_document=source_document,
+            discovery_iteration=getattr(col, 'discovery_iteration', None),
+            allowed_values=getattr(col, 'allowed_values', None),
+            auto_expand_threshold=getattr(col, 'auto_expand_threshold', 2)
+        )
+        columns.append(col_info)
+
+    total_cells = len(data_rows) * len(columns)
+    non_null_cells = sum(col.non_null_count or 0 for col in columns)
+    completeness = (non_null_cells / total_cells * 100) if total_cells > 0 else 0.0
+
+    if math.isnan(completeness) or math.isinf(completeness):
+        completeness = 0.0
+
+    stats = DataStatistics(
+        total_rows=len(data_rows),
+        total_columns=len(columns),
+        total_documents=total_documents,
+        completeness=completeness,
+        column_stats=columns,
+        schema_evolution=schema_evolution,
+        skipped_documents=skipped_documents or []
+    )
+
+    logger.info("Statistics computed: %d rows, %d documents, %d columns, %.1f%% complete", len(data_rows), total_documents, len(columns), completeness)
+    if skipped_documents:
+        logger.info("Skipped documents: %d", len(skipped_documents))
+    if schema_evolution:
+        logger.info("Schema evolution: %d snapshots, %d column sources", len(schema_evolution.snapshots), len(schema_evolution.column_sources))
+    return stats
+
+
+async def get_status(
+    session_id: str,
+    session_manager,
+    running_sessions: Dict[str, Any],
+    state_lock,
+    work_dir: Path,
+) -> ScheMatiQStatus:
+    """Get current status of ScheMatiQ execution."""
+    with state_lock:
+        is_running = session_id in running_sessions
+
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise ValueError("Session not found")
+
+    schema_completed = session.metadata.schema_discovery_completed
+    columns_discovered = len(session.columns) if session.columns else 0
+
+    if session.status == SessionStatus.COMPLETED:
+        status = "completed"
+        progress = 1.0
+    elif session.status == SessionStatus.ERROR:
+        status = "error"
+        progress = 0.0
+    elif session.status == SessionStatus.STOPPED:
+        status = "stopped"
+        progress = 1.0
+    elif is_running:
+        status = "processing"
+        progress = 0.5
+    else:
+        if session.status == SessionStatus.DOCUMENTS_UPLOADED:
+            status = "documents_uploaded"
+            progress = 1.0
+        elif session.status == SessionStatus.PROCESSING_DOCUMENTS:
+            status = "processing_documents"
+            progress = 0.5
+        elif session.status == SessionStatus.OBSERVATION_UNIT_REVIEW:
+            status = "observation_unit_review"
+            progress = 0.3
+        else:
+            status = "idle"
+            progress = 0.0
+
+    config_path = work_dir / session_id / "config.json"
+    schema_only = False
+    try:
+        if config_path.exists():
+            import json as _json
+            cfg = _json.loads(config_path.read_text())
+            schema_only = cfg.get("skip_value_extraction", False)
+    except Exception:
+        pass
+
+    return ScheMatiQStatus(
+        session_id=session_id,
+        status=status,
+        progress=progress,
+        current_step="Running" if status == "processing" else status.title(),
+        steps_completed=3 if status == "processing" else (7 if status == "completed" else 0),
+        total_steps=7,
+        schema_completed=schema_completed,
+        columns_discovered=columns_discovered,
+        total_documents=session.metadata.total_documents or 0,
+        processed_documents=session.metadata.processed_documents or 0,
+        llm_stats=session.metadata.processing_stats.get("llm_stats"),
+        schema_only=schema_only,
+    )
+
+
+async def get_schema(session_id: str, session_manager, work_dir: Path) -> Dict[str, Any]:
+    """Get discovered schema."""
+    session = session_manager.get_session(session_id)
+    if session and session.columns:
+        result = {
+            "query": session.schema_query or "",
+            "schema": [col.model_dump() for col in session.columns]
+        }
+        if session.observation_unit:
+            result["observation_unit"] = session.observation_unit.model_dump()
+        return result
+
+    schema_file = work_dir / session_id / "discovered_schema.json"
+    if schema_file.exists():
+        with open(schema_file) as f:
+            return json.load(f)
+
+    if session:
+        return {"query": session.schema_query or "", "schema": []}
+    return {"query": "", "schema": []}
+
+
+async def get_data(
+    session_id: str,
+    work_dir: Path,
+    page: int = 0,
+    page_size: int = 50,
+    filters: Optional[List[Dict]] = None,
+    sort: Optional[List[Dict]] = None,
+    search: Optional[str] = None,
+    document_filter: Optional[List[str]] = None
+) -> PaginatedData:
+    """Get extracted data from all possible locations with optional filtering and sorting."""
+    data_files = []
+
+    extracted_file = work_dir / session_id / "extracted_data.jsonl"
+    if extracted_file.exists():
+        data_files.append(extracted_file)
+
+    if not data_files:
+        schematiq_data_file = work_dir / session_id / "data.jsonl"
+        if schematiq_data_file.exists():
+            data_files.append(schematiq_data_file)
+
+    data_dir_file = Path("./data") / session_id / "data.jsonl"
+    if data_dir_file.exists():
+        if data_dir_file not in data_files:
+            data_files.append(data_dir_file)
+
+    if not data_files:
+        return PaginatedData(rows=[], total_count=0, filtered_count=None, page=page, page_size=page_size, has_more=False)
+
+    from app.services.data_utils import row_dedup_key
+
+    def normalize_row(row_data: dict) -> dict:
+        if '_row_name' in row_data:
+            return {
+                'row_name': row_data.get('_row_name'),
+                'papers': row_data.get('_papers', []),
+                'data': {k: v for k, v in row_data.items() if not k.startswith('_')},
+                'unit_name': row_data.get('_unit_name'),
+                'source_document': row_data.get('_source_document'),
+                'parent_document': row_data.get('_parent_document'),
+                '_cell_status': row_data.get('_cell_status'),
+            }
+        return row_data
+
+    needs_processing = bool(filters or sort or search or document_filter)
+
+    if needs_processing:
+        all_rows = []
+        seen_keys: set = set()
+        for data_file in data_files:
+            file_keys: set = set()
+            with open(data_file, 'r', encoding='utf-8') as f:
+                for line in f:
+                    if line.strip():
+                        try:
+                            row_data = json.loads(line.strip())
+                            key = row_dedup_key(row_data)
+                            if key[0] and key in seen_keys:
+                                continue
+                            if key[0]:
+                                file_keys.add(key)
+                            all_rows.append(normalize_row(row_data))
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+            seen_keys.update(file_keys)
+
+        if document_filter:
+            doc_set = set(document_filter)
+            all_rows = [
+                r for r in all_rows
+                if (r.get('source_document') or r.get('_source_document') or '') in doc_set
+            ]
+
+        total_count = len(all_rows)
+
+        from app.services.file_parser import FileParser
+        parser = FileParser()
+
+        if search and search.strip():
+            all_rows = parser._apply_search(all_rows, search.strip())
+
+        if filters:
+            all_rows = parser._apply_filters(all_rows, filters)
+
+        filtered_count = len(all_rows)
+
+        if sort:
+            all_rows = parser._apply_sort(all_rows, sort)
+
+        start = page * page_size
+        end = start + page_size
+        page_rows = all_rows[start:end]
+
+        rows = [DataRow(**row_data) for row_data in page_rows]
+
+        return PaginatedData(
+            rows=rows,
+            total_count=total_count,
+            filtered_count=filtered_count,
+            page=page,
+            page_size=page_size,
+            has_more=end < filtered_count
+        )
+    else:
+        # Efficient pagination (no filtering/sorting)
+        total_count = 0
+        seen_keys: set = set()
+        for data_file in data_files:
+            file_keys: set = set()
+            with open(data_file, 'r', encoding='utf-8') as f:
+                for line in f:
+                    if not line.strip():
+                        continue
+                    try:
+                        row_data = json.loads(line.strip())
+                        key = row_dedup_key(row_data)
+                        if key[0] and key in seen_keys:
+                            continue
+                        if key[0]:
+                            file_keys.add(key)
+                        total_count += 1
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+            seen_keys.update(file_keys)
+
+        rows = []
+        start_line = page * page_size
+        end_line = start_line + page_size
+        global_line = 0
+        seen_keys_page: set = set()
+
+        for data_file in data_files:
+            if global_line >= end_line:
+                break
+
+            file_keys: set = set()
+            with open(data_file, 'r', encoding='utf-8') as f:
+                for line in f:
+                    if not line.strip():
+                        continue
+                    try:
+                        row_data = json.loads(line.strip())
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                    key = row_dedup_key(row_data)
+                    if key[0] and key in seen_keys_page:
+                        continue
+                    if key[0]:
+                        file_keys.add(key)
+
+                    if global_line >= end_line:
+                        break
+                    if global_line >= start_line:
+                        normalized = normalize_row(row_data)
+                        data_row = DataRow(**normalized)
+                        rows.append(data_row)
+                    global_line += 1
+            seen_keys_page.update(file_keys)
+
+        return PaginatedData(
+            rows=rows,
+            total_count=total_count,
+            filtered_count=None,
+            page=page,
+            page_size=page_size,
+            has_more=end_line < total_count
+        )

--- a/backend/app/services/pipeline/llm_factory.py
+++ b/backend/app/services/pipeline/llm_factory.py
@@ -1,0 +1,86 @@
+"""LLM interface construction and release-mode enforcement."""
+
+import logging
+from typing import Optional
+
+from app.core.config import DEVELOPER_MODE, RELEASE_CONFIG
+
+logger = logging.getLogger(__name__)
+
+from schematiq.core.llm_backends import LLMInterface, TogetherLLM, OpenAILLM, GeminiLLM
+
+
+def build_llm_interface(
+    provider: str,
+    model: str,
+    max_output_tokens: Optional[int],
+    temperature: float,
+    api_key: str = None,
+    context_window_size: Optional[int] = None
+) -> LLMInterface:
+    """Build LLM interface based on provider.
+
+    Args:
+        provider: LLM provider name (together, openai, gemini)
+        model: Model name/identifier (empty string uses provider default)
+        max_output_tokens: Maximum tokens the model can generate in its response.
+            If None, auto-detected from model specs.
+        temperature: Sampling temperature
+        api_key: Optional user-provided API key (falls back to env var if None)
+        context_window_size: Maximum context window size. If None, auto-detected from model specs.
+    """
+    if provider.lower() == "together":
+        if not model:
+            raise ValueError("Model must be specified for Together AI provider")
+        return TogetherLLM(
+            model=model,
+            max_output_tokens=max_output_tokens,
+            temperature=temperature,
+            context_window_size=context_window_size,
+            api_key=api_key
+        )
+    elif provider.lower() == "openai":
+        if not model:
+            raise ValueError("Model must be specified for OpenAI provider")
+        return OpenAILLM(
+            model=model,
+            max_output_tokens=max_output_tokens,
+            temperature=temperature,
+            context_window_size=context_window_size,
+            api_key=api_key
+        )
+    if provider.lower() == "gemini":
+        kwargs = {
+            "max_output_tokens": max_output_tokens,
+            "temperature": temperature,
+            "context_window_size": context_window_size,
+            "api_key": api_key
+        }
+        if model:
+            kwargs["model"] = model
+        llm = GeminiLLM(**kwargs)
+        logger.info(f"Gemini LLM created: model={llm.model}, max_output_tokens={llm.max_output_tokens}, context_window={llm.context_window_size}")
+        return llm
+    else:
+        raise ValueError(f"Unsupported LLM provider: {provider}")
+
+
+def enforce_release_llm_config(backend_config: dict, is_schema_creation: bool = False) -> dict:
+    """Override LLM config with release-mode defaults if not in developer mode.
+
+    Args:
+        backend_config: The original LLM backend configuration dict
+        is_schema_creation: True for schema creation LLM, False for value extraction
+
+    Returns:
+        The config dict, potentially with provider/model/temperature overridden
+    """
+    if DEVELOPER_MODE:
+        return backend_config
+
+    return {
+        **backend_config,
+        "provider": RELEASE_CONFIG["llm_provider"],
+        "model": RELEASE_CONFIG["schema_creation_model"] if is_schema_creation else RELEASE_CONFIG["value_extraction_model"],
+        "temperature": RELEASE_CONFIG["llm_temperature"],
+    }

--- a/backend/app/services/pipeline/schema_discovery.py
+++ b/backend/app/services/pipeline/schema_discovery.py
@@ -1,0 +1,461 @@
+"""Schema discovery pipeline — iterative batch processing with convergence."""
+
+import asyncio
+import functools
+import json
+import logging
+import math
+from typing import Dict, Any, List, Callable, Optional
+from pathlib import Path
+from datetime import datetime
+
+from app.services import schematiq_thread_pool
+
+from schematiq.core import schematiq as ScheMatiQ
+from schematiq.core.schema import Schema, Column, ObservationUnit
+from schematiq.core.llm_backends import LLMInterface
+from schematiq import discover_observation_unit, ObservationUnitDiscoveryError
+
+logger = logging.getLogger(__name__)
+
+
+async def run_schema_discovery(
+    session_id: str,
+    documents: List[str],
+    filenames: List[str],
+    schematiq_config: Dict[str, Any],
+    llm: LLMInterface,
+    retriever,
+    progress_callback,
+    is_stop_requested: Callable[[str], bool],
+    ws_manager=None,
+    work_dir: Optional[Path] = None,
+):
+    """Run real schema discovery using ScheMatiQ pipeline.
+
+    Args:
+        session_id: Session identifier
+        documents: List of document text contents
+        filenames: Corresponding filenames
+        schematiq_config: Full ScheMatiQ configuration dict
+        llm: LLM interface for schema generation
+        retriever: Embedding retriever (or None)
+        progress_callback: Async callback for progress updates
+        is_stop_requested: Callable that checks if stop was requested
+        ws_manager: WebSocket manager for broadcasting schema progress
+        work_dir: Working directory for saving partial schemas
+
+    Returns:
+        Tuple of (discovered_schema, schema_evolution)
+    """
+    from app.models.session import SchemaEvolution, SchemaSnapshot
+
+    query = schematiq_config["query"]
+    max_keys = schematiq_config.get("max_keys_schema", 100)
+
+    # Initialize schema (inline schema takes priority over file path)
+    initial_schema = _load_initial_schema(schematiq_config, query, max_keys)
+    current_schema = initial_schema or Schema(query=query, columns=[], max_keys=max_keys)
+
+    batch_size = schematiq_config.get("documents_batch_size", 1)
+    convergence_threshold = schematiq_config.get("convergence_threshold") or 5
+    unchanged_count = 0
+
+    batches = [documents[i:i+batch_size] for i in range(0, len(documents), batch_size)]
+    filename_batches = [filenames[i:i+batch_size] for i in range(0, len(filenames), batch_size)]
+
+    logger.debug("Document batching - %d docs, batch_size=%d, %d batches", len(documents), batch_size, len(batches))
+
+    evolution = SchemaEvolution(snapshots=[], column_sources={})
+    cumulative_docs = 0
+
+    # Record initial columns (if any) as iteration 0
+    if len(current_schema.columns) > 0:
+        initial_column_names = [col.name for col in current_schema.columns]
+        evolution.snapshots.append(SchemaSnapshot(
+            iteration=0,
+            documents_processed=["initial_schema"],
+            total_columns=len(current_schema.columns),
+            new_columns=initial_column_names,
+            cumulative_documents=0
+        ))
+        for col in current_schema.columns:
+            evolution.column_sources[col.name] = "initial_schema"
+
+    # Handle QUERY_ONLY mode
+    if not documents:
+        return await _run_query_only_discovery(
+            session_id, query, max_keys, schematiq_config, llm, current_schema,
+            evolution, progress_callback
+        )
+
+    # Handle pre-configured observation unit
+    pending_observation_unit_name = None
+    initial_obs_unit = schematiq_config.get("initial_observation_unit")
+    if initial_obs_unit:
+        if initial_obs_unit.get("definition"):
+            current_schema.observation_unit = ObservationUnit(
+                name=initial_obs_unit["name"],
+                definition=initial_obs_unit["definition"]
+            )
+            logger.info("Using pre-configured observation unit: %s - %s", initial_obs_unit['name'], initial_obs_unit['definition'])
+        else:
+            pending_observation_unit_name = initial_obs_unit["name"]
+            logger.info("Observation unit name pre-configured: %s (definition will be discovered)", pending_observation_unit_name)
+
+    for iteration, (batch_docs, batch_names) in enumerate(zip(batches, filename_batches)):
+        if is_stop_requested(session_id):
+            logger.warning("Stop requested during schema discovery - saving partial schema with %d columns", len(current_schema.columns))
+            break
+
+        logger.debug("Schema discovery batch %d/%d (%d docs: %s)", iteration + 1, len(batches), len(batch_docs), batch_names)
+        await progress_callback(f"Schema Discovery: Batch {iteration + 1}/{len(batches)} ({len(batch_docs)} docs)", iteration / len(batches), {
+            "iteration": iteration + 1,
+            "max_iterations": len(batches),
+            "batch_docs": len(batch_docs),
+            "current_columns": len(current_schema.columns)
+        })
+
+        columns_before = {col.name.lower() for col in current_schema.columns}
+        cumulative_docs += len(batch_docs)
+
+        loop = asyncio.get_running_loop()
+        logger.debug("[%s] Offloading select_relevant_content to thread pool", session_id)
+        relevant_content = await loop.run_in_executor(
+            schematiq_thread_pool,
+            functools.partial(
+                ScheMatiQ.select_relevant_content,
+                docs=batch_docs,
+                query=query,
+                retriever=retriever,
+            )
+        )
+        logger.debug("Selected %d relevant passages from batch", len(relevant_content))
+
+        if is_stop_requested(session_id):
+            logger.warning("Stop requested after content retrieval - saving partial schema")
+            break
+
+        # Discover observation unit in first iteration (if not already set)
+        if iteration == 0 and (query or relevant_content) and not current_schema.observation_unit:
+            logger.info("Discovering observation unit from first batch...")
+            try:
+                logger.debug("[%s] Offloading discover_observation_unit to thread pool", session_id)
+                obs_unit = await loop.run_in_executor(
+                    schematiq_thread_pool,
+                    functools.partial(
+                        discover_observation_unit,
+                        query=query,
+                        passages=relevant_content,
+                        llm=llm,
+                        context_window_size=schematiq_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192),
+                        source_document=batch_names[0] if batch_names else None,
+                    )
+                )
+                if pending_observation_unit_name:
+                    logger.info("Overriding discovered name '%s' with pre-configured name '%s'", obs_unit.name, pending_observation_unit_name)
+                    obs_unit.name = pending_observation_unit_name
+                current_schema.observation_unit = obs_unit
+                logger.info("Observation unit set: %s - %s", obs_unit.name, obs_unit.definition)
+                if obs_unit.example_names:
+                    logger.info("   Examples: %s", obs_unit.example_names)
+            except ObservationUnitDiscoveryError as e:
+                logger.error("Observation unit discovery failed: %s", e)
+                raise RuntimeError(
+                    f"Failed to discover observation unit: {e}. "
+                    "Ensure documents contain extractable entities."
+                ) from e
+            except Exception as e:
+                logger.error("Unexpected error during observation unit discovery: %s", e)
+                raise RuntimeError(
+                    f"Observation unit discovery failed unexpectedly: {e}"
+                ) from e
+
+        if is_stop_requested(session_id):
+            logger.warning("Stop requested after observation unit discovery - saving partial schema")
+            break
+
+        # Generate schema for this iteration
+        logger.debug("[%s] Offloading generate_schema to thread pool", session_id)
+        try:
+            schema_result = await loop.run_in_executor(
+                schematiq_thread_pool,
+                functools.partial(
+                    ScheMatiQ.generate_schema,
+                    passages=relevant_content,
+                    query=query,
+                    max_keys_schema=schematiq_config.get("max_keys_schema", 100),
+                    current_schema=current_schema,
+                    llm=llm,
+                    context_window_size=schematiq_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192),
+                )
+            )
+            new_schema = schema_result[0] if isinstance(schema_result, tuple) else schema_result
+            logger.debug("Generated schema with %d columns", len(new_schema.columns))
+        except Exception as e:
+            logger.error("ERROR in generate_schema: %s", e)
+            raise
+
+        if is_stop_requested(session_id):
+            logger.warning("Stop requested after schema generation - saving partial schema")
+            break
+
+        # Merge with existing schema
+        logger.debug("[%s] Offloading schema merge to thread pool", session_id)
+        logger.debug("Current schema has %d columns", len(current_schema.columns))
+        logger.debug("New schema has %d columns", len(new_schema.columns))
+        try:
+            merged_schema = await loop.run_in_executor(
+                schematiq_thread_pool,
+                functools.partial(current_schema.merge, new_schema),
+            )
+            logger.debug("Merged schema has %d columns", len(merged_schema.columns))
+        except Exception as e:
+            logger.error("ERROR in schema merge: %s", e)
+            import traceback
+            traceback.print_exc()
+            raise
+
+        if is_stop_requested(session_id):
+            logger.warning("Stop requested after schema merge - saving partial schema")
+            break
+
+        # Identify NEW columns added in this iteration
+        columns_after = {col.name.lower() for col in merged_schema.columns}
+        new_column_names_lower = columns_after - columns_before
+        new_columns = [col.name for col in merged_schema.columns if col.name.lower() in new_column_names_lower]
+
+        batch_source = ", ".join(batch_names) if batch_names else f"batch_{iteration + 1}"
+        for col_name in new_columns:
+            if col_name not in evolution.column_sources:
+                evolution.column_sources[col_name] = batch_source
+
+        evolution.snapshots.append(SchemaSnapshot(
+            iteration=iteration + 1,
+            documents_processed=batch_names,
+            total_columns=len(merged_schema.columns),
+            new_columns=new_columns,
+            cumulative_documents=cumulative_docs
+        ))
+
+        logger.debug("Evolution - batch %d: %d new columns: %s", iteration + 1, len(new_columns), new_columns)
+
+        # Check convergence
+        logger.debug("[%s] Offloading evaluate_schema_convergence to thread pool", session_id)
+        converged = await loop.run_in_executor(
+            schematiq_thread_pool,
+            functools.partial(ScheMatiQ.evaluate_schema_convergence, current_schema, merged_schema),
+        )
+        if converged:
+            unchanged_count += 1
+            logger.debug("Schema unchanged (count: %d/%d)", unchanged_count, convergence_threshold)
+            if unchanged_count >= convergence_threshold:
+                logger.debug("Schema converged after %d batches", iteration + 1)
+                break
+        else:
+            unchanged_count = 0
+            logger.debug("Schema changed, continuing to next batch")
+
+        current_schema = merged_schema
+        logger.debug("Completed batch %d, moving to next", iteration + 1)
+
+        # Save partial schema to disk after each batch
+        if work_dir:
+            _save_partial_schema(current_schema, query, work_dir / session_id)
+
+        # Notify frontend about partial schema availability
+        if ws_manager:
+            await ws_manager.broadcast_to_session(session_id, {
+                "type": "schema_progress",
+                "timestamp": datetime.now().isoformat(),
+                "data": {
+                    "columns_discovered": len(current_schema.columns),
+                    "iteration": iteration + 1,
+                    "max_iterations": len(batches),
+                    "new_columns": new_columns,
+                }
+            })
+
+        await asyncio.sleep(0.1)
+
+    logger.debug("Schema discovery completed with %d columns after %d batches", len(current_schema.columns), len(evolution.snapshots))
+    logger.debug("Evolution tracking: %d snapshots, %d column sources", len(evolution.snapshots), len(evolution.column_sources))
+    return current_schema, evolution
+
+
+async def _run_query_only_discovery(
+    session_id: str,
+    query: str,
+    max_keys: int,
+    schematiq_config: Dict[str, Any],
+    llm: LLMInterface,
+    current_schema: Schema,
+    evolution,
+    progress_callback,
+):
+    """Handle QUERY_ONLY mode: generate schema from query without documents."""
+    from app.models.session import SchemaSnapshot
+
+    logger.debug("QUERY_ONLY mode - generating schema from query without documents")
+    await progress_callback("Schema Discovery: Planning from query", 0.5, {
+        "mode": "query_only",
+        "current_columns": len(current_schema.columns)
+    })
+
+    try:
+        loop = asyncio.get_running_loop()
+
+        obs_unit_config = schematiq_config.get("initial_observation_unit")
+        if obs_unit_config and obs_unit_config.get("name"):
+            observation_unit = ObservationUnit(
+                name=obs_unit_config["name"],
+                definition=obs_unit_config.get("definition", ""),
+                source_document="query_only",
+                discovery_iteration=1,
+            )
+            logger.info("[%s] QUERY_ONLY: using pre-configured observation unit: %s", session_id, observation_unit.name)
+        else:
+            logger.info("[%s] QUERY_ONLY: discovering observation unit from query", session_id)
+            observation_unit = await loop.run_in_executor(
+                schematiq_thread_pool,
+                functools.partial(
+                    discover_observation_unit,
+                    query=query,
+                    passages=None,
+                    llm=llm,
+                    source_document="query_only",
+                )
+            )
+            logger.info("[%s] QUERY_ONLY: discovered observation unit: %s", session_id, observation_unit.name if observation_unit else None)
+
+        if observation_unit:
+            current_schema.observation_unit = observation_unit
+
+        logger.debug("[%s] Offloading QUERY_ONLY generate_schema to thread pool", session_id)
+        schema_result = await loop.run_in_executor(
+            schematiq_thread_pool,
+            functools.partial(
+                ScheMatiQ.generate_schema,
+                passages=[],
+                query=query,
+                max_keys_schema=schematiq_config.get("max_keys_schema", 100),
+                current_schema=current_schema,
+                llm=llm,
+                context_window_size=schematiq_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192),
+                observation_unit=observation_unit,
+            )
+        )
+        new_schema = schema_result[0] if isinstance(schema_result, tuple) else schema_result
+        logger.debug("QUERY_ONLY generated schema with %d columns", len(new_schema.columns))
+
+        if current_schema.columns:
+            logger.debug("[%s] Offloading QUERY_ONLY schema merge to thread pool", session_id)
+            merged_schema = await loop.run_in_executor(
+                schematiq_thread_pool,
+                functools.partial(current_schema.merge, new_schema),
+            )
+        else:
+            merged_schema = new_schema
+
+        if observation_unit and not merged_schema.observation_unit:
+            merged_schema.observation_unit = observation_unit
+
+        new_column_names = [col.name for col in merged_schema.columns
+                           if col.name not in {c.name for c in current_schema.columns}]
+
+        for col_name in new_column_names:
+            evolution.column_sources[col_name] = "query_only"
+
+        evolution.snapshots.append(SchemaSnapshot(
+            iteration=1,
+            documents_processed=["query_only"],
+            total_columns=len(merged_schema.columns),
+            new_columns=new_column_names,
+            cumulative_documents=0
+        ))
+
+        logger.debug("QUERY_ONLY mode completed with %d columns: %s", len(merged_schema.columns), [c.name for c in merged_schema.columns])
+        return merged_schema, evolution
+
+    except Exception as e:
+        logger.error("ERROR in QUERY_ONLY generate_schema: %s", e)
+        import traceback
+        traceback.print_exc()
+        raise
+
+
+def _load_initial_schema(schematiq_config: Dict[str, Any], query: str, max_keys: int) -> Optional[Schema]:
+    """Load initial schema from inline config or file path."""
+    if "initial_schema" in schematiq_config:
+        try:
+            columns = []
+            for col_data in schematiq_config["initial_schema"]:
+                col = Column(
+                    name=col_data["name"],
+                    definition=col_data.get("definition", ""),
+                    rationale=col_data.get("rationale", ""),
+                    allowed_values=col_data.get("allowed_values")
+                )
+                columns.append(col)
+            initial_schema = Schema(query=query, columns=columns, max_keys=max_keys)
+            logger.info("Loaded inline initial schema with %d columns", len(columns))
+            return initial_schema
+        except Exception as e:
+            logger.warning("Could not load inline initial schema: %s", e)
+
+    elif "initial_schema_path" in schematiq_config:
+        try:
+            with open(schematiq_config["initial_schema_path"]) as f:
+                initial_data = json.load(f)
+                if isinstance(initial_data, list):
+                    columns = [
+                        Column(
+                            name=col_data["name"],
+                            definition=col_data.get("definition", ""),
+                            rationale=col_data.get("rationale", ""),
+                            allowed_values=col_data.get("allowed_values")
+                        )
+                        for col_data in initial_data
+                    ]
+                    initial_schema = Schema(query=query, columns=columns, max_keys=max_keys)
+                elif isinstance(initial_data, dict) and "schema" in initial_data:
+                    columns = [
+                        Column(
+                            name=col_data["name"],
+                            definition=col_data.get("definition", ""),
+                            rationale=col_data.get("rationale", ""),
+                            allowed_values=col_data.get("allowed_values")
+                        )
+                        for col_data in initial_data["schema"]
+                    ]
+                    initial_schema = Schema(query=query, columns=columns, max_keys=max_keys)
+                else:
+                    return None
+            logger.info("Loaded initial schema from file with %d columns", len(columns))
+            return initial_schema
+        except Exception as e:
+            logger.warning("Could not load initial schema from file: %s", e)
+
+    return None
+
+
+def _save_partial_schema(schema: Schema, query: str, session_dir: Path) -> None:
+    """Save partial schema to disk for stop resilience."""
+    partial_schema_file = session_dir / "discovered_schema.json"
+    frontend_schema = []
+    for col in schema.columns:
+        col_dict = col.to_dict()
+        frontend_col = {
+            "name": col_dict.get("column", col.name),
+            "definition": col_dict.get("definition", ""),
+            "rationale": col_dict.get("explanation", col.rationale)
+        }
+        if col_dict.get("allowed_values"):
+            frontend_col["allowed_values"] = col_dict["allowed_values"]
+        frontend_schema.append(frontend_col)
+    partial_schema_data = {"query": query, "schema": frontend_schema}
+    if schema.observation_unit:
+        partial_schema_data["observation_unit"] = schema.observation_unit.to_dict()
+    with open(partial_schema_file, 'w') as f:
+        json.dump(partial_schema_data, f, indent=2)
+    logger.debug("Saved partial schema with %d columns", len(schema.columns))

--- a/backend/app/services/pipeline/value_extraction.py
+++ b/backend/app/services/pipeline/value_extraction.py
@@ -1,0 +1,293 @@
+"""Value extraction pipeline — extracts structured data from documents using a discovered schema."""
+
+import asyncio
+import json
+import logging
+import time
+from typing import Dict, Any, List, Callable, Optional
+from pathlib import Path
+from datetime import datetime
+
+from app.services import schematiq_thread_pool
+from app.services.pipeline.callbacks import create_value_extracted_callback, create_warning_callback
+
+from schematiq.core.schema import Schema
+from schematiq.core.llm_backends import LLMInterface
+from schematiq.value_extraction.main import build_table_jsonl
+
+logger = logging.getLogger(__name__)
+
+
+async def run_value_extraction(
+    session_id: str,
+    schematiq_config: Dict[str, Any],
+    schema: Schema,
+    llm: LLMInterface,
+    retriever,
+    progress_callback,
+    is_stop_requested: Callable[[str], bool],
+    ws_mixin,
+    ws_manager,
+    session_manager,
+    work_dir: Path,
+) -> List[str]:
+    """Run real value extraction using the value extraction pipeline.
+
+    Returns:
+        List of skipped document names (documents with no observation units found)
+    """
+    session_dir = work_dir / session_id
+
+    # Save schema in value extraction format
+    schema_data = schema.to_full_dict()
+    value_extraction_schema_path = session_dir / "value_extraction_schema.json"
+    with open(value_extraction_schema_path, 'w') as f:
+        json.dump(schema_data, f, indent=2)
+
+    # Prepare documents directories
+    docs_paths = schematiq_config["docs_path"]
+    if isinstance(docs_paths, str):
+        docs_paths = [docs_paths]
+
+    docs_directories = [Path(path) for path in docs_paths]
+    output_path = session_dir / "extracted_data.jsonl"
+
+    # Count total documents for progress tracking
+    total_documents = 0
+    for docs_dir in docs_directories:
+        if docs_dir.exists():
+            doc_files = list(docs_dir.glob("*.txt")) + list(docs_dir.glob("*.md"))
+            total_documents += len(doc_files)
+
+    # Update session metadata
+    session = session_manager.get_session(session_id)
+    session.metadata.total_documents = total_documents
+    session.metadata.processed_documents = 0
+    session_manager.update_session(session)
+
+    loop = asyncio.get_event_loop()
+
+    on_value_extracted = create_value_extracted_callback(ws_mixin, session_id, loop)
+    on_warning = create_warning_callback(ws_manager, session_id, loop)
+
+    extraction_result = {}
+
+    def should_stop():
+        return is_stop_requested(session_id)
+
+    def run_extraction():
+        nonlocal extraction_result
+        extraction_result = build_table_jsonl(
+            schema_path=value_extraction_schema_path,
+            docs_directories=docs_directories,
+            output_path=output_path,
+            llm=llm,
+            retriever=retriever,
+            resume=False,
+            mode="all",
+            retrieval_k=8,
+            max_workers=1,
+            on_value_extracted=on_value_extracted,
+            should_stop=should_stop,
+            on_warning=on_warning
+        )
+        return extraction_result
+
+    # Track progress by monitoring output file
+    extraction_task = loop.run_in_executor(schematiq_thread_pool, run_extraction)
+
+    start_time = time.time()
+    last_line_count = 0
+    last_update_time = time.time()
+    prev_completed_documents = set()
+
+    stopped_early = False
+    stop_requested_at = None
+    MAX_STOP_WAIT = 120
+
+    while not extraction_task.done():
+        if is_stop_requested(session_id):
+            if stop_requested_at is None:
+                logger.warning("Stop requested during value extraction - waiting for graceful stop")
+                stop_requested_at = time.time()
+                stopped_early = True
+
+            elapsed = time.time() - stop_requested_at
+            if elapsed > MAX_STOP_WAIT:
+                logger.warning("Graceful stop timeout after %ds - forcing exit", MAX_STOP_WAIT)
+                break
+
+            await asyncio.sleep(0.5)
+            continue
+
+        try:
+            current_time = time.time()
+
+            if output_path.exists():
+                completed_documents = set()
+                current_line_count = 0
+                with open(output_path, 'r') as f:
+                    for line in f:
+                        current_line_count += 1
+                        try:
+                            row_data = json.loads(line)
+                            metadata = row_data.get("_metadata", {})
+                            doc_name = metadata.get("base_row_name") or row_data.get("_row_name")
+                            if doc_name:
+                                completed_documents.add(doc_name)
+                        except json.JSONDecodeError:
+                            pass
+
+                completed_doc_count = len(completed_documents)
+
+                if current_line_count > last_line_count:
+                    session = session_manager.get_session(session_id)
+                    session.metadata.processed_documents = min(completed_doc_count, total_documents)
+                    session_manager.update_session(session)
+
+                    newly_completed = list(completed_documents - prev_completed_documents)
+
+                    await ws_mixin.broadcast_row_completed(session_id, {
+                        "row_index": completed_doc_count,
+                        "total_rows": total_documents,
+                        "completed_at": datetime.now().isoformat(),
+                        "document_names": newly_completed,
+                        "elapsed_seconds": int(current_time - start_time),
+                    })
+
+                    prev_completed_documents = set(completed_documents)
+                    last_line_count = current_line_count
+                    last_update_time = current_time
+
+            await asyncio.sleep(2)
+
+        except Exception as e:
+            logger.warning("Progress monitoring error: %s", e)
+            await asyncio.sleep(2)
+
+    # Wait for completion
+    if not stopped_early:
+        try:
+            extraction_result = await extraction_task
+        except Exception as e:
+            raise RuntimeError(f"Value extraction failed: {e}")
+    else:
+        try:
+            await asyncio.wait_for(asyncio.shield(extraction_task), timeout=5.0)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            pass
+
+    # Final progress update
+    final_line_count = 0
+    if output_path.exists():
+        with open(output_path, 'r') as f:
+            final_line_count = sum(1 for _ in f)
+
+    session = session_manager.get_session(session_id)
+    session.metadata.processed_documents = final_line_count
+    session_manager.update_session(session)
+
+    if stopped_early:
+        logger.warning("Value extraction stopped early with %d rows extracted", final_line_count)
+        return []
+
+    suggested_values = extraction_result.get("suggested_values", {}) if extraction_result else {}
+    skipped_documents = extraction_result.get("skipped_documents", []) if extraction_result else []
+
+    if skipped_documents:
+        names = ', '.join(skipped_documents[:5])
+        suffix = f' and {len(skipped_documents) - 5} more' if len(skipped_documents) > 5 else ''
+        await ws_manager.broadcast_log(session_id, {
+            "level": "warning",
+            "message": f"{len(skipped_documents)} document(s) skipped: {names}{suffix}"
+        })
+
+    if suggested_values:
+        await process_suggested_values(session, schema, suggested_values, ws_manager)
+
+    session_manager.update_session(session)
+
+    await progress_callback("Value Extraction: Complete", 1.0, {
+        "rows_extracted": final_line_count,
+        "total_documents": total_documents,
+        "elapsed_time": int(time.time() - start_time),
+        "suggested_values_count": sum(len(vals) for vals in suggested_values.values()) if suggested_values else 0,
+        "skipped_documents": skipped_documents,
+        "skipped_documents_count": len(skipped_documents)
+    })
+
+    return skipped_documents
+
+
+async def process_suggested_values(
+    session,
+    schema: Schema,
+    suggested_values: Dict[str, Dict[str, Any]],
+    ws_manager,
+):
+    """Process suggested values from value extraction for schema evolution.
+
+    For each column with allowed_values:
+    - Auto-add values that meet the column's auto_expand_threshold
+    - Store remaining values as pending_values for user review
+    """
+    from app.models.session import PendingValue
+
+    if not suggested_values:
+        return
+
+    logger.info("Processing %d suggested values for schema evolution", sum(len(vals) for vals in suggested_values.values()))
+
+    for col in session.columns:
+        if col.name not in suggested_values:
+            continue
+
+        col_suggestions = suggested_values[col.name]
+        if not col_suggestions:
+            continue
+
+        threshold = col.auto_expand_threshold if col.auto_expand_threshold is not None else 2
+
+        auto_added = []
+        pending = []
+
+        for value, details in col_suggestions.items():
+            doc_count = details.get("count", 0)
+            documents = details.get("documents", [])
+
+            if col.allowed_values and value in col.allowed_values:
+                continue
+
+            if threshold > 0 and doc_count >= threshold:
+                if col.allowed_values is None:
+                    col.allowed_values = []
+                col.allowed_values.append(value)
+                auto_added.append(value)
+                logger.info("  Auto-added '%s' to %s (appeared in %d docs, threshold=%d)", value, col.name, doc_count, threshold)
+            else:
+                pending.append(PendingValue(
+                    value=value,
+                    document_count=doc_count,
+                    first_seen=datetime.now(),
+                    documents=documents[:10]
+                ))
+
+        if pending:
+            if col.pending_values is None:
+                col.pending_values = []
+            col.pending_values.extend(pending)
+            logger.info("  Added %d pending values to %s for review", len(pending), col.name)
+
+        if auto_added:
+            logger.info("  Auto-expanded %s allowed_values with %d new values", col.name, len(auto_added))
+
+    total_auto_added = sum(1 for col in session.columns if col.allowed_values)
+    total_pending = sum(len(col.pending_values or []) for col in session.columns)
+
+    if total_auto_added > 0 or total_pending > 0:
+        await ws_manager.broadcast_schema_updated(session.id, {
+            "operation": "schema_evolution",
+            "auto_added_values": total_auto_added,
+            "pending_values": total_pending,
+            "columns": [col.model_dump(mode='json') for col in session.columns]
+        })

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -203,48 +203,8 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
     @staticmethod
     def _is_local_path(path: str) -> bool:
-        """
-        Check if a path looks like a local filesystem path rather than a cloud storage path.
-
-        Local paths typically look like:
-        - /app/backend/data/{uuid}/pending_documents
-        - ./data/{uuid}/pending_documents
-        - /Users/.../data/...
-
-        Cloud storage paths look like:
-        - NES_documents
-        - datasets/papers_CoT
-        - files
-        """
-        if not path:
-            return False
-
-        # Common indicators of local filesystem paths
-        local_indicators = [
-            '/app/',           # Docker/Railway container paths
-            '/data/',          # Generic data directory
-            '/backend/',       # Backend directory
-            'pending_documents',  # Upload staging directory
-            '/Users/',         # macOS user paths
-            '/home/',          # Linux home paths
-            'C:\\',            # Windows paths
-            'D:\\',            # Windows paths
-            './',              # Relative paths
-            '../',             # Relative paths
-            'schematiq_work/', # Local ScheMatiQ working directory
-            'qbsd_work/',      # Legacy QBSD working directory
-        ]
-
-        for indicator in local_indicators:
-            if indicator in path:
-                return True
-
-        # Also check if path starts with / and has multiple segments
-        # (cloud paths are typically simple folder names like "NES_documents")
-        if path.startswith('/') and path.count('/') > 2:
-            return True
-
-        return False
+        from app.services.data_utils import is_local_path
+        return is_local_path(path)
 
     @staticmethod
     def calculate_column_checksum(column: ColumnInfo) -> str:
@@ -811,36 +771,6 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 logger.debug(f"Error downloading {paper_name} from Supabase: {e}")
 
         return downloaded
-
-    def _find_paper_path(self, session_dir: Path, paper_name: str) -> Optional[Path]:
-        """Find the actual file path for a paper name.
-
-        Checks both documents/ and pending_documents/ directories.
-        """
-        docs_dir = session_dir / "documents"
-        pending_dir = session_dir / "pending_documents"
-
-        # Check both directories
-        for search_dir in [docs_dir, pending_dir]:
-            if not search_dir.exists():
-                continue
-
-            # Try exact match
-            exact = search_dir / paper_name
-            if exact.exists():
-                return exact
-
-            # Try with .txt extension
-            with_ext = search_dir / f"{paper_name}.txt"
-            if with_ext.exists():
-                return with_ext
-
-            # Try matching stem
-            for f in search_dir.iterdir():
-                if f.is_file() and f.stem == paper_name:
-                    return f
-
-        return None
 
     # ==================== Re-extraction ====================
 

--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -1,12 +1,11 @@
-"""ScheMatiQ integration service."""
+"""ScheMatiQ integration service — thin facade delegating to pipeline modules."""
 
 import json
 import asyncio
-import functools
 import logging
-import math
 import os
 import random
+import shutil
 import threading
 import time
 from typing import Dict, Any, Optional, List
@@ -17,106 +16,30 @@ from app.core.config import MAX_DOCUMENTS, DEVELOPER_MODE, RELEASE_CONFIG, LLM_C
 from app.core.logging_utils import set_session_context
 from app.services import schematiq_thread_pool, concurrency_limiter
 
+from app.services.pipeline.llm_factory import build_llm_interface, enforce_release_llm_config
+from app.services.pipeline.callbacks import start_heartbeat
+from app.services.pipeline.config_handler import (
+    resolve_docs_paths, convert_config_to_schematiq_format, validate_config as _validate_config,
+)
+from app.services.pipeline.schema_discovery import run_schema_discovery
+from app.services.pipeline.value_extraction import run_value_extraction
+from app.services.pipeline.data_query import (
+    compute_statistics, get_status as _get_status, get_schema as _get_schema, get_data as _get_data,
+)
+
 logger = logging.getLogger(__name__)
 
-# Project root for path resolution
-PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
-
-# ScheMatiQ library imports
-from schematiq.core import schematiq as ScheMatiQ
-from schematiq.core.schema import Schema, Column, ObservationUnit
-from schematiq.core.llm_backends import LLMInterface, TogetherLLM, OpenAILLM, GeminiLLM
+from schematiq.core.schema import Schema, ObservationUnit
+from schematiq.core.llm_backends import LLMInterface
 from schematiq.core.llm_call_tracker import LLMCallTracker, GlobalLLMUsageTracker, QuotaExceededError
 from schematiq.core.cost_estimator import estimate_from_config
 from schematiq.core.retrievers import EmbeddingRetriever
-from schematiq.value_extraction.main import build_table_jsonl
-from schematiq import discover_observation_unit, ObservationUnitDiscoveryError
-
-SCHEMATIQ_AVAILABLE = True
-
-def build_llm_interface(
-    provider: str,
-    model: str,
-    max_output_tokens: Optional[int],
-    temperature: float,
-    api_key: str = None,
-    context_window_size: Optional[int] = None
-):
-    """Build LLM interface based on provider.
-
-    Args:
-        provider: LLM provider name (together, openai, gemini)
-        model: Model name/identifier (empty string uses provider default)
-        max_output_tokens: Maximum tokens the model can generate in its response.
-            If None, auto-detected from model specs.
-        temperature: Sampling temperature
-        api_key: Optional user-provided API key (falls back to env var if None)
-        context_window_size: Maximum context window size. If None, auto-detected from model specs.
-    """
-    if not SCHEMATIQ_AVAILABLE:
-        raise RuntimeError("ScheMatiQ components not available")
-
-    if provider.lower() == "together":
-        if not model:
-            raise ValueError("Model must be specified for Together AI provider")
-        return TogetherLLM(
-            model=model,
-            max_output_tokens=max_output_tokens,  # None = auto-detect
-            temperature=temperature,
-            context_window_size=context_window_size,  # None = auto-detect
-            api_key=api_key
-        )
-    elif provider.lower() == "openai":
-        if not model:
-            raise ValueError("Model must be specified for OpenAI provider")
-        return OpenAILLM(
-            model=model,
-            max_output_tokens=max_output_tokens,  # None = auto-detect
-            temperature=temperature,
-            context_window_size=context_window_size,  # None = auto-detect
-            api_key=api_key
-        )
-    if provider.lower() == "gemini":
-        # Token limits are auto-detected from model specs when None
-        kwargs = {
-            "max_output_tokens": max_output_tokens,  # None = auto-detect
-            "temperature": temperature,
-            "context_window_size": context_window_size,  # None = auto-detect
-            "api_key": api_key
-        }
-        if model:  # Only pass model if explicitly set
-            kwargs["model"] = model
-        llm = GeminiLLM(**kwargs)
-        logger.info(f"Gemini LLM created: model={llm.model}, max_output_tokens={llm.max_output_tokens}, context_window={llm.context_window_size}")
-        return llm
-    else:
-        raise ValueError(f"Unsupported LLM provider: {provider}")
-
-
-def enforce_release_llm_config(backend_config: dict, is_schema_creation: bool = False) -> dict:
-    """Override LLM config with release-mode defaults if not in developer mode.
-
-    Args:
-        backend_config: The original LLM backend configuration dict
-        is_schema_creation: True for schema creation LLM, False for value extraction
-
-    Returns:
-        The config dict, potentially with provider/model/temperature overridden
-    """
-    if DEVELOPER_MODE:
-        return backend_config  # No override in developer mode
-
-    # Force release-mode LLM settings
-    return {
-        **backend_config,
-        "provider": RELEASE_CONFIG["llm_provider"],
-        "model": RELEASE_CONFIG["schema_creation_model"] if is_schema_creation else RELEASE_CONFIG["value_extraction_model"],
-        "temperature": RELEASE_CONFIG["llm_temperature"],
-    }
-
 
 from app.models.schematiq import ScheMatiQConfig, ScheMatiQStatus
-from app.models.session import ColumnInfo, DataStatistics, DataRow, PaginatedData, SessionStatus, SchemaEvolution, SchemaSnapshot, VisualizationSession, ObservationUnitInfo
+from app.models.session import (
+    ColumnInfo, DataStatistics, DataRow, PaginatedData, SessionStatus,
+    SchemaEvolution, SchemaSnapshot, VisualizationSession, ObservationUnitInfo,
+)
 from app.services.websocket_manager import WebSocketManager
 from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
@@ -124,11 +47,10 @@ from app.storage import get_storage
 
 class ScheMatiQRunner(WebSocketBroadcasterMixin):
     """Handles ScheMatiQ execution and integration."""
-    
+
     def __init__(self, work_dir: str = "./schematiq_work", websocket_manager=None, session_manager=None,
                  data_collection_service=None, pubmed_enrichment_service=None,
                  uniprot_enrichment_service=None):
-        # Use provided managers or create new ones
         if websocket_manager is not None:
             self.websocket_manager = websocket_manager
         else:
@@ -139,7 +61,6 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         else:
             self.session_manager = SessionManager()
 
-        # Initialize mixin
         super().__init__(self.websocket_manager)
 
         self.work_dir = Path(work_dir)
@@ -148,18 +69,14 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         self._data_collection_service = data_collection_service
         self._pubmed_enrichment_service = pubmed_enrichment_service
         self._uniprot_enrichment_service = uniprot_enrichment_service
-        self.stop_flags: Dict[str, bool] = {}  # Track stop requests per session
+        self.stop_flags: Dict[str, bool] = {}
         self._state_lock = threading.Lock()
         self._global_usage = GlobalLLMUsageTracker(self.work_dir / "global_llm_usage.json")
 
-    def _sync_usage_from_sheets(self) -> None:
-        """Sync the local global usage file from Google Sheets.
+    # ── Usage tracking ─────────────────────────────────────────────
 
-        After a redeploy the local file is empty, but Google Sheets retains
-        the full history.  This reads the cumulative LLM call total from
-        the Sheet and updates the local tracker if it is behind.
-        Fails silently if Sheets is not configured.
-        """
+    def _sync_usage_from_sheets(self) -> None:
+        """Sync the local global usage file from Google Sheets."""
         try:
             from app.storage.google_sheets import GoogleSheetsLogger
             sheets = GoogleSheetsLogger.get_instance()
@@ -172,12 +89,7 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
             logger.debug("Could not sync usage from Google Sheets: %s", e)
 
     def _log_llm_usage_to_sheets(self, session_id: str, counts: dict) -> None:
-        """Write this session's LLM usage to Google Sheets.
-
-        Called directly from the runner so it works independently of
-        DataCollectionService (which may be disabled in developer mode).
-        Fails silently if Sheets is not configured.
-        """
+        """Write this session's LLM usage to Google Sheets."""
         try:
             from app.storage.google_sheets import GoogleSheetsLogger
             sheets = GoogleSheetsLogger.get_instance()
@@ -188,22 +100,18 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         except Exception as e:
             logger.debug("Could not log LLM usage to Google Sheets: %s", e)
 
+    # ── Stop management ────────────────────────────────────────────
+
     def is_stop_requested(self, session_id: str) -> bool:
-        """Check if stop has been requested for a session."""
         with self._state_lock:
             return self.stop_flags.get(session_id, False)
 
     def clear_stop_flag(self, session_id: str):
-        """Clear the stop flag for a session."""
         with self._state_lock:
             self.stop_flags.pop(session_id, None)
 
     async def request_stop(self, session_id: str) -> Dict[str, Any]:
-        """Set the stop flag for a session and return immediately.
-
-        The running task detects the flag at its next checkpoint,
-        handles cleanup, updates session status, and broadcasts 'stopped'.
-        """
+        """Set the stop flag for a session and return immediately."""
         with self._state_lock:
             if session_id not in self.running_sessions:
                 return {"accepted": False, "message": "No running session found"}
@@ -212,2244 +120,8 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         logger.info("Stop requested for session %s", session_id)
         return {"accepted": True, "message": "Stop signal sent"}
 
-    def _create_value_extracted_callback(self, session_id: str, loop: asyncio.AbstractEventLoop):
-        """Create a callback that streams extracted cell values via WebSocket.
-
-        The callback bridges sync extraction code to async WebSocket broadcasting.
-        """
-        def on_value_extracted(row_name: str, column_name: str, value: Any):
-            """Called for each cell value as it's extracted."""
-            try:
-                asyncio.run_coroutine_threadsafe(
-                    self.broadcast_cell_extracted(session_id, {
-                        "row_name": row_name,
-                        "column": column_name,
-                        "value": value
-                    }),
-                    loop
-                )
-            except Exception as e:
-                logger.warning("Failed to broadcast cell %s for %s: %s", column_name, row_name, e)
-
-        return on_value_extracted
-
-    def _create_warning_callback(self, session_id: str, loop: asyncio.AbstractEventLoop):
-        """Create a callback that broadcasts warnings via WebSocket.
-
-        The callback bridges sync extraction code to async WebSocket broadcasting.
-        Used to surface issues like observation unit parsing failures to the UI.
-        """
-        def on_warning(paper_title: str, warning_type: str, message: str):
-            """Called when a warning occurs during extraction."""
-            try:
-                asyncio.run_coroutine_threadsafe(
-                    self.websocket_manager.broadcast_log(session_id, {
-                        "level": "warning",
-                        "message": f"[{paper_title}] {warning_type}: {message}",
-                        "paper_title": paper_title,
-                        "warning_type": warning_type,
-                        "details": message
-                    }),
-                    loop
-                )
-            except Exception as e:
-                logger.warning("Failed to broadcast warning for %s: %s", paper_title, e)
-
-        return on_warning
-
-    async def _start_heartbeat(self, session_id: str, interval: float = 15.0) -> asyncio.Task:
-        """Start a background heartbeat to keep WebSocket alive during long operations.
-
-        Args:
-            session_id: The session to send heartbeats to
-            interval: Seconds between heartbeat messages (default 15s)
-
-        Returns:
-            The heartbeat task (caller should cancel when done)
-        """
-        async def heartbeat_loop():
-            while True:
-                await asyncio.sleep(interval)
-                try:
-                    await self.websocket_manager.broadcast_log(session_id, {
-                        "level": "info",
-                        "message": "Processing... (still working)"
-                    })
-                except Exception as e:
-                    logger.warning("Heartbeat failed: %s", e)
-                    break
-
-        return asyncio.create_task(heartbeat_loop())
-
-    async def _download_supabase_dataset(self, dataset_name: str, session_dir: Path) -> Optional[str]:
-        """Download a Supabase dataset to local directory.
-
-        Args:
-            dataset_name: Name of the dataset in Supabase
-            session_dir: Session work directory
-
-        Returns:
-            Local path to downloaded dataset, or None if not a Supabase dataset
-        """
-        storage = get_storage()
-
-        # Check if this is a Supabase dataset
-        try:
-            datasets = await storage.list_datasets()
-            dataset_names = [d.name for d in datasets]
-
-            if dataset_name in dataset_names:
-                # It's a Supabase dataset - download it
-                local_dataset_dir = session_dir / "datasets" / dataset_name
-                local_dataset_dir.mkdir(parents=True, exist_ok=True)
-
-                logger.info("Downloading Supabase dataset '%s' to %s", dataset_name, local_dataset_dir)
-                downloaded_files = await storage.download_dataset_to_local(dataset_name, str(local_dataset_dir))
-                logger.info("Downloaded %d files from '%s'", len(downloaded_files), dataset_name)
-
-                return str(local_dataset_dir)
-        except Exception as e:
-            logger.warning("Error checking/downloading Supabase dataset '%s': %s", dataset_name, e)
-
-        return None
-
-    def _convert_config_to_schematiq_format_sync(self, config: ScheMatiQConfig, session_id: str, resolved_docs_paths: List[str]) -> Dict[str, Any]:
-        """Synchronous part of config conversion after paths are resolved."""
-        session_dir = self.work_dir / session_id
-
-        # Build ScheMatiQ config with pre-resolved paths
-        schematiq_config = {
-            "query": config.query,
-            "docs_path": resolved_docs_paths[0] if len(resolved_docs_paths) == 1 else resolved_docs_paths,
-            "max_keys_schema": config.max_keys_schema,
-            "documents_batch_size": config.documents_batch_size,
-            "output_path": str(session_dir / "discovered_schema.json"),
-            "document_randomization_seed": config.document_randomization_seed,
-            "skip_value_extraction": config.skip_value_extraction,
-            "convergence_threshold": config.convergence_threshold,
-            "schema_creation_backend": {
-                "provider": config.schema_creation_backend.provider,
-                "model": config.schema_creation_backend.model,
-                "max_output_tokens": config.schema_creation_backend.max_output_tokens,
-                "temperature": config.schema_creation_backend.temperature,
-                "context_window_size": config.schema_creation_backend.context_window_size,
-                "api_key": config.schema_creation_backend.api_key
-            },
-            "value_extraction_backend": {
-                "provider": config.value_extraction_backend.provider,
-                "model": config.value_extraction_backend.model,
-                "max_output_tokens": config.value_extraction_backend.max_output_tokens,
-                "temperature": config.value_extraction_backend.temperature,
-                "context_window_size": config.value_extraction_backend.context_window_size,
-                "api_key": config.value_extraction_backend.api_key
-            }
-        }
-
-        # Add retriever config if provided
-        if config.retriever:
-            schematiq_config["retriever"] = {
-                "type": "embedding",
-                "model_name": config.retriever.model_name,
-                "k": config.retriever.k,
-                "passage_chars": config.retriever.passage_chars,
-                "overlap": config.retriever.overlap,
-                "enable_dynamic_k": config.retriever.enable_dynamic_k,
-                "dynamic_k_threshold": config.retriever.dynamic_k_threshold,
-                "dynamic_k_minimum": config.retriever.dynamic_k_minimum
-            }
-
-        # Add initial schema if provided
-        if config.initial_schema:
-            schematiq_config["initial_schema"] = [
-                {
-                    "name": col.name,
-                    "definition": col.definition,
-                    "rationale": col.rationale,
-                    "allowed_values": col.allowed_values
-                }
-                for col in config.initial_schema
-            ]
-        elif config.initial_schema_path:
-            initial_schema_path = Path(config.initial_schema_path)
-            if not initial_schema_path.is_absolute():
-                initial_schema_path = (PROJECT_ROOT / initial_schema_path).resolve()
-            if initial_schema_path.exists():
-                schematiq_config["initial_schema_path"] = str(initial_schema_path)
-
-        # Add initial observation unit if provided
-        if config.initial_observation_unit:
-            schematiq_config["initial_observation_unit"] = {
-                "name": config.initial_observation_unit.name,
-                "definition": config.initial_observation_unit.definition
-            }
-
-        # Add review_observation_unit flag
-        schematiq_config["review_observation_unit"] = config.review_observation_unit
-
-        return schematiq_config
-
-    async def _resolve_docs_paths(self, config: ScheMatiQConfig, session_id: str) -> List[str]:
-        """Resolve document paths - download from Supabase if needed, or use uploaded files."""
-        session_dir = self.work_dir / session_id
-        session_dir.mkdir(parents=True, exist_ok=True)
-
-        # Check for uploaded documents in data/{session_id}/pending_documents/ directory
-        # (documents are uploaded via add-documents endpoint which uses ./data, not ./schematiq_work)
-        data_dir = Path("./data") / session_id / "pending_documents"
-        if data_dir.exists():
-            uploaded_files = [f for f in sorted(data_dir.iterdir())
-                            if f.is_file() and not f.name.startswith('.')]
-            if uploaded_files:
-                logger.info("Using %d uploaded documents from %s", len(uploaded_files), data_dir)
-                # Return the directory containing the files, not individual files
-                return [str(data_dir.absolute())]
-
-        # No uploaded files - resolve from config.docs_path
-        docs_paths = config.docs_path if isinstance(config.docs_path, list) else [config.docs_path]
-        # Filter out None and empty values
-        docs_paths = [p for p in docs_paths if p]
-
-        if not docs_paths:
-            logger.warning("No document paths configured and no uploaded documents found")
-            return []
-
-        resolved_docs_paths = []
-
-        for path in docs_paths:
-            # First, try to download from Supabase
-            supabase_path = await self._download_supabase_dataset(path, session_dir)
-            if supabase_path:
-                resolved_docs_paths.append(supabase_path)
-                continue
-
-            # Not a Supabase dataset - try local paths
-            doc_path = Path(path)
-            if not doc_path.is_absolute():
-                # Try relative to project root and common paths
-                candidates = [
-                    PROJECT_ROOT / path,
-                    PROJECT_ROOT / "research" / "data" / Path(path).name,
-                    PROJECT_ROOT / "test" / "files",
-                    Path.cwd() / path,
-                    Path.cwd().parent / path,
-                ]
-                for candidate in candidates:
-                    if candidate.exists():
-                        resolved_docs_paths.append(str(candidate.absolute()))
-                        logger.info("Resolved document path: %s -> %s", path, candidate.absolute())
-                        break
-                else:
-                    logger.warning("Document path not found: %s", path)
-                    resolved_docs_paths.append(path)
-            else:
-                resolved_docs_paths.append(str(doc_path))
-
-        return resolved_docs_paths
-
-    async def validate_config(self, config: ScheMatiQConfig) -> Dict[str, Any]:
-        """Validate ScheMatiQ configuration.
-
-        Supports three modes:
-        - Standard: Both query and documents provided
-        - Document-only: Documents provided, no query (schema discovered from document content)
-        - Query-only: Query provided, no documents (schema planned based on query)
-
-        At least one of query or documents must be provided.
-        """
-        errors = []
-        warnings = []
-
-        # Check if we have query and/or documents
-        has_query = bool(config.query and config.query.strip())
-        docs_paths = config.docs_path if isinstance(config.docs_path, list) else [config.docs_path]
-        has_documents = bool(docs_paths and any(p for p in docs_paths if p)) or config.upload_pending
-
-        # Validate: at least one of query or documents must be provided
-        if not has_query and not has_documents:
-            errors.append("At least one of query or documents must be provided")
-        
-        # Validate document paths (only if actual paths are provided, not just upload_pending)
-        actual_paths = [p for p in docs_paths if p]
-        if actual_paths:
-            for path in actual_paths:
-                doc_path = Path(path)
-                logger.debug("Checking document path: %s -> %s", path, doc_path.absolute())
-
-                # Try relative to current directory and various parent directories
-                paths_to_try = [
-                    doc_path,
-                    Path("..") / path,  # Try from parent directory
-                    Path("../..") / path,  # Try from grandparent directory
-                    Path("../../..") / path,  # Try from great-grandparent directory
-                    # Also try the known test directory
-                    Path("../../..") / "test" / "files",
-                    PROJECT_ROOT / "test" / "files",  # Try from project root
-                    PROJECT_ROOT / "research" / "data" / "file",  # Try research data
-                    Path("../test/files"),  # Direct relative to test
-                ]
-
-                path_exists = False
-                actual_path = None
-                for try_path in paths_to_try:
-                    if try_path.exists():
-                        path_exists = True
-                        actual_path = try_path.absolute()
-                        logger.debug("Found path at: %s", actual_path)
-                        # Check if directory has files
-                        try:
-                            file_count = len(list(try_path.glob("*.txt"))) + len(list(try_path.glob("*.md")))
-                            if file_count == 0:
-                                warnings.append(f"Document path appears to be empty: {path} (no .txt or .md files)")
-                            else:
-                                logger.debug("Found %d document files", file_count)
-                        except Exception as e:
-                            warnings.append(f"Could not check document count in {path}: {e}")
-                        break
-
-                if not path_exists:
-                    # For testing, just warn instead of error and suggest test directory
-                    warnings.append(f"Document path does not exist: {path}. Try using 'test/files' which contains sample documents.")
-                    # errors.append(f"Document path does not exist: {path}")
-        
-        # Validate initial schema if provided
-        if config.initial_schema_path:
-            schema_path = Path(config.initial_schema_path)
-            # Try to resolve relative paths against PROJECT_ROOT
-            if not schema_path.is_absolute():
-                schema_path = (PROJECT_ROOT / schema_path).resolve()
-            if not schema_path.exists():
-                errors.append(f"Initial schema file does not exist: {config.initial_schema_path} (resolved: {schema_path})")
-        
-        # Validate schema creation backend config
-        if not config.schema_creation_backend.provider:
-            errors.append("Schema creation LLM provider must be specified")
-
-        # Model is required for OpenAI and Together, optional for Gemini (has default)
-        if not config.schema_creation_backend.model:
-            if config.schema_creation_backend.provider.lower() not in ["gemini"]:
-                errors.append("Schema creation LLM model must be specified (required for non-Gemini providers)")
-
-        # Validate value extraction backend config
-        if not config.value_extraction_backend.provider:
-            errors.append("Value extraction LLM provider must be specified")
-
-        # Model is required for OpenAI and Together, optional for Gemini (has default)
-        if not config.value_extraction_backend.model:
-            if config.value_extraction_backend.provider.lower() not in ["gemini"]:
-                errors.append("Value extraction LLM model must be specified (required for non-Gemini providers)")
-        
-        return {
-            "is_valid": len(errors) == 0,
-            "errors": errors,
-            "warnings": warnings
-        }
-    
-    async def save_config(self, session_id: str, config: ScheMatiQConfig):
-        """Save ScheMatiQ configuration for a session."""
-        session_dir = self.work_dir / session_id
-        session_dir.mkdir(exist_ok=True)
-        
-        config_file = session_dir / "config.json"
-        with open(config_file, 'w') as f:
-            json.dump(config.model_dump(), f, indent=2)
-    
-    async def run_schematiq(self, session_id: str):
-        """Run ScheMatiQ discovery process."""
-        set_session_context(session_id)
-        config = None  # Loaded inside try; referenced in except for quota info
-        try:
-            # Update session status
-            session = self.session_manager.get_session(session_id)
-            session.status = SessionStatus.PROCESSING
-            self.session_manager.update_session(session)
-
-            # Immediately broadcast that we're starting (before any async work)
-            await self.broadcast_step_progress(
-                session_id,
-                "Starting ScheMatiQ execution...",
-                step_number=1,
-                total_steps=5,
-                step_progress=0.0,
-                message="Initializing pipeline..."
-            )
-
-            # Load config
-            config_file = self.work_dir / session_id / "config.json"
-            with open(config_file) as f:
-                config_data = json.load(f)
-            config = ScheMatiQConfig(**config_data)
-            
-            # Create task for ScheMatiQ execution
-            task = asyncio.create_task(self._execute_schematiq(session_id, config))
-            with self._state_lock:
-                self.running_sessions[session_id] = task
-
-            # Wait for completion
-            await task
-
-        except Exception as e:
-            logger.error("ScheMatiQ run failed for session %s: %s", session_id, e)
-            # Update session with error
-            session = self.session_manager.get_session(session_id)
-            session.status = SessionStatus.ERROR
-            session.error_message = str(e)
-            self.session_manager.update_session(session)
-
-            # Check if this is a quota exceeded error — broadcast distinct message
-            is_quota_error = "quota exceeded" in str(e).lower()
-            if is_quota_error:
-                usage = self._global_usage.get_usage()
-                total_used = usage.get("total_calls", 0)
-                effective_limit = LLM_CALL_GLOBAL_LIMIT if not DEVELOPER_MODE else ((config.llm_call_limit or 0) if config else 0)
-                await self.websocket_manager.broadcast_to_session(session_id, {
-                    "type": "quota_exceeded",
-                    "message": "The system has reached its API usage limit and cannot start new processing sessions.",
-                    "data": {
-                        "total_used": total_used,
-                        "limit": effective_limit,
-                    },
-                    "timestamp": datetime.now().isoformat(),
-                })
-            else:
-                await self.broadcast_error(session_id, str(e))
-
-        finally:
-            # Clean up
-            with self._state_lock:
-                self.running_sessions.pop(session_id, None)
-            self.clear_stop_flag(session_id)
-            # Release concurrency slot (safe even if not acquired)
-            await concurrency_limiter.release(session_id)
-
-    async def resume_qbsd(self, session_id: str):
-        """Resume ScheMatiQ after observation unit review.
-
-        Reads the (potentially edited) observation unit from the session,
-        injects it into the config as a pre-configured unit, and re-runs
-        the pipeline. The pipeline will skip observation unit discovery
-        since it's already set.
-        """
-        set_session_context(session_id)
-
-        # Load saved config
-        config_file = self.work_dir / session_id / "config.json"
-        if not config_file.exists():
-            raise RuntimeError(f"Config file not found for session {session_id}")
-
-        with open(config_file) as f:
-            config_data = json.load(f)
-
-        # Read the current observation unit from the session (user may have edited it)
-        session = self.session_manager.get_session(session_id)
-        if not session:
-            raise RuntimeError(f"Session {session_id} not found")
-
-        if session.observation_unit:
-            # Inject the observation unit as a fully pre-configured unit
-            config_data["initial_observation_unit"] = {
-                "name": session.observation_unit.name,
-                "definition": session.observation_unit.definition,
-            }
-
-        # Disable review flag so it won't pause again
-        config_data["review_observation_unit"] = False
-
-        # Save updated config
-        with open(config_file, 'w') as f:
-            json.dump(config_data, f, indent=2)
-
-        # Re-run the pipeline (will skip observation unit discovery since it's pre-configured)
-        await self.run_schematiq(session_id)
-
-    async def _execute_schematiq(self, session_id: str, config: ScheMatiQConfig):
-        """Execute the real ScheMatiQ process."""
-        if not SCHEMATIQ_AVAILABLE:
-            raise RuntimeError("ScheMatiQ components not available. Cannot execute real ScheMatiQ pipeline.")
-
-        schematiq_start_time = time.time()
-        session_dir = self.work_dir / session_id
-        session_dir.mkdir(exist_ok=True)
-        
-        # Progress tracking - with user-friendly messages
-        progress_steps = [
-            "Initializing ScheMatiQ pipeline",
-            "Loading documents", 
-            "Setting up AI models",
-            "Configuring retrieval system",
-            "Schema Discovery: Analyzing documents",
-            "Value Extraction: Processing documents",
-            "Finalizing results"
-        ]
-        
-        current_step = 0
-        total_steps = len(progress_steps)
-        
-        # Cost estimation variables (updated after document load)
-        initial_cost_estimate_usd = 0.0
-        initial_calls_estimate = 0
-        
-        async def update_progress(step_name: str, step_progress: float = 0.0, details: Dict[str, Any] = None):
-            nonlocal current_step
-            
-            # Fetch current LLM stats
-            llm_tracker = LLMCallTracker.get_instance()
-            current_cost_data = llm_tracker.calculate_current_cost()
-            
-            llm_stats = {
-                "total_calls": llm_tracker.get_total(),
-                "current_cost_usd": current_cost_data["total_cost_usd"],
-                "estimated_cost_usd": initial_cost_estimate_usd,
-                "estimated_calls": initial_calls_estimate
-            }
-            
-            if details is None:
-                details = {}
-            details["llm_stats"] = llm_stats
-            
-            await self.broadcast_step_progress(
-                session_id,
-                step_name,
-                current_step + 1,
-                total_steps,
-                step_progress,
-                details.get("message") if details else None,
-                details  # Pass full details dict including iteration data
-            )
-        
-        try:
-            # Reset LLM call tracker for this session
-            llm_tracker = LLMCallTracker.get_instance()
-            llm_tracker.reset()
-
-            # Check global LLM usage quota before starting.
-            # In release mode: always enforced using LLM_CALL_GLOBAL_LIMIT.
-            # In developer mode: only enforced if config.llm_call_limit is set
-            #   (lets developers choose their own threshold).
-            if DEVELOPER_MODE:
-                effective_limit = config.llm_call_limit or 0  # 0 = no limit
-            else:
-                effective_limit = LLM_CALL_GLOBAL_LIMIT  # from env var
-
-            if effective_limit > 0:
-                # Sync local usage counter from Google Sheets (survives redeploys)
-                self._sync_usage_from_sheets()
-                try:
-                    self._global_usage.check_quota(effective_limit)
-                except QuotaExceededError as exc:
-                    logger.warning("Session %s blocked by global LLM quota: %s", session_id, exc)
-                    raise RuntimeError(str(exc)) from exc
-
-            # Step 1: Initializing
-            logger.debug("Starting ScheMatiQ execution for session %s", session_id)
-            await update_progress("Initializing", 0.0)
-
-            # Resolve document paths (download from Supabase if needed)
-            logger.debug("Resolving document paths (may download from Supabase)")
-            resolved_docs_paths = await self._resolve_docs_paths(config, session_id)
-            logger.debug("Resolved paths: %s", resolved_docs_paths)
-
-            # Convert config to ScheMatiQ format with resolved paths
-            logger.debug("Converting config to ScheMatiQ format")
-            schematiq_config = self._convert_config_to_schematiq_format_sync(config, session_id, resolved_docs_paths)
-            
-            # Save ScheMatiQ config
-            schematiq_config_file = session_dir / "schematiq_config.json"
-            with open(schematiq_config_file, 'w') as f:
-                json.dump(schematiq_config, f, indent=2)
-            logger.debug("Saved ScheMatiQ config with keys: %s", list(schematiq_config.keys()))
-            
-            await update_progress("Initializing", 1.0)
-            
-            # Step 2: Load documents
-            current_step += 1
-            await update_progress("Loading documents", 0.0)
-            
-            # Load documents using ScheMatiQ utils
-            docs_paths = schematiq_config["docs_path"]
-            if isinstance(docs_paths, str):
-                docs_paths = [docs_paths]
-
-            documents = []
-            filenames = []
-            total_docs = 0
-
-            for docs_path in docs_paths:
-                doc_path = Path(docs_path)
-                if doc_path.exists():
-                    doc_files = list(doc_path.glob("*.txt")) + list(doc_path.glob("*.md"))
-                    total_docs += len(doc_files)
-
-                    # Load document contents
-                    for doc_file in doc_files:
-                        try:
-                            content = doc_file.read_text(encoding='utf-8')
-                            documents.append(content)
-                            filenames.append(doc_file.name)
-                        except Exception as e:
-                            logger.warning("Could not read %s: %s", doc_file, e)
-
-            # Cap documents at MAX_DOCUMENTS (with seeded randomization for reproducibility)
-            bypass_limit = schematiq_config.get("bypass_limit", False)
-            if not (DEVELOPER_MODE and bypass_limit) and len(documents) > MAX_DOCUMENTS:
-                seed = schematiq_config.get("document_randomization_seed", 42)
-                original_count = len(documents)
-                combined = list(zip(documents, filenames))
-                rng = random.Random(seed)
-                rng.shuffle(combined)
-                combined = combined[:MAX_DOCUMENTS]
-                if combined:
-                    documents, filenames = zip(*combined)
-                    documents = list(documents)
-                    filenames = list(filenames)
-                else:
-                    documents = []
-                    filenames = []
-                total_docs = MAX_DOCUMENTS
-                logger.info("Document limit applied: selected %d of %d documents (seed=%d)", MAX_DOCUMENTS, original_count, seed)
-
-                # Create a filtered directory so value extraction only sees capped documents
-                capped_dir = session_dir / "capped_documents"
-                capped_dir.mkdir(exist_ok=True)
-                for fname in filenames:
-                    for docs_path in docs_paths:
-                        source = Path(docs_path) / fname
-                        if source.exists():
-                            dest = capped_dir / fname
-                            if not dest.exists():
-                                os.symlink(source.resolve(), dest)
-                            break
-                schematiq_config["docs_path"] = [str(capped_dir)]
-                logger.info("Value extraction redirected to capped_documents/ with %d files", len(filenames))
-
-            await update_progress("Loading documents", 1.0, {
-                "total_documents": total_docs,
-                "loaded_documents": len(documents)
-            })
-            
-            # Calculate cost estimate now that documents are loaded
-            try:
-                # schematiq_config is already a dict with all necessary fields
-                cost_estimate = estimate_from_config(documents, schematiq_config)
-                initial_cost_estimate_usd = cost_estimate.total_cost_usd
-                initial_calls_estimate = cost_estimate.total_api_calls
-                logger.info(f"Initial cost estimate: ${initial_cost_estimate_usd}, calls: {initial_calls_estimate}")
-            except Exception as e:
-                logger.warning(f"Failed to estimate cost during execution: {e}")
-
-            # Determine mode based on what's available
-            has_query = bool(schematiq_config.get("query", "").strip())
-            has_documents = bool(documents)
-
-            if not has_query and not has_documents:
-                raise RuntimeError("At least one of query or documents must be provided")
-
-            # Log the mode we're operating in
-            if has_query and has_documents:
-                logger.debug("STANDARD mode - query + %d documents", len(documents))
-            elif has_documents:
-                logger.debug("DOCUMENT_ONLY mode - %d documents, no query", len(documents))
-            else:
-                logger.debug("QUERY_ONLY mode - query provided, no documents")
-            
-            # Step 3: Build LLM backend
-            current_step += 1
-            logger.debug("Building Schema Creation LLM backend - provider: %s", schematiq_config['schema_creation_backend']['provider'])
-            await update_progress("Building LLM backend", 0.0)
-
-            # Build Schema Creation LLM interface
-            # In release mode, force the release-mode LLM settings
-            schema_backend = enforce_release_llm_config(schematiq_config["schema_creation_backend"], is_schema_creation=True)
-            logger.debug("Creating Schema Creation LLM interface...")
-            llm = build_llm_interface(
-                provider=schema_backend["provider"],
-                model=schema_backend["model"],
-                max_output_tokens=schema_backend.get("max_output_tokens"),  # None = auto-detect
-                temperature=schema_backend["temperature"],
-                api_key=schema_backend.get("api_key"),
-                context_window_size=schema_backend.get("context_window_size")  # None = auto-detect
-            )
-            logger.debug("LLM interface created successfully")
-            
-            logger.debug("Updating progress to 1.0...")
-            await update_progress("Building LLM backend", 1.0)
-            logger.debug("Progress update completed")
-            
-            # Step 4: Setup retriever
-            current_step += 1
-            logger.debug("Setting up retriever...")
-            await update_progress("Setting up retriever", 0.0)
-            
-            retriever = None
-            if "retriever" in schematiq_config:
-                logger.debug("Creating EmbeddingRetriever...")
-                retriever_config = schematiq_config["retriever"]
-                logger.debug("Retriever config: %s", retriever_config)
-                try:
-                    retriever = EmbeddingRetriever(
-                        model_name=retriever_config.get("model_name", "all-MiniLM-L6-v2"),
-                        max_words=retriever_config.get("passage_chars", 512),  # Convert passage_chars to max_words
-                        k=retriever_config.get("k", 15),
-                        enable_dynamic_k=retriever_config.get("enable_dynamic_k", True),
-                        dynamic_k_threshold=retriever_config.get("dynamic_k_threshold", 0.65),
-                        dynamic_k_minimum=retriever_config.get("dynamic_k_minimum", 3)
-                    )
-                    logger.debug("EmbeddingRetriever created successfully!")
-                except Exception as e:
-                    logger.error("ERROR creating EmbeddingRetriever: %s", e)
-                    raise
-            else:
-                logger.debug("No retriever config found, using None")
-            
-            await update_progress("Setting up retriever", 1.0)
-
-            # Step 5: Observation unit discovery (when review_observation_unit is enabled)
-            # When the user wants to review the observation unit before schema generation,
-            # we discover it as a separate step, save it, and pause the pipeline.
-            review_observation_unit = schematiq_config.get("review_observation_unit", False)
-            if review_observation_unit and has_documents:
-                current_step += 1
-                await update_progress("Discovering observation unit", 0.0)
-
-                # Check if observation unit is already fully pre-configured (name + definition)
-                initial_obs_unit = schematiq_config.get("initial_observation_unit")
-                obs_unit_already_set = initial_obs_unit and initial_obs_unit.get("definition")
-
-                if obs_unit_already_set:
-                    # Already fully specified - use as-is but still pause for review
-                    obs_unit = ObservationUnit(
-                        name=initial_obs_unit["name"],
-                        definition=initial_obs_unit["definition"]
-                    )
-                    logger.info("Using pre-configured observation unit for review: %s", obs_unit.name)
-                else:
-                    # Need to discover the observation unit from documents
-                    batch_size = schematiq_config.get("documents_batch_size", 1)
-                    first_batch_docs = documents[:batch_size]
-                    first_batch_names = filenames[:batch_size]
-                    query = schematiq_config.get("query", "")
-
-                    # Select relevant content from first batch
-                    loop = asyncio.get_running_loop()
-                    relevant_content = await loop.run_in_executor(
-                        schematiq_thread_pool,
-                        functools.partial(
-                            ScheMatiQ.select_relevant_content,
-                            docs=first_batch_docs,
-                            query=query,
-                            retriever=retriever,
-                        )
-                    )
-
-                    # Discover observation unit
-                    logger.info("Discovering observation unit for review...")
-                    try:
-                        obs_unit = await loop.run_in_executor(
-                            schematiq_thread_pool,
-                            functools.partial(
-                                discover_observation_unit,
-                                query=query if query.strip() else None,
-                                passages=relevant_content,
-                                llm=llm,
-                                context_window_size=schematiq_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192),
-                                source_document=first_batch_names[0] if first_batch_names else None,
-                            )
-                        )
-                        # If name was pre-configured (name-only mode), override discovered name
-                        if initial_obs_unit and initial_obs_unit.get("name") and not initial_obs_unit.get("definition"):
-                            logger.info("Overriding discovered name '%s' with pre-configured name '%s'", obs_unit.name, initial_obs_unit["name"])
-                            obs_unit.name = initial_obs_unit["name"]
-                        logger.info("Observation unit discovered for review: %s - %s", obs_unit.name, obs_unit.definition)
-                    except ObservationUnitDiscoveryError as e:
-                        logger.error("Observation unit discovery failed: %s", e)
-                        raise RuntimeError(
-                            f"Failed to discover observation unit: {e}. "
-                            "Ensure documents contain extractable entities."
-                        ) from e
-                    except Exception as e:
-                        logger.error("Unexpected error during observation unit discovery: %s", e)
-                        raise RuntimeError(
-                            f"Observation unit discovery failed unexpectedly: {e}"
-                        ) from e
-
-                # Save observation unit to session and pause for review
-                session = self.session_manager.get_session(session_id)
-                session.observation_unit = ObservationUnitInfo(
-                    name=obs_unit.name,
-                    definition=obs_unit.definition,
-                    example_names=obs_unit.example_names,
-                    source_document=getattr(obs_unit, 'source_document', None),
-                    discovery_iteration=getattr(obs_unit, 'discovery_iteration', None)
-                )
-                session.status = SessionStatus.OBSERVATION_UNIT_REVIEW
-                self.session_manager.update_session(session)
-                logger.info("Pipeline paused for observation unit review: %s", obs_unit.name)
-
-                # Broadcast observation_unit_ready event
-                obs_unit_data = {
-                    "name": obs_unit.name,
-                    "definition": obs_unit.definition,
-                    "example_names": obs_unit.example_names or [],
-                }
-                await self.broadcast_observation_unit_ready(session_id, obs_unit_data)
-
-                # Release concurrency slot while paused (will re-acquire on resume)
-                await concurrency_limiter.release(session_id)
-
-                # Return early - pipeline will be resumed via /schematiq/resume endpoint
-                return
-
-            # Step 6: Schema discovery
-            current_step += 1
-            await update_progress("Discovering schema", 0.0)
-
-            # Run real schema discovery with heartbeat to keep WebSocket alive
-            logger.debug("Starting schema discovery with %d documents", len(documents))
-            heartbeat_task = await self._start_heartbeat(session_id, interval=15.0)
-            try:
-                discovered_schema, schema_evolution = await self._run_schema_discovery(
-                    session_id, documents, filenames, schematiq_config, llm, retriever, update_progress
-                )
-            finally:
-                heartbeat_task.cancel()
-                try:
-                    await heartbeat_task
-                except asyncio.CancelledError:
-                    pass  # Expected when cancelling
-            logger.debug("Schema discovery completed with %d columns", len(discovered_schema.columns))
-            logger.debug("Schema evolution: %d snapshots tracked", len(schema_evolution.snapshots))
-            logger.info("LLM call stats after schema discovery: %s", llm_tracker.get_summary())
-            
-            # Save discovered schema with frontend-compatible format
-            schema_file = session_dir / "discovered_schema.json"
-            frontend_schema = []
-            for col in discovered_schema.columns:
-                col_dict = col.to_dict()
-                # Convert ScheMatiQ format to frontend format
-                frontend_col = {
-                    "name": col_dict.get("column", col.name),  # "column" -> "name"
-                    "definition": col_dict.get("definition", ""),
-                    "rationale": col_dict.get("explanation", col.rationale)  # "explanation" -> "rationale"
-                }
-                # Include allowed_values if present
-                if col_dict.get("allowed_values"):
-                    frontend_col["allowed_values"] = col_dict["allowed_values"]
-                frontend_schema.append(frontend_col)
-            
-            schema_for_frontend = {
-                "query": schematiq_config["query"],
-                "schema": frontend_schema
-            }
-            # Include observation_unit if discovered
-            if discovered_schema.observation_unit:
-                schema_for_frontend["observation_unit"] = discovered_schema.observation_unit.to_dict()
-
-            with open(schema_file, 'w') as f:
-                json.dump(schema_for_frontend, f, indent=2)
-            
-            await update_progress("Schema Discovery: Complete", 1.0, {
-                "columns_discovered": len(discovered_schema.columns)
-            })
-            
-            # Update session status to SCHEMA_READY
-            session = self.session_manager.get_session(session_id)
-            session.status = SessionStatus.SCHEMA_READY
-            session.metadata.schema_discovery_completed = True
-            logger.debug("Updated session %s status to SCHEMA_READY with %d columns", session_id, len(discovered_schema.columns))
-            
-            # Update session with discovered schema
-            schema_columns = []
-            for col in discovered_schema.columns:
-                # ScheMatiQ Column objects have these fields directly
-                col_info = ColumnInfo(
-                    name=col.name,
-                    definition=col.definition,
-                    rationale=col.rationale,
-                    data_type="object",
-                    source_document=col.source_document,
-                    discovery_iteration=col.discovery_iteration,
-                    allowed_values=[v for v in col.allowed_values if v is not None] if col.allowed_values else None,
-                    auto_expand_threshold=getattr(col, 'auto_expand_threshold', 2)
-                )
-                schema_columns.append(col_info)
-            
-            session.columns = schema_columns
-            session.schema_query = schematiq_config["query"]
-            # Transfer observation_unit to session if discovered
-            if discovered_schema.observation_unit:
-                session.observation_unit = ObservationUnitInfo(
-                    name=discovered_schema.observation_unit.name,
-                    definition=discovered_schema.observation_unit.definition,
-                    example_names=discovered_schema.observation_unit.example_names,
-                    source_document=discovered_schema.observation_unit.source_document,
-                    discovery_iteration=discovered_schema.observation_unit.discovery_iteration
-                )
-            self.session_manager.update_session(session)
-            logger.debug("Session %s saved with %d columns, status: %s", session_id, len(schema_columns), session.status)
-            
-            # Broadcast schema completion event
-            schema_completed_data = {
-                "query": schematiq_config["query"],
-                "columns": [col.model_dump() for col in schema_columns],
-                "total_columns": len(discovered_schema.columns)
-            }
-            if discovered_schema.observation_unit:
-                schema_completed_data["observation_unit"] = discovered_schema.observation_unit.to_dict()
-            await self.broadcast_schema_completed(session_id, schema_completed_data)
-
-            # Check if stop was requested during schema discovery - skip remaining steps
-            if self.is_stop_requested(session_id):
-                logger.warning("Stop requested - skipping value extraction and finalization")
-                # Update status to STOPPED immediately (don't rely on stop_execution race)
-                session = self.session_manager.get_session(session_id)
-                session.status = SessionStatus.STOPPED
-                session.error_message = None
-                self.session_manager.update_session(session)
-                logger.debug("Updated session status to STOPPED (from schema discovery stop)")
-                # Broadcast stopped message
-                await self.broadcast_stopped(session_id, {
-                    "schema_saved": True,
-                    "data_rows_saved": 0,
-                    "message": "Processing stopped after schema discovery"
-                })
-                return
-
-            # Step 6: Value extraction (skip if schema-only mode)
-            skipped_documents: List[str] = []
-            if schematiq_config.get("skip_value_extraction", False) or not has_documents:
-                logger.info("Skipping value extraction (schema-only mode)")
-                # Skip to finalization without value extraction
-            else:
-                current_step += 1
-                await update_progress("Extracting values", 0.0)
-
-                # Build Value Extraction LLM interface (separate from schema creation)
-                # In release mode, force the release-mode LLM settings
-                value_backend = enforce_release_llm_config(schematiq_config["value_extraction_backend"], is_schema_creation=False)
-                logger.debug("Creating Value Extraction LLM interface...")
-                value_extraction_llm = build_llm_interface(
-                    provider=value_backend["provider"],
-                    model=value_backend["model"],
-                    max_output_tokens=value_backend.get("max_output_tokens"),  # None = auto-detect
-                    temperature=value_backend["temperature"],
-                    api_key=value_backend.get("api_key"),
-                    context_window_size=value_backend.get("context_window_size")  # None = auto-detect
-                )
-                logger.debug("Value Extraction LLM interface created successfully")
-
-                # Run real value extraction with dedicated LLM (with heartbeat for long operations)
-                heartbeat_task = await self._start_heartbeat(session_id, interval=15.0)
-                try:
-                    skipped_documents = await self._run_value_extraction(
-                        session_id, schematiq_config, discovered_schema, value_extraction_llm, retriever, update_progress
-                    )
-                finally:
-                    heartbeat_task.cancel()
-                    try:
-                        await heartbeat_task
-                    except asyncio.CancelledError:
-                        pass  # Expected when cancelling
-
-                await update_progress("Extracting values", 1.0)
-                logger.info("LLM call stats after value extraction: %s", llm_tracker.get_summary())
-
-            # Check if stop was requested during value extraction - skip finalization
-            if self.is_stop_requested(session_id):
-                logger.warning("Stop requested - skipping finalization")
-                # Update status to STOPPED immediately (don't rely on stop_execution race)
-                session = self.session_manager.get_session(session_id)
-                session.status = SessionStatus.STOPPED
-                session.error_message = None
-                self.session_manager.update_session(session)
-                logger.debug("Updated session status to STOPPED (from value extraction stop)")
-                # Count rows saved
-                data_file = session_dir / "extracted_data.jsonl"
-                rows_saved = 0
-                if data_file.exists():
-                    with open(data_file, 'r') as f:
-                        rows_saved = sum(1 for _ in f)
-                # Broadcast stopped message
-                await self.broadcast_stopped(session_id, {
-                    "schema_saved": True,
-                    "data_rows_saved": rows_saved,
-                    "message": "Processing stopped during value extraction"
-                })
-                # Archive partial results for research (fire-and-forget)
-                if self._data_collection_service and rows_saved > 0:
-                    await self._data_collection_service.trigger_archive(session_id, "schematiq_stopped_partial")
-                if self._pubmed_enrichment_service and rows_saved > 0:
-                    await self._pubmed_enrichment_service.enrich_session(session_id)
-                if self._uniprot_enrichment_service and rows_saved > 0:
-                    await self._uniprot_enrichment_service.enrich_session(session_id)
-                return
-
-            # Step 7: Finalize
-            current_step += 1
-            await update_progress("Finalizing results", 0.0)
-
-            # Compute statistics from extracted data (include evolution and skipped documents)
-            statistics = self._compute_statistics_from_extracted_data(
-                session_id, discovered_schema, schema_evolution, skipped_documents
-            )
-
-            # Save LLM call tracking stats to session directory
-            llm_call_summary = llm_tracker.get_summary()
-            llm_call_summary["log"] = llm_tracker.get_log()
-            llm_stats_file = session_dir / "llm_call_stats.json"
-            with open(llm_stats_file, 'w') as f:
-                json.dump(llm_call_summary, f, indent=2)
-            logger.info("LLM call stats saved to %s: %s", llm_stats_file, llm_tracker.get_counts())
-
-            # Update global cumulative LLM usage (persisted across sessions)
-            # Skip if the session opted out of quota tracking
-            if config.count_toward_quota:
-                self._global_usage.record_session(session_id, llm_tracker.get_counts())
-                # Also persist to Google Sheets (survives redeploys)
-                self._log_llm_usage_to_sheets(session_id, llm_tracker.get_counts())
-            else:
-                logger.info("Session %s opted out of quota tracking (count_toward_quota=False)", session_id)
-
-            # Update session as completed with statistics
-            session = self.session_manager.get_session(session_id)
-            session.statistics = statistics
-            session.status = SessionStatus.COMPLETED
-            final_cost_data = llm_tracker.calculate_current_cost()
-            session.metadata.processing_stats["llm_stats"] = {
-                "total_calls": llm_tracker.get_total(),
-                "current_cost_usd": final_cost_data.get("total_cost_usd", 0.0),
-                "estimated_cost_usd": initial_cost_estimate_usd,
-                "estimated_calls": initial_calls_estimate,
-            }
-            self.session_manager.update_session(session)
-
-            # Capture schema baseline for re-extraction change detection
-            self.session_manager.capture_schema_baseline(session_id)
-
-            await update_progress("Finalizing results", 1.0)
-
-            # Broadcast completion
-            schema_only = schematiq_config.get("skip_value_extraction", False) or not has_documents
-            completion_message = (
-                "Schema discovery completed (value extraction skipped)"
-                if schema_only
-                else "ScheMatiQ execution completed successfully"
-            )
-            completion_details = {
-                "total_documents": total_docs,
-                "schema_columns": len(discovered_schema.columns),
-                "schema_only": schema_only,
-                "elapsed_seconds": int(time.time() - schematiq_start_time),
-                "llm_stats": session.metadata.processing_stats.get("llm_stats", {}),
-            }
-            # Only expose LLM call stats to developers, not end users
-            if DEVELOPER_MODE:
-                completion_details["llm_call_stats"] = llm_tracker.get_counts()
-            await self.broadcast_completion(session_id, completion_message, completion_details)
-
-            # Archive session data for research (fire-and-forget)
-            if self._data_collection_service:
-                await self._data_collection_service.trigger_archive(session_id, "schematiq_completion")
-
-            # Enrich source documents with PubMed/DOI links (fire-and-forget)
-            if self._pubmed_enrichment_service:
-                await self._pubmed_enrichment_service.enrich_session(session_id)
-
-            # Enrich protein rows with UniProt data (fire-and-forget, protein units only)
-            if self._uniprot_enrichment_service:
-                await self._uniprot_enrichment_service.enrich_session(session_id)
-
-            # Move processed documents from pending_documents/ to documents/
-            # Prevents stale files from being re-picked up by continue discovery
-            data_session_dir = Path("./data") / session_id
-            pending_dir = data_session_dir / "pending_documents"
-            completed_docs_dir = data_session_dir / "documents"
-            if pending_dir.exists():
-                completed_docs_dir.mkdir(parents=True, exist_ok=True)
-                import shutil
-                moved_count = 0
-                for file_path in pending_dir.iterdir():
-                    if file_path.is_file():
-                        dest_path = completed_docs_dir / file_path.name
-                        if dest_path.exists():
-                            base_name = file_path.stem
-                            extension = file_path.suffix
-                            counter = 1
-                            while dest_path.exists():
-                                dest_path = completed_docs_dir / f"{base_name}_{counter}{extension}"
-                                counter += 1
-                        shutil.move(str(file_path), str(dest_path))
-                        moved_count += 1
-                logger.info("Moved %d files from pending_documents/ to documents/ for session %s", moved_count, session_id)
-
-        except Exception as e:
-            logger.error("ScheMatiQ execution failed: %s", e, exc_info=True)
-            # Update session with error
-            session = self.session_manager.get_session(session_id)
-            session.status = SessionStatus.ERROR
-            session.error_message = str(e)
-            self.session_manager.update_session(session)
-
-            await self.broadcast_error(session_id, str(e))
-            raise
-    
-    async def _run_schema_discovery(
-        self,
-        session_id: str,
-        documents: List[str],
-        filenames: List[str],
-        schematiq_config: Dict[str, Any],
-        llm: LLMInterface,
-        retriever,
-        progress_callback
-    ) -> tuple[Schema, SchemaEvolution]:
-        """Run real schema discovery using ScheMatiQ pipeline.
-
-        Returns:
-            Tuple of (discovered_schema, schema_evolution)
-        """
-
-        # Extract config values needed for Schema creation
-        query = schematiq_config["query"]
-        max_keys = schematiq_config.get("max_keys_schema", 100)
-
-        # Initialize schema (inline schema takes priority over file path)
-        initial_schema = None
-        if "initial_schema" in schematiq_config:
-            # Inline schema provided directly
-            try:
-                columns = []
-                for col_data in schematiq_config["initial_schema"]:
-                    col = Column(
-                        name=col_data["name"],
-                        definition=col_data.get("definition", ""),
-                        rationale=col_data.get("rationale", ""),
-                        allowed_values=col_data.get("allowed_values")
-                    )
-                    columns.append(col)
-                initial_schema = Schema(query=query, columns=columns, max_keys=max_keys)
-                logger.info("Loaded inline initial schema with %d columns", len(columns))
-            except Exception as e:
-                logger.warning("Could not load inline initial schema: %s", e)
-        elif "initial_schema_path" in schematiq_config:
-            try:
-                with open(schematiq_config["initial_schema_path"]) as f:
-                    initial_data = json.load(f)
-                    # Handle both formats: array of columns or dict with "schema" key
-                    if isinstance(initial_data, list):
-                        columns = []
-                        for col_data in initial_data:
-                            col = Column(
-                                name=col_data["name"],
-                                definition=col_data.get("definition", ""),
-                                rationale=col_data.get("rationale", ""),
-                                allowed_values=col_data.get("allowed_values")
-                            )
-                            columns.append(col)
-                        initial_schema = Schema(query=query, columns=columns, max_keys=max_keys)
-                    elif isinstance(initial_data, dict) and "schema" in initial_data:
-                        columns = []
-                        for col_data in initial_data["schema"]:
-                            col = Column(
-                                name=col_data["name"],
-                                definition=col_data.get("definition", ""),
-                                rationale=col_data.get("rationale", ""),
-                                allowed_values=col_data.get("allowed_values")
-                            )
-                            columns.append(col)
-                        initial_schema = Schema(query=query, columns=columns, max_keys=max_keys)
-                logger.info("Loaded initial schema from file with %d columns", len(columns))
-            except Exception as e:
-                logger.warning("Could not load initial schema from file: %s", e)
-
-        current_schema = initial_schema or Schema(query=query, columns=[], max_keys=max_keys)
-
-        # Calculate iterations based on document batching
-        batch_size = schematiq_config.get("documents_batch_size", 1)
-        max_iterations = math.ceil(len(documents) / batch_size) if documents else 1
-        convergence_threshold = schematiq_config.get("convergence_threshold") or 5
-        unchanged_count = 0
-
-        # Create document batches
-        batches = [documents[i:i+batch_size] for i in range(0, len(documents), batch_size)]
-        filename_batches = [filenames[i:i+batch_size] for i in range(0, len(filenames), batch_size)]
-
-        logger.debug("Document batching - %d docs, batch_size=%d, %d batches", len(documents), batch_size, len(batches))
-
-        # Initialize schema evolution tracking
-        evolution = SchemaEvolution(snapshots=[], column_sources={})
-        cumulative_docs = 0
-
-        # Record initial columns (if any) as iteration 0
-        if len(current_schema.columns) > 0:
-            initial_column_names = [col.name for col in current_schema.columns]
-            evolution.snapshots.append(SchemaSnapshot(
-                iteration=0,
-                documents_processed=["initial_schema"],
-                total_columns=len(current_schema.columns),
-                new_columns=initial_column_names,
-                cumulative_documents=0
-            ))
-            # Mark initial columns as from initial schema
-            for col in current_schema.columns:
-                evolution.column_sources[col.name] = "initial_schema"
-
-        # Handle QUERY_ONLY mode: no documents, generate schema from query alone
-        if not documents:
-            logger.debug("QUERY_ONLY mode - generating schema from query without documents")
-            await progress_callback("Schema Discovery: Planning from query", 0.5, {
-                "mode": "query_only",
-                "current_columns": len(current_schema.columns)
-            })
-
-            try:
-                loop = asyncio.get_running_loop()
-
-                # Resolve observation unit: use pre-configured one, or discover from query
-                obs_unit_config = schematiq_config.get("initial_observation_unit")
-                if obs_unit_config and obs_unit_config.get("name"):
-                    observation_unit = ObservationUnit(
-                        name=obs_unit_config["name"],
-                        definition=obs_unit_config.get("definition", ""),
-                        source_document="query_only",
-                        discovery_iteration=1,
-                    )
-                    logger.info("[%s] QUERY_ONLY: using pre-configured observation unit: %s", session_id, observation_unit.name)
-                else:
-                    logger.info("[%s] QUERY_ONLY: discovering observation unit from query", session_id)
-                    observation_unit = await loop.run_in_executor(
-                        schematiq_thread_pool,
-                        functools.partial(
-                            discover_observation_unit,
-                            query=query,
-                            passages=None,
-                            llm=llm,
-                            source_document="query_only",
-                        )
-                    )
-                    logger.info("[%s] QUERY_ONLY: discovered observation unit: %s", session_id, observation_unit.name if observation_unit else None)
-
-                # Attach observation unit to the base schema so merge() preserves it
-                if observation_unit:
-                    current_schema.observation_unit = observation_unit
-
-                # Call generate_schema with empty passages (offloaded to thread pool)
-                logger.debug("[%s] Offloading QUERY_ONLY generate_schema to thread pool", session_id)
-                schema_result = await loop.run_in_executor(
-                    schematiq_thread_pool,
-                    functools.partial(
-                        ScheMatiQ.generate_schema,
-                        passages=[],
-                        query=query,
-                        max_keys_schema=schematiq_config.get("max_keys_schema", 100),
-                        current_schema=current_schema,
-                        llm=llm,
-                        context_window_size=schematiq_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192),
-                        observation_unit=observation_unit,
-                    )
-                )
-                new_schema = schema_result[0] if isinstance(schema_result, tuple) else schema_result
-                logger.debug("QUERY_ONLY generated schema with %d columns", len(new_schema.columns))
-
-                # Merge with any initial schema (offloaded to thread pool)
-                if current_schema.columns:
-                    logger.debug("[%s] Offloading QUERY_ONLY schema merge to thread pool", session_id)
-                    merged_schema = await loop.run_in_executor(
-                        schematiq_thread_pool,
-                        functools.partial(current_schema.merge, new_schema),
-                    )
-                else:
-                    merged_schema = new_schema
-
-                # Ensure observation_unit is propagated (merge preserves from current_schema,
-                # but if current_schema had no columns, we went through new_schema directly)
-                if observation_unit and not merged_schema.observation_unit:
-                    merged_schema.observation_unit = observation_unit
-
-                # Track new columns
-                new_column_names = [col.name for col in merged_schema.columns
-                                   if col.name not in {c.name for c in current_schema.columns}]
-
-                # Record column sources
-                for col_name in new_column_names:
-                    evolution.column_sources[col_name] = "query_only"
-
-                # Add evolution snapshot
-                evolution.snapshots.append(SchemaSnapshot(
-                    iteration=1,
-                    documents_processed=["query_only"],
-                    total_columns=len(merged_schema.columns),
-                    new_columns=new_column_names,
-                    cumulative_documents=0
-                ))
-
-                logger.debug("QUERY_ONLY mode completed with %d columns: %s", len(merged_schema.columns), [c.name for c in merged_schema.columns])
-                return merged_schema, evolution
-
-            except Exception as e:
-                logger.error("ERROR in QUERY_ONLY generate_schema: %s", e)
-                import traceback
-                traceback.print_exc()
-                raise
-
-        # Handle pre-configured observation unit (if provided)
-        pending_observation_unit_name = None  # For name-only mode
-        initial_obs_unit = schematiq_config.get("initial_observation_unit")
-        if initial_obs_unit:
-            if initial_obs_unit.get("definition"):
-                # Full specification - use as-is
-                current_schema.observation_unit = ObservationUnit(
-                    name=initial_obs_unit["name"],
-                    definition=initial_obs_unit["definition"]
-                )
-                logger.info("Using pre-configured observation unit: %s - %s", initial_obs_unit['name'], initial_obs_unit['definition'])
-            else:
-                # Name-only mode - store name for later discovery
-                pending_observation_unit_name = initial_obs_unit["name"]
-                logger.info("Observation unit name pre-configured: %s (definition will be discovered)", pending_observation_unit_name)
-
-        for iteration, (batch_docs, batch_names) in enumerate(zip(batches, filename_batches)):
-            # Check for stop request at the start of each iteration
-            if self.is_stop_requested(session_id):
-                logger.warning("Stop requested during schema discovery - saving partial schema with %d columns", len(current_schema.columns))
-                break
-
-            logger.debug("Schema discovery batch %d/%d (%d docs: %s)", iteration + 1, len(batches), len(batch_docs), batch_names)
-            await progress_callback(f"Schema Discovery: Batch {iteration + 1}/{len(batches)} ({len(batch_docs)} docs)", iteration / len(batches), {
-                "iteration": iteration + 1,
-                "max_iterations": len(batches),
-                "batch_docs": len(batch_docs),
-                "current_columns": len(current_schema.columns)
-            })
-
-            # Track column names before this iteration
-            columns_before = {col.name.lower() for col in current_schema.columns}
-            cumulative_docs += len(batch_docs)
-
-            # Select relevant content from this batch's documents (offloaded to thread pool)
-            loop = asyncio.get_running_loop()
-            logger.debug("[%s] Offloading select_relevant_content to thread pool", session_id)
-            relevant_content = await loop.run_in_executor(
-                schematiq_thread_pool,
-                functools.partial(
-                    ScheMatiQ.select_relevant_content,
-                    docs=batch_docs,
-                    query=query,
-                    retriever=retriever,
-                )
-            )
-            logger.debug("Selected %d relevant passages from batch", len(relevant_content))
-
-            # Check for stop after content retrieval
-            if self.is_stop_requested(session_id):
-                logger.warning("Stop requested after content retrieval - saving partial schema")
-                break
-
-            # Discover observation unit in first iteration (if not already set)
-            # Support all modes: STANDARD (query + docs), DOCUMENT_ONLY (docs only), QUERY_ONLY handled separately
-            if iteration == 0 and (query or relevant_content) and not current_schema.observation_unit:
-                logger.info("Discovering observation unit from first batch...")
-                try:
-                    logger.debug("[%s] Offloading discover_observation_unit to thread pool", session_id)
-                    obs_unit = await loop.run_in_executor(
-                        schematiq_thread_pool,
-                        functools.partial(
-                            discover_observation_unit,
-                            query=query,
-                            passages=relevant_content,
-                            llm=llm,
-                            context_window_size=schematiq_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192),
-                            source_document=batch_names[0] if batch_names else None,
-                        )
-                    )
-                    # If name was pre-configured, override discovered name
-                    if pending_observation_unit_name:
-                        logger.info("Overriding discovered name '%s' with pre-configured name '%s'", obs_unit.name, pending_observation_unit_name)
-                        obs_unit.name = pending_observation_unit_name
-                    current_schema.observation_unit = obs_unit
-                    logger.info("Observation unit set: %s - %s", obs_unit.name, obs_unit.definition)
-                    if obs_unit.example_names:
-                        logger.info("   Examples: %s", obs_unit.example_names)
-                except ObservationUnitDiscoveryError as e:
-                    # Re-raise discovery errors with clear message
-                    logger.error("Observation unit discovery failed: %s", e)
-                    raise RuntimeError(
-                        f"Failed to discover observation unit: {e}. "
-                        "Ensure documents contain extractable entities."
-                    ) from e
-                except Exception as e:
-                    # Wrap unexpected errors
-                    logger.error("Unexpected error during observation unit discovery: %s", e)
-                    raise RuntimeError(
-                        f"Observation unit discovery failed unexpectedly: {e}"
-                    ) from e
-
-            # Check for stop after observation unit discovery
-            if self.is_stop_requested(session_id):
-                logger.warning("Stop requested after observation unit discovery - saving partial schema")
-                break
-
-            # Generate schema for this iteration (offloaded to thread pool)
-            logger.debug("[%s] Offloading generate_schema to thread pool", session_id)
-            try:
-                schema_result = await loop.run_in_executor(
-                    schematiq_thread_pool,
-                    functools.partial(
-                        ScheMatiQ.generate_schema,
-                        passages=relevant_content,
-                        query=query,
-                        max_keys_schema=schematiq_config.get("max_keys_schema", 100),
-                        current_schema=current_schema,
-                        llm=llm,
-                        context_window_size=schematiq_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192),
-                    )
-                )
-                # generate_schema returns a tuple (Schema, bool)
-                new_schema = schema_result[0] if isinstance(schema_result, tuple) else schema_result
-                logger.debug("Generated schema with %d columns", len(new_schema.columns))
-            except Exception as e:
-                logger.error("ERROR in generate_schema: %s", e)
-                raise
-
-            # Check for stop after schema generation
-            if self.is_stop_requested(session_id):
-                logger.warning("Stop requested after schema generation - saving partial schema")
-                break
-
-            # Merge with existing schema (offloaded to thread pool)
-            logger.debug("[%s] Offloading schema merge to thread pool", session_id)
-            logger.debug("Current schema has %d columns", len(current_schema.columns))
-            logger.debug("New schema has %d columns", len(new_schema.columns))
-            try:
-                merged_schema = await loop.run_in_executor(
-                    schematiq_thread_pool,
-                    functools.partial(current_schema.merge, new_schema),
-                )
-                logger.debug("Merged schema has %d columns", len(merged_schema.columns))
-            except Exception as e:
-                logger.error("ERROR in schema merge: %s", e)
-                import traceback
-                traceback.print_exc()
-                raise
-
-            # Check for stop after schema merge
-            if self.is_stop_requested(session_id):
-                logger.warning("Stop requested after schema merge - saving partial schema")
-                break
-
-            # Identify NEW columns added in this iteration
-            columns_after = {col.name.lower() for col in merged_schema.columns}
-            new_column_names_lower = columns_after - columns_before
-            new_columns = [col.name for col in merged_schema.columns if col.name.lower() in new_column_names_lower]
-
-            # Record column sources for new columns (use actual document names)
-            batch_source = ", ".join(batch_names) if batch_names else f"batch_{iteration + 1}"
-            for col_name in new_columns:
-                if col_name not in evolution.column_sources:
-                    evolution.column_sources[col_name] = batch_source
-
-            # Add snapshot to evolution with actual document names
-            evolution.snapshots.append(SchemaSnapshot(
-                iteration=iteration + 1,
-                documents_processed=batch_names,
-                total_columns=len(merged_schema.columns),
-                new_columns=new_columns,
-                cumulative_documents=cumulative_docs
-            ))
-
-            logger.debug("Evolution - batch %d: %d new columns: %s", iteration + 1, len(new_columns), new_columns)
-
-            # Check convergence (offloaded to thread pool)
-            logger.debug("[%s] Offloading evaluate_schema_convergence to thread pool", session_id)
-            converged = await loop.run_in_executor(
-                schematiq_thread_pool,
-                functools.partial(ScheMatiQ.evaluate_schema_convergence, current_schema, merged_schema),
-            )
-            if converged:
-                unchanged_count += 1
-                logger.debug("Schema unchanged (count: %d/%d)", unchanged_count, convergence_threshold)
-                if unchanged_count >= convergence_threshold:
-                    logger.debug("Schema converged after %d batches", iteration + 1)
-                    break
-            else:
-                unchanged_count = 0
-                logger.debug("Schema changed, continuing to next batch")
-
-            current_schema = merged_schema
-            logger.debug("Completed batch %d, moving to next", iteration + 1)
-
-            # Save partial schema to disk after each batch (for stop resilience)
-            session_dir = self.work_dir / session_id
-            partial_schema_file = session_dir / "discovered_schema.json"
-            frontend_schema = []
-            for col in current_schema.columns:
-                col_dict = col.to_dict()
-                frontend_col = {
-                    "name": col_dict.get("column", col.name),
-                    "definition": col_dict.get("definition", ""),
-                    "rationale": col_dict.get("explanation", col.rationale)
-                }
-                if col_dict.get("allowed_values"):
-                    frontend_col["allowed_values"] = col_dict["allowed_values"]
-                frontend_schema.append(frontend_col)
-            partial_schema_data = {"query": query, "schema": frontend_schema}
-            # Include observation_unit if discovered
-            if current_schema.observation_unit:
-                partial_schema_data["observation_unit"] = current_schema.observation_unit.to_dict()
-            with open(partial_schema_file, 'w') as f:
-                json.dump(partial_schema_data, f, indent=2)
-            logger.debug("Saved partial schema with %d columns", len(current_schema.columns))
-
-            # Notify frontend about partial schema availability
-            await self.websocket_manager.broadcast_to_session(session_id, {
-                "type": "schema_progress",
-                "timestamp": datetime.now().isoformat(),
-                "data": {
-                    "columns_discovered": len(current_schema.columns),
-                    "iteration": iteration + 1,
-                    "max_iterations": len(batches),
-                    "new_columns": new_columns,
-                }
-            })
-
-            # Small delay to allow other tasks
-            await asyncio.sleep(0.1)
-
-        logger.debug("Schema discovery completed with %d columns after %d batches", len(current_schema.columns), len(evolution.snapshots))
-        logger.debug("Evolution tracking: %d snapshots, %d column sources", len(evolution.snapshots), len(evolution.column_sources))
-        return current_schema, evolution
-    
-    async def _run_value_extraction(
-        self,
-        session_id: str,
-        schematiq_config: Dict[str, Any],
-        schema: Schema,
-        llm: LLMInterface,
-        retriever,
-        progress_callback
-    ) -> List[str]:
-        """Run real value extraction using the value extraction pipeline.
-
-        Returns:
-            List of skipped document names (documents with no observation units found)
-        """
-        
-        session_dir = self.work_dir / session_id
-
-        # Save schema in value extraction format (includes observation_unit)
-        schema_data = schema.to_full_dict()
-
-        value_extraction_schema_path = session_dir / "value_extraction_schema.json"
-        with open(value_extraction_schema_path, 'w') as f:
-            json.dump(schema_data, f, indent=2)
-        
-        # Prepare documents directories
-        docs_paths = schematiq_config["docs_path"]
-        if isinstance(docs_paths, str):
-            docs_paths = [docs_paths]
-        
-        docs_directories = [Path(path) for path in docs_paths]
-        output_path = session_dir / "extracted_data.jsonl"
-        
-        # Count total documents for progress tracking
-        total_documents = 0
-        for docs_dir in docs_directories:
-            if docs_dir.exists():
-                doc_files = list(docs_dir.glob("*.txt")) + list(docs_dir.glob("*.md"))
-                total_documents += len(doc_files)
-        
-        # Update session metadata
-        session = self.session_manager.get_session(session_id)
-        session.metadata.total_documents = total_documents
-        session.metadata.processed_documents = 0
-        self.session_manager.update_session(session)
-        
-        # Run value extraction in a separate thread to avoid blocking
-        loop = asyncio.get_event_loop()
-
-        # Create callback to stream cell values as they're extracted
-        on_value_extracted = self._create_value_extracted_callback(session_id, loop)
-
-        # Create callback to broadcast warnings via WebSocket
-        on_warning = self._create_warning_callback(session_id, loop)
-
-        extraction_result = {}
-
-        # Create should_stop callback that checks for stop requests
-        def should_stop():
-            return self.is_stop_requested(session_id)
-
-        def run_value_extraction():
-            nonlocal extraction_result
-            extraction_result = build_table_jsonl(
-                schema_path=value_extraction_schema_path,
-                docs_directories=docs_directories,
-                output_path=output_path,
-                llm=llm,
-                retriever=retriever,
-                resume=False,
-                mode="all",  # Process all columns together
-                retrieval_k=8,
-                max_workers=1,  # Single worker to avoid overwhelming API
-                on_value_extracted=on_value_extracted,  # Stream values as extracted
-                should_stop=should_stop,  # Allow graceful stop
-                on_warning=on_warning  # Broadcast warnings to UI
-            )
-            return extraction_result
-
-        # Track progress by monitoring output file
-        extraction_task = loop.run_in_executor(schematiq_thread_pool, run_value_extraction)
-        
-        # Monitor progress while extraction runs
-        start_time = time.time()
-        last_line_count = 0
-        last_update_time = time.time()
-        prev_completed_documents = set()
-        
-        stopped_early = False
-        stop_requested_at = None
-        MAX_STOP_WAIT = 120  # 2 minutes max wait for graceful stop
-
-        while not extraction_task.done():
-            # Check for stop request - continue monitoring until thread actually stops
-            if self.is_stop_requested(session_id):
-                if stop_requested_at is None:
-                    logger.warning("Stop requested during value extraction - waiting for graceful stop")
-                    stop_requested_at = time.time()
-                    stopped_early = True
-
-                # Check if we've waited too long for graceful stop
-                elapsed = time.time() - stop_requested_at
-                if elapsed > MAX_STOP_WAIT:
-                    logger.warning("Graceful stop timeout after %ds - forcing exit", MAX_STOP_WAIT)
-                    break
-
-                # Poll more frequently while waiting for stop
-                await asyncio.sleep(0.5)
-                continue  # Skip progress updates while stopping
-
-            try:
-                current_time = time.time()
-
-                # Check output file for progress - count unique documents completed
-                if output_path.exists():
-                    completed_documents = set()
-                    current_line_count = 0
-                    with open(output_path, 'r') as f:
-                        for line in f:
-                            current_line_count += 1
-                            try:
-                                row_data = json.loads(line)
-                                # Get document name: use base_row_name for observation units, else _row_name
-                                metadata = row_data.get("_metadata", {})
-                                doc_name = metadata.get("base_row_name") or row_data.get("_row_name")
-                                if doc_name:
-                                    completed_documents.add(doc_name)
-                            except json.JSONDecodeError:
-                                pass
-
-                    completed_doc_count = len(completed_documents)
-
-                    if current_line_count > last_line_count:
-                        # Update session metadata with actual document count
-                        session = self.session_manager.get_session(session_id)
-                        session.metadata.processed_documents = min(completed_doc_count, total_documents)
-                        self.session_manager.update_session(session)
-
-                        # Compute newly completed documents since last poll
-                        newly_completed = list(completed_documents - prev_completed_documents)
-
-                        # Broadcast document completion with names
-                        await self.broadcast_row_completed(session_id, {
-                            "row_index": completed_doc_count,
-                            "total_rows": total_documents,
-                            "completed_at": datetime.now().isoformat(),
-                            "document_names": newly_completed,
-                            "elapsed_seconds": int(current_time - start_time),
-                        })
-
-                        prev_completed_documents = set(completed_documents)
-
-                        last_line_count = current_line_count
-                        last_update_time = current_time
-                
-                await asyncio.sleep(2)  # Check every 2 seconds
-                
-            except Exception as e:
-                logger.warning("Progress monitoring error: %s", e)
-                await asyncio.sleep(2)
-        
-        # Wait for completion
-        if not stopped_early:
-            try:
-                extraction_result = await extraction_task
-            except Exception as e:
-                raise RuntimeError(f"Value extraction failed: {e}")
-        else:
-            # When stopped, still wait briefly for task to finish cleanly
-            try:
-                await asyncio.wait_for(asyncio.shield(extraction_task), timeout=5.0)
-            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
-                pass  # Task didn't finish cleanly, but that's OK - we're stopping
-
-        # Final progress update
-        final_line_count = 0
-        if output_path.exists():
-            with open(output_path, 'r') as f:
-                final_line_count = sum(1 for _ in f)
-
-        # Update final session metadata
-        session = self.session_manager.get_session(session_id)
-        session.metadata.processed_documents = final_line_count
-        self.session_manager.update_session(session)
-
-        # If stopped early, return without processing suggested values or sending "Complete"
-        if stopped_early:
-            logger.warning("Value extraction stopped early with %d rows extracted", final_line_count)
-            return []
-
-        # Extract results from the new return format
-        suggested_values = extraction_result.get("suggested_values", {}) if extraction_result else {}
-        skipped_documents = extraction_result.get("skipped_documents", []) if extraction_result else []
-
-        # Warn user about skipped documents
-        if skipped_documents:
-            names = ', '.join(skipped_documents[:5])
-            suffix = f' and {len(skipped_documents) - 5} more' if len(skipped_documents) > 5 else ''
-            await self.websocket_manager.broadcast_log(session_id, {
-                "level": "warning",
-                "message": f"{len(skipped_documents)} document(s) skipped: {names}{suffix}"
-            })
-
-        # Process suggested values for schema evolution
-        if suggested_values:
-            await self._process_suggested_values(session, schema, suggested_values)
-
-        self.session_manager.update_session(session)
-
-        await progress_callback("Value Extraction: Complete", 1.0, {
-            "rows_extracted": final_line_count,
-            "total_documents": total_documents,
-            "elapsed_time": int(time.time() - start_time),
-            "suggested_values_count": sum(len(vals) for vals in suggested_values.values()) if suggested_values else 0,
-            "skipped_documents": skipped_documents,
-            "skipped_documents_count": len(skipped_documents)
-        })
-
-        return skipped_documents
-
-    async def _process_suggested_values(
-        self,
-        session: VisualizationSession,
-        schema: Schema,
-        suggested_values: Dict[str, Dict[str, Any]]
-    ):
-        """
-        Process suggested values from value extraction for schema evolution.
-
-        For each column with allowed_values:
-        - Auto-add values that meet the column's auto_expand_threshold
-        - Store remaining values as pending_values for user review
-        """
-        from app.models.session import PendingValue
-        from datetime import datetime
-
-        if not suggested_values:
-            return
-
-        logger.info("Processing %d suggested values for schema evolution", sum(len(vals) for vals in suggested_values.values()))
-
-        for col in session.columns:
-            if col.name not in suggested_values:
-                continue
-
-            col_suggestions = suggested_values[col.name]
-            if not col_suggestions:
-                continue
-
-            # Get threshold for this column (default to 2 if not set)
-            threshold = col.auto_expand_threshold if col.auto_expand_threshold is not None else 2
-
-            auto_added = []
-            pending = []
-
-            for value, details in col_suggestions.items():
-                doc_count = details.get("count", 0)
-                documents = details.get("documents", [])
-
-                # Skip if value already in allowed_values
-                if col.allowed_values and value in col.allowed_values:
-                    continue
-
-                if threshold > 0 and doc_count >= threshold:
-                    # Auto-add this value
-                    if col.allowed_values is None:
-                        col.allowed_values = []
-                    col.allowed_values.append(value)
-                    auto_added.append(value)
-                    logger.info("  Auto-added '%s' to %s (appeared in %d docs, threshold=%d)", value, col.name, doc_count, threshold)
-                else:
-                    # Add to pending values for user review
-                    pending.append(PendingValue(
-                        value=value,
-                        document_count=doc_count,
-                        first_seen=datetime.now(),
-                        documents=documents[:10]  # Limit to first 10 documents
-                    ))
-
-            # Update column's pending values
-            if pending:
-                if col.pending_values is None:
-                    col.pending_values = []
-                col.pending_values.extend(pending)
-                logger.info("  Added %d pending values to %s for review", len(pending), col.name)
-
-            if auto_added:
-                logger.info("  Auto-expanded %s allowed_values with %d new values", col.name, len(auto_added))
-
-        # Broadcast schema update if there were changes
-        total_auto_added = sum(1 for col in session.columns if col.allowed_values)
-        total_pending = sum(len(col.pending_values or []) for col in session.columns)
-
-        if total_auto_added > 0 or total_pending > 0:
-            await self.websocket_manager.broadcast_schema_updated(session.id, {
-                "operation": "schema_evolution",
-                "auto_added_values": total_auto_added,
-                "pending_values": total_pending,
-                "columns": [col.model_dump(mode='json') for col in session.columns]
-            })
-
-    def _compute_statistics_from_extracted_data(
-        self,
-        session_id: str,
-        schema: Schema,
-        schema_evolution: Optional[SchemaEvolution] = None,
-        skipped_documents: Optional[List[str]] = None
-    ) -> Optional[DataStatistics]:
-        """Compute statistics from extracted JSONL data.
-
-        Args:
-            session_id: The session ID
-            schema: The discovered schema with column definitions
-            schema_evolution: Optional schema evolution data from discovery
-            skipped_documents: Optional list of documents skipped during value extraction
-
-        Returns:
-            DataStatistics object or None if no data available
-        """
-        from app.services.data_utils import collect_all_data_rows, normalize_row_data
-
-        data_rows = collect_all_data_rows(session_id, work_dir=self.work_dir)
-
-        if not data_rows:
-            logger.warning("Statistics: No data found for session %s (schema-only mode)", session_id)
-            # Schema-only mode: return statistics based on schema without data
-            columns = []
-            for col in schema.columns:
-                col_info = ColumnInfo(
-                    name=col.name,
-                    definition=col.definition,
-                    rationale=col.rationale,
-                    data_type="object",
-                    non_null_count=0,
-                    unique_count=0,
-                    source_document=col.source_document,
-                    discovery_iteration=col.discovery_iteration,
-                    allowed_values=col.allowed_values
-                )
-                columns.append(col_info)
-
-            return DataStatistics(
-                total_rows=0,
-                total_columns=len(schema.columns),
-                total_documents=0,
-                completeness=0.0,
-                column_stats=columns,
-                schema_evolution=schema_evolution,
-                skipped_documents=skipped_documents or []
-            )
-
-        # Count unique documents from papers field (handle both formats)
-        unique_documents = set()
-        for row in data_rows:
-            papers = row.get('papers', row.get('_papers', []))
-            if isinstance(papers, list):
-                unique_documents.update(papers)
-            elif isinstance(papers, str) and papers:
-                unique_documents.add(papers)
-        total_documents = len(unique_documents) if unique_documents else len(data_rows)
-
-        # Build column stats from schema + data
-        columns = []
-        for col in schema.columns:
-            # Count non-null values for this column
-            # For ScheMatiQ data, check if the "answer" field exists and is not "None" string or empty
-            def is_valid_value(value):
-                if value is None:
-                    return False
-                if isinstance(value, dict):
-                    answer = value.get("answer")
-                    if answer is None or answer == "None" or answer == "" or answer == "[]":
-                        return False
-                    return True
-                # For non-dict values, check if it's not None or "None" string
-                return value != "None" and value != "" and value != "[]"
-
-            non_null_count = 0
-            unique_values = set()
-
-            for row in data_rows:
-                # Handle both DataRow format (with 'data' key) and direct format
-                row_data = normalize_row_data(row)
-
-                if col.name in row_data:
-                    value = row_data[col.name]
-                    if is_valid_value(value):
-                        non_null_count += 1
-                    # Count unique values by answer only (not excerpt) to avoid inflating count
-                    canonical = value.get("answer") if isinstance(value, dict) else value
-                    try:
-                        unique_values.add(json.dumps(canonical, sort_keys=True))
-                    except (TypeError, ValueError):
-                        unique_values.add(str(canonical))
-            unique_count = len(unique_values)
-
-            # Include source document info from evolution if available
-            source_document = None
-            if schema_evolution and col.name in schema_evolution.column_sources:
-                source_document = schema_evolution.column_sources[col.name]
-
-            col_info = ColumnInfo(
-                name=col.name,
-                definition=col.definition,
-                rationale=col.rationale,
-                data_type="object",  # ScheMatiQ data is typically complex objects
-                non_null_count=non_null_count,
-                unique_count=unique_count,
-                source_document=source_document,
-                discovery_iteration=getattr(col, 'discovery_iteration', None),
-                allowed_values=getattr(col, 'allowed_values', None),
-                auto_expand_threshold=getattr(col, 'auto_expand_threshold', 2)
-            )
-            columns.append(col_info)
-
-        # Calculate overall completeness
-        total_cells = len(data_rows) * len(columns)
-        non_null_cells = sum(col.non_null_count or 0 for col in columns)
-        completeness = (non_null_cells / total_cells * 100) if total_cells > 0 else 0.0
-
-        # Ensure completeness is a valid number
-        if math.isnan(completeness) or math.isinf(completeness):
-            completeness = 0.0
-
-        stats = DataStatistics(
-            total_rows=len(data_rows),
-            total_columns=len(columns),
-            total_documents=total_documents,
-            completeness=completeness,
-            column_stats=columns,
-            schema_evolution=schema_evolution,
-            skipped_documents=skipped_documents or []
-        )
-
-        logger.info("Statistics computed: %d rows, %d documents, %d columns, %.1f%% complete", len(data_rows), total_documents, len(columns), completeness)
-        if skipped_documents:
-            logger.info("Skipped documents: %d", len(skipped_documents))
-        if schema_evolution:
-            logger.info("Schema evolution: %d snapshots, %d column sources", len(schema_evolution.snapshots), len(schema_evolution.column_sources))
-        return stats
-
-    async def get_status(self, session_id: str) -> ScheMatiQStatus:
-        """Get current status of ScheMatiQ execution."""
-        with self._state_lock:
-            is_running = session_id in self.running_sessions
-
-        # Always load session for phase info
-        session = self.session_manager.get_session(session_id)
-        if not session:
-            raise ValueError("Session not found")
-
-        schema_completed = session.metadata.schema_discovery_completed
-        columns_discovered = len(session.columns) if session.columns else 0
-
-        # Terminal persisted states win over the in-memory running flag. The runner
-        # sets STOPPED/COMPLETED/ERROR on the session before the asyncio task leaves
-        # running_sessions; reporting "processing" until then cleared the Data tab
-        # (streaming cells cleared, data query still keyed off status).
-        if session.status == SessionStatus.COMPLETED:
-            status = "completed"
-            progress = 1.0
-        elif session.status == SessionStatus.ERROR:
-            status = "error"
-            progress = 0.0
-        elif session.status == SessionStatus.STOPPED:
-            status = "stopped"
-            progress = 1.0
-        elif is_running:
-            status = "processing"
-            progress = 0.5  # Mock progress
-        else:
-            if session.status == SessionStatus.DOCUMENTS_UPLOADED:
-                status = "documents_uploaded"
-                progress = 1.0
-            elif session.status == SessionStatus.PROCESSING_DOCUMENTS:
-                status = "processing_documents"
-                progress = 0.5
-            elif session.status == SessionStatus.OBSERVATION_UNIT_REVIEW:
-                status = "observation_unit_review"
-                progress = 0.3  # Partway through the pipeline
-            else:
-                status = "idle"
-                progress = 0.0
-
-        # Read schema_only flag from persisted session config
-        config_path = self.work_dir / session_id / "config.json"
-        schema_only = False
-        try:
-            if config_path.exists():
-                import json as _json
-                cfg = _json.loads(config_path.read_text())
-                schema_only = cfg.get("skip_value_extraction", False)
-        except Exception:
-            pass
-
-        return ScheMatiQStatus(
-            session_id=session_id,
-            status=status,
-            progress=progress,
-            current_step="Running" if status == "processing" else status.title(),
-            steps_completed=3 if status == "processing" else (7 if status == "completed" else 0),
-            total_steps=7,
-            schema_completed=schema_completed,
-            columns_discovered=columns_discovered,
-            total_documents=session.metadata.total_documents or 0,
-            processed_documents=session.metadata.processed_documents or 0,
-            llm_stats=session.metadata.processing_stats.get("llm_stats"),
-            schema_only=schema_only,
-        )
-    
-    async def get_schema(self, session_id: str) -> Dict[str, Any]:
-        """Get discovered schema."""
-        # Prefer session.columns (always up-to-date with user edits)
-        session = self.session_manager.get_session(session_id)
-        if session and session.columns:
-            result = {
-                "query": session.schema_query or "",
-                "schema": [col.model_dump() for col in session.columns]
-            }
-            if session.observation_unit:
-                result["observation_unit"] = session.observation_unit.model_dump()
-            return result
-
-        # Fall back to file (during ScheMatiQ creation, before columns are synced to session)
-        schema_file = self.work_dir / session_id / "discovered_schema.json"
-        if schema_file.exists():
-            with open(schema_file) as f:
-                return json.load(f)
-
-        # Last resort
-        if session:
-            return {"query": session.schema_query or "", "schema": []}
-        return {"query": "", "schema": []}
-    
-    async def get_data(
-        self,
-        session_id: str,
-        page: int = 0,
-        page_size: int = 50,
-        filters: Optional[List[Dict]] = None,
-        sort: Optional[List[Dict]] = None,
-        search: Optional[str] = None,
-        document_filter: Optional[List[str]] = None
-    ) -> PaginatedData:
-        """Get extracted data from all possible locations with optional filtering and sorting.
-
-        Data can be in multiple locations:
-        - ./schematiq_work/{session_id}/extracted_data.jsonl - Original ScheMatiQ value extraction
-        - ./schematiq_work/{session_id}/data.jsonl - Fallback location
-        - ./data/{session_id}/data.jsonl - Additional document processing (upload_document_processor)
-
-        When original ScheMatiQ data exists AND additional data exists, both are combined.
-        """
-        # Collect all data files that exist
-        data_files = []
-
-        # Check schematiq_work directory (original ScheMatiQ extraction)
-        extracted_file = self.work_dir / session_id / "extracted_data.jsonl"
-        if extracted_file.exists():
-            data_files.append(extracted_file)
-
-        # Check schematiq_work for data.jsonl (only if extracted_data.jsonl doesn't exist)
-        if not data_files:
-            schematiq_data_file = self.work_dir / session_id / "data.jsonl"
-            if schematiq_data_file.exists():
-                data_files.append(schematiq_data_file)
-
-        # Check data directory - ALWAYS check this as it may contain additional documents
-        data_dir_file = Path("./data") / session_id / "data.jsonl"
-        if data_dir_file.exists():
-            # Only add if it's not already in the list (avoid duplicates)
-            if data_dir_file not in data_files:
-                data_files.append(data_dir_file)
-
-        if not data_files:
-            return PaginatedData(rows=[], total_count=0, filtered_count=None, page=page, page_size=page_size, has_more=False)
-
-        from app.services.data_utils import row_dedup_key
-
-        # Helper function to normalize row data
-        def normalize_row(row_data: dict) -> dict:
-            if '_row_name' in row_data:
-                return {
-                    'row_name': row_data.get('_row_name'),
-                    'papers': row_data.get('_papers', []),
-                    'data': {k: v for k, v in row_data.items() if not k.startswith('_')},
-                    'unit_name': row_data.get('_unit_name'),
-                    'source_document': row_data.get('_source_document'),
-                    'parent_document': row_data.get('_parent_document'),
-                    '_cell_status': row_data.get('_cell_status'),
-                }
-            return row_data
-
-        # Check if we need to filter/sort (requires loading all rows)
-        needs_processing = bool(filters or sort or search or document_filter)
-
-        if needs_processing:
-            # Load all rows from all data files (deduplicated by composite key across files only)
-            all_rows = []
-            seen_keys: set = set()
-            for data_file in data_files:
-                file_keys: set = set()
-                with open(data_file, 'r', encoding='utf-8') as f:
-                    for line in f:
-                        if line.strip():
-                            try:
-                                row_data = json.loads(line.strip())
-                                key = row_dedup_key(row_data)
-                                if key[0] and key in seen_keys:
-                                    continue
-                                if key[0]:
-                                    file_keys.add(key)
-                                all_rows.append(normalize_row(row_data))
-                            except (json.JSONDecodeError, TypeError):
-                                pass
-                seen_keys.update(file_keys)
-
-            # Apply document filter before counting total
-            if document_filter:
-                doc_set = set(document_filter)
-                all_rows = [
-                    r for r in all_rows
-                    if (r.get('source_document') or r.get('_source_document') or '') in doc_set
-                ]
-
-            total_count = len(all_rows)
-
-            # Use FileParser's filtering/sorting methods
-            from app.services.file_parser import FileParser
-            parser = FileParser()
-
-            # Apply global search
-            if search and search.strip():
-                all_rows = parser._apply_search(all_rows, search.strip())
-
-            # Apply column filters
-            if filters:
-                all_rows = parser._apply_filters(all_rows, filters)
-
-            filtered_count = len(all_rows)
-
-            # Apply sorting
-            if sort:
-                all_rows = parser._apply_sort(all_rows, sort)
-
-            # Paginate
-            start = page * page_size
-            end = start + page_size
-            page_rows = all_rows[start:end]
-
-            # Convert to DataRow objects
-            rows = [DataRow(**row_data) for row_data in page_rows]
-
-            return PaginatedData(
-                rows=rows,
-                total_count=total_count,
-                filtered_count=filtered_count,
-                page=page,
-                page_size=page_size,
-                has_more=end < filtered_count
-            )
-        else:
-            # Efficient pagination (no filtering/sorting)
-            # First pass: count valid rows (dedup only across files, not within)
-            total_count = 0
-            seen_keys: set = set()
-            for data_file in data_files:
-                file_keys: set = set()
-                with open(data_file, 'r', encoding='utf-8') as f:
-                    for line in f:
-                        if not line.strip():
-                            continue
-                        try:
-                            row_data = json.loads(line.strip())
-                            key = row_dedup_key(row_data)
-                            if key[0] and key in seen_keys:
-                                continue
-                            if key[0]:
-                                file_keys.add(key)
-                            total_count += 1
-                        except (json.JSONDecodeError, TypeError):
-                            pass
-                seen_keys.update(file_keys)
-
-            rows = []
-            start_line = page * page_size
-            end_line = start_line + page_size
-            global_line = 0
-            seen_keys_page: set = set()
-
-            # Second pass: read paginated rows (dedup only across files, not within)
-            for data_file in data_files:
-                if global_line >= end_line:
-                    break  # Already have enough rows
-
-                file_keys: set = set()
-                with open(data_file, 'r', encoding='utf-8') as f:
-                    for line in f:
-                        if not line.strip():
-                            continue
-                        try:
-                            row_data = json.loads(line.strip())
-                        except (json.JSONDecodeError, TypeError):
-                            continue
-                        key = row_dedup_key(row_data)
-                        if key[0] and key in seen_keys_page:
-                            continue
-                        if key[0]:
-                            file_keys.add(key)
-
-                        if global_line >= end_line:
-                            break
-                        if global_line >= start_line:
-                            normalized = normalize_row(row_data)
-                            data_row = DataRow(**normalized)
-                            rows.append(data_row)
-                        global_line += 1
-                seen_keys_page.update(file_keys)
-
-            return PaginatedData(
-                rows=rows,
-                total_count=total_count,
-                filtered_count=None,
-                page=page,
-                page_size=page_size,
-                has_more=end_line < total_count
-            )
-    
     async def stop_execution(self, session_id: str) -> Dict[str, Any]:
-        """Stop ScheMatiQ execution gracefully.
-
-        Returns:
-            Dict with status info including what was saved (schema, data counts)
-        """
+        """Stop ScheMatiQ execution gracefully."""
         logger.debug("stop_execution: Called for session %s", session_id)
         logger.debug("stop_execution: running_sessions keys = %s", list(self.running_sessions.keys()))
 
@@ -2468,14 +140,11 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
                 task = self.running_sessions[session_id]
 
         if is_running:
-
-            # Give the task time to stop gracefully (LLM calls can take 30+ seconds)
             try:
                 logger.debug("stop_execution: Waiting for task to finish gracefully...")
                 await asyncio.wait_for(asyncio.shield(task), timeout=60.0)
                 logger.debug("stop_execution: Task finished gracefully")
             except asyncio.TimeoutError:
-                # If it doesn't stop gracefully after 60s, force cancel it
                 logger.warning("Graceful stop timed out after 60s, force cancelling task for %s", session_id)
                 task.cancel()
                 try:
@@ -2484,16 +153,14 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
                     pass
             except asyncio.CancelledError:
                 logger.debug("stop_execution: Task was cancelled")
-                pass  # Task was cancelled, which is expected
+                pass
             except Exception as e:
                 logger.error("Exception during stop: %s", e)
 
-            # Clean up
             with self._state_lock:
                 self.running_sessions.pop(session_id, None)
                 self.stop_flags.pop(session_id, None)
 
-            # Check what was saved
             session_dir = self.work_dir / session_id
             schema_file = session_dir / "discovered_schema.json"
             data_file = session_dir / "extracted_data.jsonl"
@@ -2505,7 +172,6 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
                 with open(data_file, 'r') as f:
                     result["data_rows_saved"] = sum(1 for _ in f)
 
-            # Only update status + broadcast if the task didn't already handle it
             session = self.session_manager.get_session(session_id)
             if session and session.status not in (SessionStatus.STOPPED, SessionStatus.COMPLETED):
                 logger.debug("stop_execution: Task didn't handle stop — force-updating to STOPPED")
@@ -2527,3 +193,719 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         logger.debug("stop_execution: Session NOT in running_sessions!")
         result["message"] = "No running session found"
         return result
+
+    # ── Config ─────────────────────────────────────────────────────
+
+    async def validate_config(self, config: ScheMatiQConfig) -> Dict[str, Any]:
+        return await _validate_config(config)
+
+    async def save_config(self, session_id: str, config: ScheMatiQConfig):
+        session_dir = self.work_dir / session_id
+        session_dir.mkdir(exist_ok=True)
+        config_file = session_dir / "config.json"
+        with open(config_file, 'w') as f:
+            json.dump(config.model_dump(), f, indent=2)
+
+    # ── Query ──────────────────────────────────────────────────────
+
+    async def get_status(self, session_id: str) -> ScheMatiQStatus:
+        return await _get_status(
+            session_id, self.session_manager, self.running_sessions,
+            self._state_lock, self.work_dir,
+        )
+
+    async def get_schema(self, session_id: str) -> Dict[str, Any]:
+        return await _get_schema(session_id, self.session_manager, self.work_dir)
+
+    async def get_data(
+        self,
+        session_id: str,
+        page: int = 0,
+        page_size: int = 50,
+        filters: Optional[List[Dict]] = None,
+        sort: Optional[List[Dict]] = None,
+        search: Optional[str] = None,
+        document_filter: Optional[List[str]] = None
+    ) -> PaginatedData:
+        return await _get_data(
+            session_id, self.work_dir, page, page_size, filters, sort, search, document_filter,
+        )
+
+    # ── Pipeline execution ─────────────────────────────────────────
+
+    async def run_schematiq(self, session_id: str):
+        """Run ScheMatiQ discovery process."""
+        set_session_context(session_id)
+        config = None
+        try:
+            session = self.session_manager.get_session(session_id)
+            session.status = SessionStatus.PROCESSING
+            self.session_manager.update_session(session)
+
+            await self.broadcast_step_progress(
+                session_id,
+                "Starting ScheMatiQ execution...",
+                step_number=1,
+                total_steps=5,
+                step_progress=0.0,
+                message="Initializing pipeline..."
+            )
+
+            config_file = self.work_dir / session_id / "config.json"
+            with open(config_file) as f:
+                config_data = json.load(f)
+            config = ScheMatiQConfig(**config_data)
+
+            task = asyncio.create_task(self._execute_schematiq(session_id, config))
+            with self._state_lock:
+                self.running_sessions[session_id] = task
+
+            await task
+
+        except Exception as e:
+            logger.error("ScheMatiQ run failed for session %s: %s", session_id, e)
+            session = self.session_manager.get_session(session_id)
+            session.status = SessionStatus.ERROR
+            session.error_message = str(e)
+            self.session_manager.update_session(session)
+
+            is_quota_error = "quota exceeded" in str(e).lower()
+            if is_quota_error:
+                usage = self._global_usage.get_usage()
+                total_used = usage.get("total_calls", 0)
+                effective_limit = LLM_CALL_GLOBAL_LIMIT if not DEVELOPER_MODE else ((config.llm_call_limit or 0) if config else 0)
+                await self.websocket_manager.broadcast_to_session(session_id, {
+                    "type": "quota_exceeded",
+                    "message": "The system has reached its API usage limit and cannot start new processing sessions.",
+                    "data": {
+                        "total_used": total_used,
+                        "limit": effective_limit,
+                    },
+                    "timestamp": datetime.now().isoformat(),
+                })
+            else:
+                await self.broadcast_error(session_id, str(e))
+
+        finally:
+            with self._state_lock:
+                self.running_sessions.pop(session_id, None)
+            self.clear_stop_flag(session_id)
+            await concurrency_limiter.release(session_id)
+
+    async def resume_qbsd(self, session_id: str):
+        """Resume ScheMatiQ after observation unit review."""
+        set_session_context(session_id)
+
+        config_file = self.work_dir / session_id / "config.json"
+        if not config_file.exists():
+            raise RuntimeError(f"Config file not found for session {session_id}")
+
+        with open(config_file) as f:
+            config_data = json.load(f)
+
+        session = self.session_manager.get_session(session_id)
+        if not session:
+            raise RuntimeError(f"Session {session_id} not found")
+
+        if session.observation_unit:
+            config_data["initial_observation_unit"] = {
+                "name": session.observation_unit.name,
+                "definition": session.observation_unit.definition,
+            }
+
+        config_data["review_observation_unit"] = False
+
+        with open(config_file, 'w') as f:
+            json.dump(config_data, f, indent=2)
+
+        await self.run_schematiq(session_id)
+
+    async def _execute_schematiq(self, session_id: str, config: ScheMatiQConfig):
+        """Execute the ScheMatiQ pipeline — orchestrates pipeline modules."""
+        schematiq_start_time = time.time()
+        session_dir = self.work_dir / session_id
+        session_dir.mkdir(exist_ok=True)
+
+        progress_steps = [
+            "Initializing ScheMatiQ pipeline",
+            "Loading documents",
+            "Setting up AI models",
+            "Configuring retrieval system",
+            "Schema Discovery: Analyzing documents",
+            "Value Extraction: Processing documents",
+            "Finalizing results"
+        ]
+
+        current_step = 0
+        total_steps = len(progress_steps)
+
+        initial_cost_estimate_usd = 0.0
+        initial_calls_estimate = 0
+
+        async def update_progress(step_name: str, step_progress: float = 0.0, details: Dict[str, Any] = None):
+            nonlocal current_step
+            llm_tracker = LLMCallTracker.get_instance()
+            current_cost_data = llm_tracker.calculate_current_cost()
+            llm_stats = {
+                "total_calls": llm_tracker.get_total(),
+                "current_cost_usd": current_cost_data["total_cost_usd"],
+                "estimated_cost_usd": initial_cost_estimate_usd,
+                "estimated_calls": initial_calls_estimate
+            }
+            if details is None:
+                details = {}
+            details["llm_stats"] = llm_stats
+            await self.broadcast_step_progress(
+                session_id,
+                step_name,
+                current_step + 1,
+                total_steps,
+                step_progress,
+                details.get("message") if details else None,
+                details
+            )
+
+        try:
+            llm_tracker = LLMCallTracker.get_instance()
+            llm_tracker.reset()
+
+            # Check global LLM usage quota
+            if DEVELOPER_MODE:
+                effective_limit = config.llm_call_limit or 0
+            else:
+                effective_limit = LLM_CALL_GLOBAL_LIMIT
+
+            if effective_limit > 0:
+                self._sync_usage_from_sheets()
+                try:
+                    self._global_usage.check_quota(effective_limit)
+                except QuotaExceededError as exc:
+                    logger.warning("Session %s blocked by global LLM quota: %s", session_id, exc)
+                    raise RuntimeError(str(exc)) from exc
+
+            # Step 1: Initialize
+            logger.debug("Starting ScheMatiQ execution for session %s", session_id)
+            await update_progress("Initializing", 0.0)
+
+            logger.debug("Resolving document paths (may download from Supabase)")
+            resolved_docs_paths = await resolve_docs_paths(config, session_id, self.work_dir)
+            logger.debug("Resolved paths: %s", resolved_docs_paths)
+
+            logger.debug("Converting config to ScheMatiQ format")
+            schematiq_config = convert_config_to_schematiq_format(config, session_id, self.work_dir, resolved_docs_paths)
+
+            schematiq_config_file = session_dir / "schematiq_config.json"
+            with open(schematiq_config_file, 'w') as f:
+                json.dump(schematiq_config, f, indent=2)
+            logger.debug("Saved ScheMatiQ config with keys: %s", list(schematiq_config.keys()))
+
+            await update_progress("Initializing", 1.0)
+
+            # Step 2: Load documents
+            current_step += 1
+            await update_progress("Loading documents", 0.0)
+
+            docs_paths = schematiq_config["docs_path"]
+            if isinstance(docs_paths, str):
+                docs_paths = [docs_paths]
+
+            documents = []
+            filenames = []
+            total_docs = 0
+
+            for docs_path in docs_paths:
+                doc_path = Path(docs_path)
+                if doc_path.exists():
+                    doc_files = list(doc_path.glob("*.txt")) + list(doc_path.glob("*.md"))
+                    total_docs += len(doc_files)
+                    for doc_file in doc_files:
+                        try:
+                            content = doc_file.read_text(encoding='utf-8')
+                            documents.append(content)
+                            filenames.append(doc_file.name)
+                        except Exception as e:
+                            logger.warning("Could not read %s: %s", doc_file, e)
+
+            # Cap documents at MAX_DOCUMENTS
+            bypass_limit = schematiq_config.get("bypass_limit", False)
+            if not (DEVELOPER_MODE and bypass_limit) and len(documents) > MAX_DOCUMENTS:
+                seed = schematiq_config.get("document_randomization_seed", 42)
+                original_count = len(documents)
+                combined = list(zip(documents, filenames))
+                rng = random.Random(seed)
+                rng.shuffle(combined)
+                combined = combined[:MAX_DOCUMENTS]
+                if combined:
+                    documents, filenames = zip(*combined)
+                    documents = list(documents)
+                    filenames = list(filenames)
+                else:
+                    documents = []
+                    filenames = []
+                total_docs = MAX_DOCUMENTS
+                logger.info("Document limit applied: selected %d of %d documents (seed=%d)", MAX_DOCUMENTS, original_count, seed)
+
+                capped_dir = session_dir / "capped_documents"
+                capped_dir.mkdir(exist_ok=True)
+                for fname in filenames:
+                    for dp in docs_paths:
+                        source = Path(dp) / fname
+                        if source.exists():
+                            dest = capped_dir / fname
+                            if not dest.exists():
+                                os.symlink(source.resolve(), dest)
+                            break
+                schematiq_config["docs_path"] = [str(capped_dir)]
+                logger.info("Value extraction redirected to capped_documents/ with %d files", len(filenames))
+
+            await update_progress("Loading documents", 1.0, {
+                "total_documents": total_docs,
+                "loaded_documents": len(documents)
+            })
+
+            # Cost estimate
+            try:
+                cost_estimate = estimate_from_config(documents, schematiq_config)
+                initial_cost_estimate_usd = cost_estimate.total_cost_usd
+                initial_calls_estimate = cost_estimate.total_api_calls
+                logger.info(f"Initial cost estimate: ${initial_cost_estimate_usd}, calls: {initial_calls_estimate}")
+            except Exception as e:
+                logger.warning(f"Failed to estimate cost during execution: {e}")
+
+            has_query = bool(schematiq_config.get("query", "").strip())
+            has_documents = bool(documents)
+
+            if not has_query and not has_documents:
+                raise RuntimeError("At least one of query or documents must be provided")
+
+            if has_query and has_documents:
+                logger.debug("STANDARD mode - query + %d documents", len(documents))
+            elif has_documents:
+                logger.debug("DOCUMENT_ONLY mode - %d documents, no query", len(documents))
+            else:
+                logger.debug("QUERY_ONLY mode - query provided, no documents")
+
+            # Step 3: Build LLM backend
+            current_step += 1
+            logger.debug("Building Schema Creation LLM backend - provider: %s", schematiq_config['schema_creation_backend']['provider'])
+            await update_progress("Building LLM backend", 0.0)
+
+            schema_backend = enforce_release_llm_config(schematiq_config["schema_creation_backend"], is_schema_creation=True)
+            logger.debug("Creating Schema Creation LLM interface...")
+            llm = build_llm_interface(
+                provider=schema_backend["provider"],
+                model=schema_backend["model"],
+                max_output_tokens=schema_backend.get("max_output_tokens"),
+                temperature=schema_backend["temperature"],
+                api_key=schema_backend.get("api_key"),
+                context_window_size=schema_backend.get("context_window_size")
+            )
+            logger.debug("LLM interface created successfully")
+
+            logger.debug("Updating progress to 1.0...")
+            await update_progress("Building LLM backend", 1.0)
+            logger.debug("Progress update completed")
+
+            # Step 4: Setup retriever
+            current_step += 1
+            logger.debug("Setting up retriever...")
+            await update_progress("Setting up retriever", 0.0)
+
+            retriever = None
+            if "retriever" in schematiq_config:
+                logger.debug("Creating EmbeddingRetriever...")
+                retriever_config = schematiq_config["retriever"]
+                logger.debug("Retriever config: %s", retriever_config)
+                try:
+                    retriever = EmbeddingRetriever(
+                        model_name=retriever_config.get("model_name", "all-MiniLM-L6-v2"),
+                        max_words=retriever_config.get("passage_chars", 512),
+                        k=retriever_config.get("k", 15),
+                        enable_dynamic_k=retriever_config.get("enable_dynamic_k", True),
+                        dynamic_k_threshold=retriever_config.get("dynamic_k_threshold", 0.65),
+                        dynamic_k_minimum=retriever_config.get("dynamic_k_minimum", 3)
+                    )
+                    logger.debug("EmbeddingRetriever created successfully!")
+                except Exception as e:
+                    logger.error("ERROR creating EmbeddingRetriever: %s", e)
+                    raise
+            else:
+                logger.debug("No retriever config found, using None")
+
+            await update_progress("Setting up retriever", 1.0)
+
+            # Step 5: Observation unit review (optional pause)
+            review_observation_unit = schematiq_config.get("review_observation_unit", False)
+            if review_observation_unit and has_documents:
+                paused = await self._handle_observation_unit_review(
+                    session_id, documents, filenames, schematiq_config, llm, retriever, update_progress
+                )
+                if paused:
+                    return  # Pipeline will be resumed via /schematiq/resume endpoint
+
+            # Step 6: Schema discovery
+            current_step += 1
+            await update_progress("Discovering schema", 0.0)
+
+            logger.debug("Starting schema discovery with %d documents", len(documents))
+            heartbeat_task = await start_heartbeat(self.websocket_manager, session_id, interval=15.0)
+            try:
+                discovered_schema, schema_evolution = await run_schema_discovery(
+                    session_id, documents, filenames, schematiq_config, llm, retriever,
+                    update_progress, self.is_stop_requested,
+                    ws_manager=self.websocket_manager,
+                    work_dir=self.work_dir,
+                )
+            finally:
+                heartbeat_task.cancel()
+                try:
+                    await heartbeat_task
+                except asyncio.CancelledError:
+                    pass
+
+            logger.debug("Schema discovery completed with %d columns", len(discovered_schema.columns))
+            logger.debug("Schema evolution: %d snapshots tracked", len(schema_evolution.snapshots))
+            logger.info("LLM call stats after schema discovery: %s", llm_tracker.get_summary())
+
+            # Save and broadcast schema
+            self._save_schema_to_session(session_id, discovered_schema, schematiq_config, schema_evolution)
+
+            await update_progress("Schema Discovery: Complete", 1.0, {
+                "columns_discovered": len(discovered_schema.columns)
+            })
+
+            # Check for stop after schema discovery
+            if self.is_stop_requested(session_id):
+                await self._handle_stop_after_schema(session_id)
+                return
+
+            # Step 6b: Value extraction
+            skipped_documents: List[str] = []
+            if schematiq_config.get("skip_value_extraction", False) or not has_documents:
+                logger.info("Skipping value extraction (schema-only mode)")
+            else:
+                current_step += 1
+                await update_progress("Extracting values", 0.0)
+
+                value_backend = enforce_release_llm_config(schematiq_config["value_extraction_backend"], is_schema_creation=False)
+                logger.debug("Creating Value Extraction LLM interface...")
+                value_extraction_llm = build_llm_interface(
+                    provider=value_backend["provider"],
+                    model=value_backend["model"],
+                    max_output_tokens=value_backend.get("max_output_tokens"),
+                    temperature=value_backend["temperature"],
+                    api_key=value_backend.get("api_key"),
+                    context_window_size=value_backend.get("context_window_size")
+                )
+                logger.debug("Value Extraction LLM interface created successfully")
+
+                heartbeat_task = await start_heartbeat(self.websocket_manager, session_id, interval=15.0)
+                try:
+                    skipped_documents = await run_value_extraction(
+                        session_id, schematiq_config, discovered_schema, value_extraction_llm,
+                        retriever, update_progress, self.is_stop_requested,
+                        ws_mixin=self, ws_manager=self.websocket_manager,
+                        session_manager=self.session_manager, work_dir=self.work_dir,
+                    )
+                finally:
+                    heartbeat_task.cancel()
+                    try:
+                        await heartbeat_task
+                    except asyncio.CancelledError:
+                        pass
+
+                await update_progress("Extracting values", 1.0)
+                logger.info("LLM call stats after value extraction: %s", llm_tracker.get_summary())
+
+            # Check for stop after value extraction
+            if self.is_stop_requested(session_id):
+                await self._handle_stop_after_extraction(session_id)
+                return
+
+            # Step 7: Finalize
+            current_step += 1
+            await update_progress("Finalizing results", 0.0)
+
+            statistics = compute_statistics(
+                session_id, discovered_schema, schema_evolution, skipped_documents, self.work_dir
+            )
+
+            # Save LLM call tracking
+            llm_call_summary = llm_tracker.get_summary()
+            llm_call_summary["log"] = llm_tracker.get_log()
+            llm_stats_file = session_dir / "llm_call_stats.json"
+            with open(llm_stats_file, 'w') as f:
+                json.dump(llm_call_summary, f, indent=2)
+            logger.info("LLM call stats saved to %s: %s", llm_stats_file, llm_tracker.get_counts())
+
+            if config.count_toward_quota:
+                self._global_usage.record_session(session_id, llm_tracker.get_counts())
+                self._log_llm_usage_to_sheets(session_id, llm_tracker.get_counts())
+            else:
+                logger.info("Session %s opted out of quota tracking (count_toward_quota=False)", session_id)
+
+            # Update session as completed
+            session = self.session_manager.get_session(session_id)
+            session.statistics = statistics
+            session.status = SessionStatus.COMPLETED
+            final_cost_data = llm_tracker.calculate_current_cost()
+            session.metadata.processing_stats["llm_stats"] = {
+                "total_calls": llm_tracker.get_total(),
+                "current_cost_usd": final_cost_data.get("total_cost_usd", 0.0),
+                "estimated_cost_usd": initial_cost_estimate_usd,
+                "estimated_calls": initial_calls_estimate,
+            }
+            self.session_manager.update_session(session)
+            self.session_manager.capture_schema_baseline(session_id)
+
+            await update_progress("Finalizing results", 1.0)
+
+            # Broadcast completion
+            schema_only = schematiq_config.get("skip_value_extraction", False) or not has_documents
+            completion_message = (
+                "Schema discovery completed (value extraction skipped)"
+                if schema_only
+                else "ScheMatiQ execution completed successfully"
+            )
+            completion_details = {
+                "total_documents": total_docs,
+                "schema_columns": len(discovered_schema.columns),
+                "schema_only": schema_only,
+                "elapsed_seconds": int(time.time() - schematiq_start_time),
+                "llm_stats": session.metadata.processing_stats.get("llm_stats", {}),
+            }
+            if DEVELOPER_MODE:
+                completion_details["llm_call_stats"] = llm_tracker.get_counts()
+            await self.broadcast_completion(session_id, completion_message, completion_details)
+
+            # Fire-and-forget post-completion tasks
+            if self._data_collection_service:
+                await self._data_collection_service.trigger_archive(session_id, "schematiq_completion")
+            if self._pubmed_enrichment_service:
+                await self._pubmed_enrichment_service.enrich_session(session_id)
+            if self._uniprot_enrichment_service:
+                await self._uniprot_enrichment_service.enrich_session(session_id)
+
+            # Move processed documents from pending_documents/ to documents/
+            self._move_pending_documents(session_id)
+
+        except Exception as e:
+            logger.error("ScheMatiQ execution failed: %s", e, exc_info=True)
+            session = self.session_manager.get_session(session_id)
+            session.status = SessionStatus.ERROR
+            session.error_message = str(e)
+            self.session_manager.update_session(session)
+            await self.broadcast_error(session_id, str(e))
+            raise
+
+    # ── Private orchestration helpers ──────────────────────────────
+
+    async def _handle_observation_unit_review(
+        self, session_id, documents, filenames, schematiq_config, llm, retriever, update_progress
+    ) -> bool:
+        """Discover observation unit and pause for review. Returns True if paused."""
+        import functools
+        from schematiq.core import schematiq as ScheMatiQ
+        from schematiq import discover_observation_unit, ObservationUnitDiscoveryError
+
+        await update_progress("Discovering observation unit", 0.0)
+
+        initial_obs_unit = schematiq_config.get("initial_observation_unit")
+        obs_unit_already_set = initial_obs_unit and initial_obs_unit.get("definition")
+
+        current_step = 4  # observation unit review is after retriever setup
+        if obs_unit_already_set:
+            obs_unit = ObservationUnit(
+                name=initial_obs_unit["name"],
+                definition=initial_obs_unit["definition"]
+            )
+            logger.info("Using pre-configured observation unit for review: %s", obs_unit.name)
+        else:
+            batch_size = schematiq_config.get("documents_batch_size", 1)
+            first_batch_docs = documents[:batch_size]
+            first_batch_names = filenames[:batch_size]
+            query = schematiq_config.get("query", "")
+
+            loop = asyncio.get_running_loop()
+            relevant_content = await loop.run_in_executor(
+                schematiq_thread_pool,
+                functools.partial(
+                    ScheMatiQ.select_relevant_content,
+                    docs=first_batch_docs,
+                    query=query,
+                    retriever=retriever,
+                )
+            )
+
+            logger.info("Discovering observation unit for review...")
+            logger.debug("[%s] Offloading discover_observation_unit to thread pool", session_id)
+            try:
+                obs_unit = await loop.run_in_executor(
+                    schematiq_thread_pool,
+                    functools.partial(
+                        discover_observation_unit,
+                        query=query if query.strip() else None,
+                        passages=relevant_content,
+                        llm=llm,
+                        context_window_size=schematiq_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192),
+                        source_document=first_batch_names[0] if first_batch_names else None,
+                    )
+                )
+                # If name was pre-configured (name-only mode), override discovered name
+                if initial_obs_unit and initial_obs_unit.get("name") and not initial_obs_unit.get("definition"):
+                    logger.info("Overriding discovered name '%s' with pre-configured name '%s'", obs_unit.name, initial_obs_unit["name"])
+                    obs_unit.name = initial_obs_unit["name"]
+                logger.info("Observation unit discovered for review: %s - %s", obs_unit.name, obs_unit.definition)
+            except ObservationUnitDiscoveryError as e:
+                logger.error("Observation unit discovery failed: %s", e)
+                raise RuntimeError(
+                    f"Failed to discover observation unit: {e}. "
+                    "Ensure documents contain extractable entities."
+                ) from e
+            except Exception as e:
+                logger.error("Unexpected error during observation unit discovery: %s", e)
+                raise RuntimeError(
+                    f"Observation unit discovery failed unexpectedly: {e}"
+                ) from e
+
+        session = self.session_manager.get_session(session_id)
+        session.observation_unit = ObservationUnitInfo(
+            name=obs_unit.name,
+            definition=obs_unit.definition,
+            example_names=obs_unit.example_names,
+            source_document=getattr(obs_unit, 'source_document', None),
+            discovery_iteration=getattr(obs_unit, 'discovery_iteration', None)
+        )
+        session.status = SessionStatus.OBSERVATION_UNIT_REVIEW
+        self.session_manager.update_session(session)
+        logger.info("Pipeline paused for observation unit review: %s", obs_unit.name)
+
+        obs_unit_data = {
+            "name": obs_unit.name,
+            "definition": obs_unit.definition,
+            "example_names": obs_unit.example_names or [],
+        }
+        await self.broadcast_observation_unit_ready(session_id, obs_unit_data)
+        await concurrency_limiter.release(session_id)
+        return True
+
+    def _save_schema_to_session(self, session_id, discovered_schema, schematiq_config, schema_evolution):
+        """Save discovered schema to file and session object, then broadcast."""
+        session_dir = self.work_dir / session_id
+        schema_file = session_dir / "discovered_schema.json"
+        frontend_schema = []
+        for col in discovered_schema.columns:
+            col_dict = col.to_dict()
+            frontend_col = {
+                "name": col_dict.get("column", col.name),
+                "definition": col_dict.get("definition", ""),
+                "rationale": col_dict.get("explanation", col.rationale)
+            }
+            if col_dict.get("allowed_values"):
+                frontend_col["allowed_values"] = col_dict["allowed_values"]
+            frontend_schema.append(frontend_col)
+
+        schema_for_frontend = {
+            "query": schematiq_config["query"],
+            "schema": frontend_schema
+        }
+        if discovered_schema.observation_unit:
+            schema_for_frontend["observation_unit"] = discovered_schema.observation_unit.to_dict()
+
+        with open(schema_file, 'w') as f:
+            json.dump(schema_for_frontend, f, indent=2)
+
+        session = self.session_manager.get_session(session_id)
+        session.status = SessionStatus.SCHEMA_READY
+        session.metadata.schema_discovery_completed = True
+        logger.debug("Updated session %s status to SCHEMA_READY with %d columns", session_id, len(discovered_schema.columns))
+
+        schema_columns = []
+        for col in discovered_schema.columns:
+            col_info = ColumnInfo(
+                name=col.name,
+                definition=col.definition,
+                rationale=col.rationale,
+                data_type="object",
+                source_document=col.source_document,
+                discovery_iteration=col.discovery_iteration,
+                allowed_values=[v for v in col.allowed_values if v is not None] if col.allowed_values else None,
+                auto_expand_threshold=getattr(col, 'auto_expand_threshold', 2)
+            )
+            schema_columns.append(col_info)
+
+        session.columns = schema_columns
+        session.schema_query = schematiq_config["query"]
+        if discovered_schema.observation_unit:
+            session.observation_unit = ObservationUnitInfo(
+                name=discovered_schema.observation_unit.name,
+                definition=discovered_schema.observation_unit.definition,
+                example_names=discovered_schema.observation_unit.example_names,
+                source_document=discovered_schema.observation_unit.source_document,
+                discovery_iteration=discovered_schema.observation_unit.discovery_iteration
+            )
+        self.session_manager.update_session(session)
+        logger.debug("Session %s saved with %d columns, status: %s", session_id, len(schema_columns), session.status)
+
+    async def _handle_stop_after_schema(self, session_id: str):
+        """Handle stop requested after schema discovery."""
+        logger.warning("Stop requested - skipping value extraction and finalization")
+        session = self.session_manager.get_session(session_id)
+        session.status = SessionStatus.STOPPED
+        session.error_message = None
+        self.session_manager.update_session(session)
+        logger.debug("Updated session status to STOPPED (from schema discovery stop)")
+        await self.broadcast_stopped(session_id, {
+            "schema_saved": True,
+            "data_rows_saved": 0,
+            "message": "Processing stopped after schema discovery"
+        })
+
+    async def _handle_stop_after_extraction(self, session_id: str):
+        """Handle stop requested after value extraction."""
+        logger.warning("Stop requested - skipping finalization")
+        session = self.session_manager.get_session(session_id)
+        session.status = SessionStatus.STOPPED
+        session.error_message = None
+        self.session_manager.update_session(session)
+        logger.debug("Updated session status to STOPPED (from value extraction stop)")
+        session_dir = self.work_dir / session_id
+        data_file = session_dir / "extracted_data.jsonl"
+        rows_saved = 0
+        if data_file.exists():
+            with open(data_file, 'r') as f:
+                rows_saved = sum(1 for _ in f)
+        await self.broadcast_stopped(session_id, {
+            "schema_saved": True,
+            "data_rows_saved": rows_saved,
+            "message": "Processing stopped during value extraction"
+        })
+        if self._data_collection_service and rows_saved > 0:
+            await self._data_collection_service.trigger_archive(session_id, "schematiq_stopped_partial")
+        if self._pubmed_enrichment_service and rows_saved > 0:
+            await self._pubmed_enrichment_service.enrich_session(session_id)
+        if self._uniprot_enrichment_service and rows_saved > 0:
+            await self._uniprot_enrichment_service.enrich_session(session_id)
+
+    def _move_pending_documents(self, session_id: str):
+        """Move processed documents from pending_documents/ to documents/."""
+        data_session_dir = Path("./data") / session_id
+        pending_dir = data_session_dir / "pending_documents"
+        completed_docs_dir = data_session_dir / "documents"
+        if pending_dir.exists():
+            completed_docs_dir.mkdir(parents=True, exist_ok=True)
+            moved_count = 0
+            for file_path in pending_dir.iterdir():
+                if file_path.is_file():
+                    dest_path = completed_docs_dir / file_path.name
+                    if dest_path.exists():
+                        base_name = file_path.stem
+                        extension = file_path.suffix
+                        counter = 1
+                        while dest_path.exists():
+                            dest_path = completed_docs_dir / f"{base_name}_{counter}{extension}"
+                            counter += 1
+                    shutil.move(str(file_path), str(dest_path))
+                    moved_count += 1
+            if moved_count:
+                logger.info("Moved %d files from pending_documents/ to documents/ for session %s", moved_count, session_id)

--- a/backend/app/services/upload_document_processor.py
+++ b/backend/app/services/upload_document_processor.py
@@ -237,6 +237,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
 
             start_time = time.time()
             last_processed_line = 0
+            last_file_pos = 0
 
             while not extraction_task.done():
                 # Check for stop request
@@ -298,15 +299,16 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
                 if output_path.exists():
                     try:
                         current_new_rows = []
-                        current_line_count = 0
 
-                        # Read new rows since last check (for progress tracking and broadcasting)
+                        # Read only new lines since last check using file seek position
                         with open(output_path, 'r') as f:
-                            for line_num, line in enumerate(f):
-                                current_line_count += 1
-                                if line_num >= last_processed_line and line.strip():
+                            f.seek(last_file_pos)
+                            for line in f:
+                                if line.strip():
                                     row_data = json.loads(line)
                                     current_new_rows.append(row_data)
+                            last_file_pos = f.tell()
+                        current_line_count = last_processed_line + len(current_new_rows)
 
                         # If we have new rows, update progress (but DON'T write to data.jsonl - that happens in _merge_extracted_data)
                         if current_new_rows:


### PR DESCRIPTION
Break down the 2,528-line god class into 7 focused modules under pipeline/ (llm_factory, callbacks, config_handler, schema_discovery, value_extraction, data_query, __init__). ScheMatiQRunner stays as the public facade with identical API — no caller changes needed.

Also: deduplicate enforce_release_llm_config and is_local_path across services, remove dead _find_paper_path in reextraction_service, and fix O(n) progress monitoring in upload_document_processor (seek-based).