### PR TITLE
feat: add Gemini cache logging and reduce TTL to 300s

### DIFF
--- a/schematiq-lib/schematiq/core/llm_backends.py
+++ b/schematiq-lib/schematiq/core/llm_backends.py
@@ -15,7 +15,7 @@ from abc import ABC, abstractmethod
 from typing import List, Dict, Any, Union, Optional
 import re
 
-from schematiq.core.model_specs import get_model_spec, get_max_output_tokens
+from schematiq.core.model_specs import get_model_spec, get_max_output_tokens, ModelNames
 from schematiq.core.llm_call_tracker import LLMCallTracker
 
 logger = logging.getLogger(__name__)
@@ -489,7 +489,7 @@ class GeminiLLM(LLMInterface):
 
     def __init__(
         self,
-        model: str = "gemini-2.5-flash-lite",
+        model: str = ModelNames.DEFAULT_VALUE_EXTRACTION,
         api_key: str | None = None,
         max_output_tokens: Optional[int] = None,
         temperature: float = 0.3,
@@ -791,9 +791,13 @@ class GeminiLLM(LLMInterface):
                     ttl=f"{ttl_seconds}s",
                 )
             )
+            logger.info(
+                "Gemini context cache CREATED (model=%s, doc_chars=%d, ttl=%ds, cache=%s)",
+                self.model, len(document_text), ttl_seconds, cache.name,
+            )
             return cache
         except Exception as e:
-            print(f"Context cache creation failed: {e}. Proceeding without cache.")
+            logger.warning("Gemini context cache creation FAILED (model=%s, doc_chars=%d): %s", self.model, len(document_text), e)
             return None
 
     def delete_context_cache(self, cache):
@@ -801,8 +805,9 @@ class GeminiLLM(LLMInterface):
         try:
             if cache:
                 self._client.caches.delete(name=cache.name)
-        except Exception:
-            pass
+                logger.info("Gemini context cache DELETED (cache=%s)", cache.name)
+        except Exception as e:
+            logger.debug("Gemini context cache delete failed (cache=%s): %s", cache.name, e)
 
     def generate_with_cache(self, prompt: str, cache, **kwargs) -> str:
         """Generate using a cached context. Falls back to regular generate if cache is None."""
@@ -821,6 +826,10 @@ class GeminiLLM(LLMInterface):
         else:
             prompt_text = prompt
 
+        logger.info(
+            "Gemini cached API call START (model=%s, cache=%s, prompt_chars=%d)",
+            self.model, cache.name, len(prompt_text),
+        )
         print(f"🚀 Starting Gemini cached API call (model: {self.model}, prompt: ~{len(prompt_text):,} chars)")
         start_time = time.time()
 

--- a/schematiq-lib/schematiq/value_extraction/core/llm_cache.py
+++ b/schematiq-lib/schematiq/value_extraction/core/llm_cache.py
@@ -1,20 +1,25 @@
 """Thread-safe LRU cache for LLM responses."""
 
 import hashlib
+import logging
 import threading
 from collections import OrderedDict
 from typing import Dict, Any, Optional
 
 from ..config.constants import DEFAULT_CACHE_SIZE, CACHE_EVICTION_BATCH
 
+logger = logging.getLogger(__name__)
+
 
 class LLMCache:
     """Thread-safe LRU cache for LLM responses with size limit."""
-    
+
     def __init__(self, max_size: int = DEFAULT_CACHE_SIZE):
         self._cache: OrderedDict = OrderedDict()
         self._lock = threading.Lock()
         self._max_size = max_size
+        self._hits = 0
+        self._misses = 0
     
     def _get_text_hash(self, text: str) -> str:
         """Generate a hash for text content for caching purposes."""
@@ -29,10 +34,19 @@ class LLMCache:
         """Thread-safe cache retrieval."""
         with self._lock:
             if cache_key in self._cache:
-                # Move to end (most recently used)
                 value = self._cache.pop(cache_key)
                 self._cache[cache_key] = value
+                self._hits += 1
+                logger.info(
+                    "LLM response cache HIT (key=%s, hits=%d, misses=%d, size=%d)",
+                    cache_key, self._hits, self._misses, len(self._cache),
+                )
                 return value
+            self._misses += 1
+            logger.debug(
+                "LLM response cache MISS (key=%s, hits=%d, misses=%d, size=%d)",
+                cache_key, self._hits, self._misses, len(self._cache),
+            )
             return None
     
     def put(self, cache_key: str, response: Dict[str, Any]) -> None:
@@ -59,3 +73,23 @@ class LLMCache:
         """Get current cache size."""
         with self._lock:
             return len(self._cache)
+
+    def stats(self) -> dict:
+        """Return cache hit/miss statistics."""
+        with self._lock:
+            total = self._hits + self._misses
+            rate = (self._hits / total * 100) if total else 0.0
+            return {
+                "hits": self._hits,
+                "misses": self._misses,
+                "hit_rate": round(rate, 1),
+                "size": len(self._cache),
+            }
+
+    def log_stats(self) -> None:
+        """Log cache statistics summary."""
+        s = self.stats()
+        logger.info(
+            "LLM response cache stats: %d hits, %d misses, %.1f%% hit rate, %d entries",
+            s["hits"], s["misses"], s["hit_rate"], s["size"],
+        )

--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -3,6 +3,8 @@
 import json
 import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 from typing import Dict, Any, Set, Callable, Optional, List, Iterator
 from schematiq.core.schema import Schema, Column, ObservationUnit, _embed
 from schematiq.core.llm_backends import LLMInterface
@@ -160,13 +162,14 @@ class PaperProcessor:
     def _create_document_cache(self, system_prompt: str, paper_text: str):
         """Create a Gemini context cache for a document. Returns cache or None."""
         if not self._is_gemini_backend():
+            logger.debug("Context cache skipped: non-Gemini backend")
             return None
-        # Only cache if document is large enough (~1024 tokens ≈ 4096 chars)
         if len(paper_text) < 4096:
+            logger.info("Context cache skipped: document too small (%d chars < 4096)", len(paper_text))
             return None
         if not hasattr(self.llm, 'create_context_cache'):
             return None
-        return self.llm.create_context_cache(system_prompt, paper_text)
+        return self.llm.create_context_cache(system_prompt, paper_text, ttl_seconds=300)
 
     def _delete_document_cache(self):
         """Delete the active context cache if one exists."""
@@ -1648,70 +1651,70 @@ class PaperProcessor:
         import time as time_module
 
         results = []
-        for i, unit in enumerate(units, 1):
-            if self._check_stop_requested():
-                print(f"🛑 Stop requested during unit extraction")
-                self._delete_document_cache()
-                break
+        try:
+            for i, unit in enumerate(units, 1):
+                if self._check_stop_requested():
+                    print(f"🛑 Stop requested during unit extraction")
+                    break
 
-            unit_name = unit.get("unit_name", f"Unit {i}")
-            relevant_passages = unit.get("relevant_passages", [paper_text])
-            confidence = unit.get("confidence", "medium")
+                unit_name = unit.get("unit_name", f"Unit {i}")
+                relevant_passages = unit.get("relevant_passages", [paper_text])
+                confidence = unit.get("confidence", "medium")
 
-            # When DISABLE_RETRIEVER is on, always use the full document text
-            # instead of the (possibly truncated) relevant_passages from unit identification.
-            # This ensures the LLM has the full context of the CURRENT document and
-            # doesn't hallucinate from other documents if the cache was somehow contaminated.
-            if DISABLE_RETRIEVER:
-                relevant_passages = [paper_text]
-            else:
-                # Ensure we have at least some text for the unit
-                if not relevant_passages:
+                # When DISABLE_RETRIEVER is on, always use the full document text
+                # instead of the (possibly truncated) relevant_passages from unit identification.
+                # This ensures the LLM has the full context of the CURRENT document and
+                # doesn't hallucinate from other documents if the cache was somehow contaminated.
+                if DISABLE_RETRIEVER:
                     relevant_passages = [paper_text]
+                else:
+                    # Ensure we have at least some text for the unit
+                    if not relevant_passages:
+                        relevant_passages = [paper_text]
 
-            print(
-                f"  → Extracting values for unit {i}/{len(units)}: {unit_name} (confidence: {confidence})"
-            )
-            unit_start = time_module.time()
-
-            # Extract values for this specific unit
-            unit_values = self.extract_values_for_unit(
-                unit_name=unit_name,
-                relevant_passages=relevant_passages,
-                schema=schema,
-                max_new_tokens=max_new_tokens,
-                paper_title=paper_title,
-                paper_text=paper_text,
-            )
-
-            unit_elapsed = time_module.time() - unit_start
-
-            if unit_values:
-                # Add metadata fields
-                unit_values["_unit_name"] = unit_name
-                unit_values["_source_document"] = paper_title
-                unit_values["_parent_document"] = paper_title
-                unit_values["_observation_unit"] = observation_unit.name
-                unit_values["_unit_confidence"] = confidence
-
-                results.append(unit_values)
-
-                # Callback for streaming
-                if on_unit_extracted:
-                    on_unit_extracted(unit_name, unit_values)
-
-                col_count = len([k for k in unit_values if not k.startswith("_")])
                 print(
-                    f"    ✓ Extracted {col_count} columns for {unit_name} ({unit_elapsed:.1f}s)"
+                    f"  → Extracting values for unit {i}/{len(units)}: {unit_name} (confidence: {confidence})"
                 )
-            else:
-                print(
-                    f"    ✗ No values extracted for {unit_name} ({unit_elapsed:.1f}s)"
+                unit_start = time_module.time()
+
+                # Extract values for this specific unit
+                unit_values = self.extract_values_for_unit(
+                    unit_name=unit_name,
+                    relevant_passages=relevant_passages,
+                    schema=schema,
+                    max_new_tokens=max_new_tokens,
+                    paper_title=paper_title,
+                    paper_text=paper_text,
                 )
 
-        # Clean up context cache for this document
-        self._delete_document_cache()
+                unit_elapsed = time_module.time() - unit_start
 
+                if unit_values:
+                    # Add metadata fields
+                    unit_values["_unit_name"] = unit_name
+                    unit_values["_source_document"] = paper_title
+                    unit_values["_parent_document"] = paper_title
+                    unit_values["_observation_unit"] = observation_unit.name
+                    unit_values["_unit_confidence"] = confidence
+
+                    results.append(unit_values)
+
+                    # Callback for streaming
+                    if on_unit_extracted:
+                        on_unit_extracted(unit_name, unit_values)
+
+                    col_count = len([k for k in unit_values if not k.startswith("_")])
+                    print(
+                        f"    ✓ Extracted {col_count} columns for {unit_name} ({unit_elapsed:.1f}s)"
+                    )
+                else:
+                    print(
+                        f"    ✗ No values extracted for {unit_name} ({unit_elapsed:.1f}s)"
+                    )
+        finally:
+            self._delete_document_cache()
+
+        self.cache.log_stats()
         print(
             f"  ✅ Completed {paper_title}: {len(results)} rows from {len(units)} units"
         )


### PR DESCRIPTION
## Summary
- Add hit/miss logging and statistics to `LLMCache` (app-level response cache)
- Add lifecycle logging to Gemini context cache (create/delete/use per API call)
- Reduce per-document context cache TTL from 1800s to 300s — caches are deleted right after processing, so the long TTL only risked storage charges on cleanup failure
- Wrap unit extraction loop in `try/finally` to prevent cache leaks on unexpected exceptions

## Test plan
- [ ] Run extraction on a multi-unit document and verify cache logs appear (context cache CREATED/DELETED, LLM response cache stats)
- [ ] Verify small documents (<4096 chars) log "document too small" skip message
- [ ] Confirm cache is cleaned up even if extraction raises an exception mid-document

🤖 Generated with [Claude Code](https://claude.com/claude-code)