### PR TITLE
fix: require all column keys in controlled-gen schema

### DIFF
--- a/schematiq-lib/schematiq/value_extraction/utils/schema_builder.py
+++ b/schematiq-lib/schematiq/value_extraction/utils/schema_builder.py
@@ -85,5 +85,6 @@ def build_extraction_response_schema(
     schema = {
         "type": "OBJECT",
         "properties": properties,
+        "required": [_sanitize_name(col.name) for col in columns],
     }
     return schema, key_map


### PR DESCRIPTION
## Summary
- The Gemini controlled-generation `response_schema` declared column properties but had no `"required"` array — all keys were optional
- This allowed Gemini to silently omit columns (e.g., 34 requested, 9 returned)
- Add `"required": [all_column_names]` to the top-level schema so every column must appear in the response

## Test plan
- [ ] Run extraction with controlled-gen active and verify all requested columns appear in the response JSON
- [ ] Verify columns with no answer return `{"answer": null, "excerpts": []}` instead of being omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)