### PR TITLE
Raise release-mode max documents to 150

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -97,7 +97,7 @@ DEVELOPER_MODE = os.environ.get("DEVELOPER_MODE", "false").lower() == "true"
 # All mode-dependent feature flags live here.
 # To add a new release restriction, add a key with its release-mode default.
 RELEASE_CONFIG = {
-    "max_documents": 120,          # release mode cap
+    "max_documents": 150,          # release mode cap
     # LLM configuration for release mode (locked to Gemini)
     "schema_creation_model": "gemini-2.5-flash",
     "value_extraction_model": "gemini-3.1-flash-lite-preview",


### PR DESCRIPTION
## Summary
- Bumps `RELEASE_CONFIG["max_documents"]` from 120 to 150 so release-mode sessions can process more documents before hitting the cap (unless overridden by `MAX_DOCUMENTS`).

## Test plan
- [ ] Confirm `/api/config` (or equivalent) reflects the new cap when `DEVELOPER_MODE` is false and `MAX_DOCUMENTS` is unset.

Made with [Cursor](https://cursor.com)