### PR TITLE
fix: attach PubMed document URLs only for PubMed-backed sources

### DIFF
--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -927,6 +927,15 @@ async def add_documents(session_id: str, files: List[UploadFile] = File(...), by
         # Update session metadata — append new filenames to any already queued
         existing_docs = session.metadata.uploaded_documents or []
         session.metadata.uploaded_documents = existing_docs + uploaded_filenames
+        # Never attach PubMed/EuropePMC-derived URLs to user-uploaded source documents
+        sup = session.metadata.pubmed_link_suppressed_document_names or []
+        sup_set = set(sup)
+        for fn in uploaded_filenames:
+            for label in (fn, Path(fn).stem):
+                if label not in sup_set:
+                    sup.append(label)
+                    sup_set.add(label)
+        session.metadata.pubmed_link_suppressed_document_names = sup
         session.status = SessionStatus.DOCUMENTS_UPLOADED
         session.metadata.last_modified = datetime.now()
         session_manager.update_session(session)
@@ -1008,6 +1017,12 @@ async def remove_uploaded_document(session_id: str, request: RemoveDocumentReque
 
         # Remove from metadata
         session.metadata.uploaded_documents.remove(request.filename)
+        _fn = request.filename
+        _stem = Path(_fn).stem
+        session.metadata.pubmed_link_suppressed_document_names = [
+            x for x in (session.metadata.pubmed_link_suppressed_document_names or [])
+            if x not in {_fn, _stem}
+        ]
 
         # Remove the actual file from pending_documents directory
         parser = FileParser()

--- a/backend/app/api/routes/units.py
+++ b/backend/app/api/routes/units.py
@@ -71,10 +71,16 @@ async def list_source_documents(session_id: str):
         doc_summaries = []
         for d in documents:
             meta = doc_metadata.get(d["name"], {})
+            raw_url = meta.get("url")
+            url = (
+                raw_url
+                if pubmed_enrichment_service.document_qualifies_for_pubmed_link(session, d["name"])
+                else None
+            )
             doc_summaries.append(DocumentSummary(
                 name=d["name"],
                 row_count=d["row_count"],
-                url=meta.get("url"),
+                url=url,
             ))
 
         # Trigger background PubMed enrichment for documents missing URLs

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -125,6 +125,8 @@ class SessionMetadata(BaseModel):
     additional_rows_added: int = 0  # Rows added through document processing
     cloud_dataset: Optional[str] = None  # Original cloud dataset name (e.g., "nes_full_text")
     document_metadata: Dict[str, Dict[str, Any]] = Field(default_factory=dict)  # Per-document metadata: filename -> { "url": str, ... }
+    # Filenames/stems from /add-documents — never attach PubMed/EuropePMC-resolved URLs to these
+    pubmed_link_suppressed_document_names: List[str] = Field(default_factory=list)
 
 class DataStatistics(BaseModel):
     """Statistics about the dataset."""

--- a/backend/app/services/pubmed_enrichment_service.py
+++ b/backend/app/services/pubmed_enrichment_service.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional, Set
 import requests
 
 from app.core.config import DEFAULT_DATA_DIR
+from app.models.session import SessionType, VisualizationSession
 from app.services.session_manager import SessionManager
 
 logger = logging.getLogger(__name__)
@@ -202,6 +203,10 @@ class PubMedEnrichmentService:
     document names with no entry yet in ``document_metadata`` (a missing entry
     means "never tried"; ``{"url": None}`` means "tried, no link" and stops
     repeat polling).
+
+    PubMed / EuropePMC URLs are only resolved for documents that plausibly came
+    from a PubMed-backed corpus (cloud dataset or ScheMatiQ local batch), not
+    for user-uploaded files tracked in ``pubmed_link_suppressed_document_names``.
     """
 
     def __init__(self, session_manager: SessionManager, data_dir: str = DEFAULT_DATA_DIR):
@@ -210,6 +215,36 @@ class PubMedEnrichmentService:
         self._active_tasks: Set[asyncio.Task] = set()
         # Track sessions currently being enriched to avoid duplicate work
         self._in_progress: Set[str] = set()
+
+    @staticmethod
+    def _document_name_matches_suppressed(doc_name: str, suppressed: List[str]) -> bool:
+        """Match row _source_document (often stem or unit-prefixed) to upload-tracked names."""
+        if not suppressed or not doc_name:
+            return False
+        sset = set(suppressed)
+        stripped = re.sub(r"^[a-z]{2,5}-", "", doc_name)
+        variants = {doc_name, stripped, Path(doc_name).stem, Path(stripped).stem}
+        if variants & sset:
+            return True
+        stem = Path(stripped).stem
+        for ext in (".txt", ".md", ".pdf", ".doc", ".docx", ".rtf"):
+            if f"{stem}{ext}" in sset:
+                return True
+        return False
+
+    def document_qualifies_for_pubmed_link(
+        self, session: Optional[VisualizationSession], doc_name: Optional[str]
+    ) -> bool:
+        """Whether we may resolve or expose an external PubMed/DOI URL for this source document."""
+        if not session or not doc_name:
+            return False
+        meta = session.metadata
+        if session.type == SessionType.UPLOAD and not meta.cloud_dataset:
+            return False
+        suppressed = getattr(meta, "pubmed_link_suppressed_document_names", None) or []
+        if self._document_name_matches_suppressed(doc_name, suppressed):
+            return False
+        return True
 
     def _resolve_doc_path(self, session_id: str, doc_name: str) -> Optional[Path]:
         """Locate the source document on disk for a given session.
@@ -301,8 +336,16 @@ class PubMedEnrichmentService:
         if not missing:
             return False
 
+        ineligible = [n for n in missing if not self.document_qualifies_for_pubmed_link(session, n)]
+        eligible_missing = [n for n in missing if self.document_qualifies_for_pubmed_link(session, n)]
+        if ineligible:
+            self._store_enrichment_misses_batch(session_id, ineligible)
+
+        if not eligible_missing:
+            return False
+
         self._in_progress.add(session_id)
-        task = asyncio.create_task(self._enrich_documents(session_id, missing))
+        task = asyncio.create_task(self._enrich_documents(session_id, eligible_missing))
         self._active_tasks.add(task)
 
         def _on_done(t: asyncio.Task) -> None:
@@ -312,7 +355,7 @@ class PubMedEnrichmentService:
         task.add_done_callback(_on_done)
         logger.info(
             "[pubmed-enrichment] Started enrichment for %d/%d documents in session %s",
-            len(missing), len(doc_names), session_id[:8],
+            len(eligible_missing), len(doc_names), session_id[:8],
         )
         return True
 


### PR DESCRIPTION
Track user-uploaded filenames on the session and skip EuropePMC enrichment for them. Upload sessions without a cloud_dataset never get external article links. GET /units/documents hides stored URLs when a document is not eligible so old metadata cannot mislead the UI.