### PR TITLE
Support deferred extraction after schema-only discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See [Features > Core Library](#core-library-schematiq-lib) for the full API surf
 - **Continue Discovery** — Extend schema after initial convergence by processing more documents
 - **Reextraction** — Re-run structured data extraction with the current or edited schema
 - **Cost Estimation** — Preview estimated API costs before running expensive operations
-- **Document Upload** — PDF and TXT support with automatic preprocessing
+- **Document Upload** — TXT, MD, PDF, DOC, DOCX, and RTF; non-text formats are converted to plain text automatically before schema discovery and extraction
 - **Export** — Download results as CSV, JSON, or JSONL
 
 ### Core Library (schematiq-lib)

--- a/backend/app/api/routes/schema.py
+++ b/backend/app/api/routes/schema.py
@@ -874,8 +874,12 @@ async def get_schema_change_status(session_id: str) -> SchemaChangeStatusRespons
         for col_name in changes["column_changes"]:
             changes["column_changes"][col_name]["row_count_affected"] = row_count
 
-        # can_reextract = session has data (frontend checks doc availability separately)
-        changes["can_reextract"] = row_count > 0
+        # Allow re-extraction when rows exist OR session still has source documents (schema-only mode)
+        paper_discovery = await reextraction_service.discover_papers(session_id)
+        has_session_documents = bool(paper_discovery.get("available_papers")) or bool(
+            paper_discovery.get("session_document_count")
+        )
+        changes["can_reextract"] = row_count > 0 or has_session_documents
 
         return SchemaChangeStatusResponse(
             has_changes=changes["has_changes"],

--- a/backend/app/services/pipeline/data_query.py
+++ b/backend/app/services/pipeline/data_query.py
@@ -192,6 +192,14 @@ async def get_status(
     except Exception:
         pass
 
+    # Deferred extraction completed — table data exists even if config still has skip flag
+    if schema_only:
+        extracted_file = work_dir / session_id / "extracted_data.jsonl"
+        if extracted_file.exists() and extracted_file.stat().st_size > 0:
+            schema_only = False
+        elif session.statistics and (session.statistics.total_rows or 0) > 0:
+            schema_only = False
+
     return ScheMatiQStatus(
         session_id=session_id,
         status=status,

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -375,6 +375,55 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
     # ==================== Paper Discovery ====================
 
+    def _get_session_document_dirs(self, session_id: str) -> List[Path]:
+        """Directories that may hold source documents for a session."""
+        data_session_dir = Path("./data") / session_id
+        schematiq_session_dir = Path("./schematiq_work") / session_id
+        docs_dir = data_session_dir / "documents"
+        pending_dir = data_session_dir / "pending_documents"
+
+        local_dirs_to_check: List[Path] = [docs_dir, pending_dir]
+
+        schematiq_datasets_dir = schematiq_session_dir / "datasets"
+        if schematiq_datasets_dir.exists():
+            for dataset_dir in schematiq_datasets_dir.iterdir():
+                if dataset_dir.is_dir():
+                    local_dirs_to_check.append(dataset_dir)
+
+        capped_dir = schematiq_session_dir / "capped_documents"
+        if capped_dir.exists():
+            local_dirs_to_check.append(capped_dir)
+
+        schematiq_config_file = schematiq_session_dir / "schematiq_config.json"
+        if schematiq_config_file.exists():
+            try:
+                with open(schematiq_config_file) as f:
+                    schematiq_config = json.load(f)
+                config_docs_path = schematiq_config.get("docs_path", [])
+                if isinstance(config_docs_path, str):
+                    config_docs_path = [config_docs_path]
+                for dp in config_docs_path:
+                    if dp:
+                        dp_path = Path(dp)
+                        if dp_path.is_dir() and dp_path not in local_dirs_to_check:
+                            local_dirs_to_check.append(dp_path)
+            except Exception as e:
+                logger.debug("Could not read ScheMatiQ config for docs_path: %s", e)
+
+        return [d for d in local_dirs_to_check if d.exists()]
+
+    def _collect_session_document_filenames(self, session_id: str) -> List[str]:
+        """List document filenames on disk (used when the table has no rows yet)."""
+        seen: Set[str] = set()
+        filenames: List[str] = []
+        for local_dir in self._get_session_document_dirs(session_id):
+            for f in sorted(local_dir.iterdir()):
+                if f.is_file() and not f.name.startswith("."):
+                    if f.name not in seen:
+                        seen.add(f.name)
+                        filenames.append(f.name)
+        return filenames
+
     async def discover_papers(self, session_id: str) -> Dict[str, Any]:
         """
         Discover papers associated with table rows in storage.
@@ -409,7 +458,6 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
         data_session_dir = Path("./data") / session_id
         schematiq_session_dir = Path("./schematiq_work") / session_id
-        docs_dir = data_session_dir / "documents"
 
         # Find data files from all possible locations (same logic as schematiq_runner.get_extracted_data)
         data_files = []
@@ -513,38 +561,8 @@ class ReextractionService(WebSocketBroadcasterMixin):
                             continue
 
         # Check which papers exist in local storage
-        # Check documents/, pending_documents/, schematiq_work datasets, and original docs_path
         local_files: Set[str] = set()
-        pending_dir = data_session_dir / "pending_documents"
-
-        local_dirs_to_check = [docs_dir, pending_dir]
-        # Also check schematiq_work datasets directories (Supabase datasets downloaded during ScheMatiQ creation)
-        schematiq_datasets_dir = schematiq_session_dir / "datasets"
-        if schematiq_datasets_dir.exists():
-            for dataset_dir in schematiq_datasets_dir.iterdir():
-                if dataset_dir.is_dir():
-                    local_dirs_to_check.append(dataset_dir)
-        # Also check schematiq_work capped_documents (if document limit was applied)
-        capped_dir = schematiq_session_dir / "capped_documents"
-        if capped_dir.exists():
-            local_dirs_to_check.append(capped_dir)
-        # Also check original docs_path from ScheMatiQ config (the directories used during creation)
-        schematiq_config_file = schematiq_session_dir / "schematiq_config.json"
-        if schematiq_config_file.exists():
-            try:
-                with open(schematiq_config_file) as f:
-                    schematiq_config = json.load(f)
-                config_docs_path = schematiq_config.get("docs_path", [])
-                if isinstance(config_docs_path, str):
-                    config_docs_path = [config_docs_path]
-                for dp in config_docs_path:
-                    if dp:
-                        dp_path = Path(dp)
-                        if dp_path.is_dir() and dp_path not in local_dirs_to_check:
-                            local_dirs_to_check.append(dp_path)
-                            logger.debug(f"Added docs_path from ScheMatiQ config: {dp_path}")
-            except Exception as e:
-                logger.debug(f"Could not read ScheMatiQ config for docs_path: {e}")
+        local_dirs_to_check = self._get_session_document_dirs(session_id)
 
         for local_dir in local_dirs_to_check:
             if local_dir.exists():
@@ -620,6 +638,20 @@ class ReextractionService(WebSocketBroadcasterMixin):
         # Combine local and cloud papers for available list
         available = local_papers + list(cloud_papers.keys())
 
+        # Schema-only / first extraction: no table rows yet, but documents were uploaded for discovery
+        session_document_filenames: List[str] = []
+        if not paper_refs:
+            session_document_filenames = self._collect_session_document_filenames(session_id)
+            if session_document_filenames:
+                for doc_name in session_document_filenames:
+                    if doc_name not in local_papers:
+                        local_papers.append(doc_name)
+                available = list(dict.fromkeys(local_papers + list(cloud_papers.keys())))
+                logger.info(
+                    "discover_papers: no row references; using %d on-disk session document(s)",
+                    len(session_document_filenames),
+                )
+
         # Build paper to rows mapping (extract display name from tuple key)
         paper_to_rows: Dict[str, List[str]] = {}
         for paper in available:
@@ -667,7 +699,8 @@ class ReextractionService(WebSocketBroadcasterMixin):
             "missing_papers": missing,
             "paper_to_rows": paper_to_rows,
             "cloud_papers": cloud_papers,
-            "local_papers": local_papers
+            "local_papers": local_papers,
+            "session_document_count": len(self._collect_session_document_filenames(session_id)),
         }
 
     async def _backfill_papers_from_documents(
@@ -846,8 +879,11 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     "Cannot re-extract: session has no observation unit configured. "
                     "Please set the observation unit before re-extracting."
                 )
-        # Discover papers
+        # Discover papers (includes on-disk uploads when the table has no rows yet)
         paper_discovery = await self.discover_papers(session_id)
+        doc_count = len(paper_discovery.get("available_papers") or [])
+        if doc_count == 0:
+            doc_count = paper_discovery.get("session_document_count") or 0
 
         # Validate LLM config before starting background task (fail fast with HTTP error)
         try:
@@ -863,7 +899,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
             columns=columns,
             status="starting"
         )
-        operation.total_documents = len(paper_discovery["available_papers"])
+        operation.total_documents = doc_count
         with self._state_lock:
             self.active_operations[operation_id] = operation
 
@@ -875,8 +911,8 @@ class ReextractionService(WebSocketBroadcasterMixin):
             "status": "started",
             "operation_id": operation_id,
             "columns": columns,
-            "estimated_papers": len(paper_discovery["available_papers"]),
-            "rows_to_process": len(paper_discovery["available_papers"]),
+            "estimated_papers": doc_count,
+            "rows_to_process": doc_count,
             "missing_papers": paper_discovery["missing_papers"]
         }
 
@@ -981,6 +1017,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
             def on_document_started(paper_title: str):
                 """Fired once per source document file — drives the 'X of Y docs' counter."""
                 doc_index[0] += 1
+                operation.processed_documents = doc_index[0]
                 try:
                     asyncio.run_coroutine_threadsafe(
                         self.broadcast_event(
@@ -1000,7 +1037,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
             def on_value_extracted(row_name: str, column_name: str, value: Any):
                 processed_count[0] += 1
-                operation.processed_documents = processed_count[0]
+                # processed_documents = source files; processed_count = cells (do not mix)
 
                 # Schedule broadcasts on main event loop from thread (fire and forget)
                 try:
@@ -1021,6 +1058,8 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     )
 
                     # 2. Broadcast progress for UI indicators
+                    docs_done = doc_index[0]
+                    total_docs = max(operation.total_documents, 1)
                     asyncio.run_coroutine_threadsafe(
                         self.broadcast_event(
                             operation.session_id,
@@ -1028,8 +1067,9 @@ class ReextractionService(WebSocketBroadcasterMixin):
                             {
                                 "operation_id": operation_id,
                                 "column": column_name,
-                                "progress": processed_count[0] / max(operation.total_documents * len(operation.columns), 1),
-                                "processed_documents": processed_count[0],
+                                "progress": min(1.0, docs_done / total_docs),
+                                "processed_documents": docs_done,
+                                "processed_cells": processed_count[0],
                                 "total_documents": operation.total_documents,
                                 "current_row": row_name
                             }
@@ -1039,37 +1079,19 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 except Exception as e:
                     logger.warning(f"Broadcast error: {e}")
 
-            # Run extraction - check documents/, pending_documents/, schematiq_work datasets, and original docs_path
-            candidate_dirs = [docs_dir, pending_dir]
-            # Also check schematiq_work datasets directories (Supabase datasets downloaded during ScheMatiQ creation)
-            schematiq_datasets_dir = schematiq_dir / "datasets"
-            if schematiq_datasets_dir.exists():
-                for dataset_subdir in schematiq_datasets_dir.iterdir():
-                    if dataset_subdir.is_dir():
-                        candidate_dirs.append(dataset_subdir)
-            # Also check schematiq_work capped_documents
-            capped_dir = schematiq_dir / "capped_documents"
-            if capped_dir.exists():
-                candidate_dirs.append(capped_dir)
-            # Also check original docs_path from ScheMatiQ config
-            schematiq_config_file = schematiq_dir / "schematiq_config.json"
-            if schematiq_config_file.exists():
-                try:
-                    with open(schematiq_config_file) as f:
-                        schematiq_cfg = json.load(f)
-                    config_docs_path = schematiq_cfg.get("docs_path", [])
-                    if isinstance(config_docs_path, str):
-                        config_docs_path = [config_docs_path]
-                    for dp in config_docs_path:
-                        if dp:
-                            dp_path = Path(dp)
-                            if dp_path.is_dir() and dp_path not in candidate_dirs:
-                                candidate_dirs.append(dp_path)
-                except Exception:
-                    pass
-            docs_directories = [d for d in candidate_dirs if d.exists()]
+            # Same directory resolution as discover_papers / precheck
+            docs_directories = self._get_session_document_dirs(operation.session_id)
             docs_had_directories = bool(docs_directories)
-            logger.info(f"Re-extraction docs_directories={[str(d) for d in docs_directories]}, count={len(docs_directories)}")
+            logger.info(
+                "Re-extraction docs_directories=%s, count=%d",
+                [str(d) for d in docs_directories],
+                len(docs_directories),
+            )
+            if operation.total_documents > 0 and not docs_directories:
+                raise RuntimeError(
+                    "No document directories found on disk for this session. "
+                    "Re-upload documents on the Data tab and try again."
+                )
 
             rediscover_observation_units = bool(
                 session.metadata.pending_observation_unit_rediscovery
@@ -1254,10 +1276,6 @@ class ReextractionService(WebSocketBroadcasterMixin):
         if load_data_file.exists() and load_data_file.resolve() not in [f.resolve() for f in data_files]:
             data_files.append(load_data_file)
 
-        if not data_files:
-            logger.warning(f"No data files found for merge in session {session_id}")
-            return
-
         # Read extracted values indexed by composite key (row_name, source_document)
         # to avoid collisions when the same observation unit appears in multiple docs
         from app.services.data_utils import row_dedup_key, _resolve_source_document
@@ -1279,6 +1297,23 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     extracted_by_row_name.setdefault(key[0], []).append(row_data)
 
         logger.debug(f"Extracted composite keys from extraction file: {list(extracted_by_key.keys())}")
+
+        if not data_files:
+            schematiq_extracted_file.parent.mkdir(parents=True, exist_ok=True)
+            new_rows = [
+                self._storage_row_from_extraction(ext_row_data)
+                for ext_row_data in extracted_by_key.values()
+            ]
+            with open(schematiq_extracted_file, "w") as f:
+                for row in new_rows:
+                    f.write(json.dumps(row, ensure_ascii=False) + "\n")
+            logger.info(
+                "Created %s with %d rows (first extraction after schema-only)",
+                schematiq_extracted_file,
+                len(new_rows),
+            )
+            self._update_session_stats_after_merge(session_id, columns, new_rows)
+            return
 
         # Build a fallback mapping from paper name stem to extracted data list
         extracted_by_paper_stem: Dict[str, List[Dict[str, Any]]] = {}
@@ -1364,21 +1399,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     if ext_key in matched_extracted_keys:
                         continue
 
-                    ext_row_name = ext_key[0]
-                    new_row = {
-                        "row_name": ext_row_name,
-                        "papers": ext_row_data.get("_papers", []),
-                        "data": {k: v for k, v in ext_row_data.items() 
-                                if not k.startswith('_') and k != "document_directory"}
-                    }
-                    if unit_name := ext_row_data.get("_unit_name"):
-                        new_row["_unit_name"] = unit_name
-                    metadata = ext_row_data.get("_metadata", {})
-                    if base_row_name := metadata.get("base_row_name"):
-                        new_row["_source_document"] = base_row_name
-                    elif papers_list := ext_row_data.get("_papers", []):
-                        new_row["_source_document"] = papers_list[0] if isinstance(papers_list, list) else str(papers_list)
-
+                    new_row = self._storage_row_from_extraction(ext_row_data)
                     updated_rows.append(new_row)
                     new_rows_added += 1
 
@@ -1397,28 +1418,77 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
         logger.debug(f"Merged re-extracted data for {len(columns)} columns across {len(data_files)} files, {total_rows_updated} rows updated, {total_new_rows} new rows added")
 
-        # Update session statistics to reflect new data (including new rows)
-        session = self.session_manager.get_session(session_id)
-        if session and session.statistics:
-            if total_new_rows > 0:
-                old_total = session.statistics.total_rows
-                session.statistics.total_rows = len(all_updated_rows)
-                logger.info(f"Updated total_rows: {old_total} -> {session.statistics.total_rows} (+{total_new_rows} new rows)")
+        self._update_session_stats_after_merge(session_id, columns, all_updated_rows)
 
-            # Update non-null counts for re-extracted columns
+    def _storage_row_from_extraction(self, ext_row_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize build_table_jsonl output for extracted_data.jsonl (flat runtime format)."""
+        if ext_row_data.get("_row_name"):
+            return ext_row_data
+        row_name = ext_row_data.get("row_name")
+        storage: Dict[str, Any] = {}
+        if row_name:
+            storage["_row_name"] = row_name
+        papers = ext_row_data.get("_papers") or ext_row_data.get("papers") or []
+        if papers:
+            storage["_papers"] = papers
+        nested = ext_row_data.get("data")
+        if isinstance(nested, dict):
+            for k, v in nested.items():
+                if not k.startswith("_"):
+                    storage[k] = v
+        for k, v in ext_row_data.items():
+            if k.startswith("_") and k not in storage:
+                storage[k] = v
+            elif k not in ("row_name", "papers", "data", "document_directory"):
+                storage[k] = v
+        if ext_row_data.get("_unit_name"):
+            storage["_unit_name"] = ext_row_data["_unit_name"]
+        if ext_row_data.get("_source_document"):
+            storage["_source_document"] = ext_row_data["_source_document"]
+        return storage
+
+    def _cell_value_present(self, row: Dict[str, Any], col_name: str) -> bool:
+        val = row.get(col_name)
+        if val is None and isinstance(row.get("data"), dict):
+            val = row["data"].get(col_name)
+        if val is None:
+            return False
+        if isinstance(val, dict) and "answer" in val:
+            return val.get("answer") is not None and val.get("answer") != ""
+        return val != ""
+
+    def _update_session_stats_after_merge(
+        self,
+        session_id: str,
+        columns: List[str],
+        all_rows: List[Dict[str, Any]],
+    ) -> None:
+        """Update session statistics and column fill counts after a merge."""
+        session = self.session_manager.get_session(session_id)
+        if not session:
+            return
+
+        if session.statistics:
+            session.statistics.total_rows = len(all_rows)
             for col_stat in session.statistics.column_stats:
                 if col_stat.name in columns:
-                    non_null_count = sum(
-                        1 for row in all_updated_rows
-                        if (row.get('data', {}).get(col_stat.name) is not None
-                            or row.get(col_stat.name) is not None)
+                    col_stat.non_null_count = sum(
+                        1 for row in all_rows if self._cell_value_present(row, col_stat.name)
                     )
-                    old_count = col_stat.non_null_count
-                    col_stat.non_null_count = non_null_count
-                    logger.debug(f"Updated stats for column '{col_stat.name}': non_null_count {old_count} -> {non_null_count}")
+        for col in session.columns:
+            if col.name in columns:
+                col.non_null_count = sum(
+                    1 for row in all_rows if self._cell_value_present(row, col.name)
+                )
 
-            self.session_manager.update_session(session)
-            logger.debug(f"Updated session statistics for {len(columns)} columns, {total_new_rows} new rows added")
+        session.metadata.processed_documents = session.metadata.total_documents or len(all_rows)
+        self.session_manager.update_session(session)
+        logger.info(
+            "Updated session %s after merge: %d rows, columns=%s",
+            session_id,
+            len(all_rows),
+            columns[:5],
+        )
 
     def _get_llm_from_session(self, session_id: str):
         """Get LLM configuration from session, including API key."""

--- a/frontend/src/components/ScheMatiQMonitor/ScheMatiQMonitor.tsx
+++ b/frontend/src/components/ScheMatiQMonitor/ScheMatiQMonitor.tsx
@@ -16,6 +16,8 @@ import {
   Plus,
   X,
   Pencil,
+  RefreshCw,
+  Table,
 } from 'lucide-react';
 import { useQuery, useQueryClient } from 'react-query';
 
@@ -34,14 +36,22 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 
-import { schematiqAPI, observationUnitAPI, loadAPI } from '../../services/api';
+import { schematiqAPI, observationUnitAPI, loadAPI, schemaAPI, configAPI } from '../../services/api';
 import { webSocketService } from '../../services/websocket';
-import { ScheMatiQStatus, WebSocketMessage, ProgressData, SchemaCompletionData, RowCompletionData, LogData, StoppedData, ObservationUnitReadyData } from '../../types';
+import { ScheMatiQStatus, WebSocketMessage, ProgressData, SchemaCompletionData, RowCompletionData, LogData, StoppedData, ObservationUnitReadyData, ReextractionRequest } from '../../types';
+import { getApiKeyForProvider, getConfiguredProviders } from '../../utils/apiKeyStorage';
+import {
+  LLMProviderKey,
+  getDefaultModelForProvider,
+  getAvailableProviders,
+} from '@/constants/llmModels';
 
 interface ScheMatiQMonitorProps {
   sessionId: string;
   autoStarted?: boolean;
   initialCapacityMessage?: string;
+  /** Notify parent when deferred extraction starts (schema-only → full table fill). */
+  onExtractionStarted?: (columns: string[], operationId?: string) => void;
 }
 
 interface LogEntry {
@@ -61,7 +71,12 @@ interface LlmStats {
   estimated_calls: number;
 }
 
-const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({ sessionId, autoStarted = false, initialCapacityMessage = '' }) => {
+const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
+  sessionId,
+  autoStarted = false,
+  initialCapacityMessage = '',
+  onExtractionStarted,
+}) => {
   const queryClient = useQueryClient();
   const llmStatsCacheKey = ['schematiq-llm-stats', sessionId];
   const cachedStatus = queryClient.getQueryData<ScheMatiQStatus>(['schematiq-status', sessionId]);
@@ -130,6 +145,9 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({ sessionId, autoStar
 
   // Whether value extraction was deliberately skipped (schema-only mode)
   const [schemaOnly, setSchemaOnly] = useState<boolean>(cachedStatus?.schema_only ?? false);
+  const [isDeferredExtracting, setIsDeferredExtracting] = useState(false);
+  const [deferredExtractError, setDeferredExtractError] = useState('');
+  const [activeReextractionId, setActiveReextractionId] = useState<string | null>(null);
 
   // Track ScheMatiQ start time for elapsed display
   const startTimeRef = useRef<number | null>(null);
@@ -399,6 +417,111 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({ sessionId, autoStar
           setObsUnitEdited(false);
         }
         queryClient.invalidateQueries(['schematiq-status', sessionId]);
+      } else if (message.type === 'reextraction_started') {
+        const data = message.data as { operation_id?: string; columns?: string[]; total_documents?: number };
+        setSchemaOnly(false);
+        setProcessingState('extraction');
+        setDeferredExtractError('');
+        if (data?.operation_id) {
+          setActiveReextractionId(data.operation_id);
+        }
+        const total = data?.total_documents ?? 0;
+        if (total > 0) {
+          setExtractionProgress({
+            processedDocs: 0,
+            totalDocs: total,
+            isComplete: false,
+          });
+          setCurrentStepMessage(`Extracting values from ${total} document(s)...`);
+        }
+        addLog('info', 'Extracting table data from your uploaded documents...');
+      } else if (message.type === 'document_started') {
+        const data = message.data as {
+          document_name?: string;
+          document_index?: number;
+          total_documents?: number;
+        };
+        setProcessingState('extraction');
+        setSchemaOnly(false);
+        const total = data?.total_documents ?? 0;
+        const index = data?.document_index ?? 0;
+        if (total > 0) {
+          setExtractionProgress(prev => ({
+            ...prev,
+            totalDocs: total,
+            processedDocs: Math.max(prev.processedDocs, index - 1),
+            isComplete: false,
+          }));
+          setCurrentStepMessage(
+            `Processing ${data?.document_name || 'document'} (${index}/${total})...`,
+          );
+        }
+      } else if (message.type === 'reextraction_progress') {
+        const data = message.data as {
+          processed_documents?: number;
+          total_documents?: number;
+          current_row?: string;
+        };
+        setProcessingState('extraction');
+        setSchemaOnly(false);
+        const total = data?.total_documents ?? 0;
+        const processed = total > 0
+          ? Math.min(data?.processed_documents ?? 0, total)
+          : (data?.processed_documents ?? 0);
+        setExtractionProgress(prev => ({
+          ...prev,
+          processedDocs: processed || prev.processedDocs,
+          totalDocs: total || prev.totalDocs,
+          isComplete: false,
+        }));
+        if (total > 0) {
+          setCurrentStepMessage(
+            data?.current_row
+              ? `Extracting row "${data.current_row}" (document ${processed}/${total})...`
+              : `Extracting values (document ${processed}/${total})...`,
+          );
+        }
+      } else if (message.type === 'reextraction_completed') {
+        const data = message.data as { columns?: string[] };
+        setActiveReextractionId(null);
+        setSchemaOnly(false);
+        setIsStopping(false);
+        setProcessingState('completed');
+        setExtractionProgress(prev => ({
+          ...prev,
+          isComplete: true,
+          processedDocs: prev.totalDocs || prev.processedDocs,
+        }));
+        setCurrentStepMessage('Extraction complete.');
+        addLog('success', `Extraction complete${data?.columns?.length ? ` (${data.columns.length} columns)` : ''}.`);
+        queryClient.invalidateQueries(['schematiq-status', sessionId]);
+        queryClient.invalidateQueries(['session', sessionId, 'schematiq']);
+        queryClient.invalidateQueries(['data', sessionId]);
+      } else if (message.type === 'reextraction_failed') {
+        const data = message.data as { error?: string };
+        setActiveReextractionId(null);
+        setIsStopping(false);
+        setDeferredExtractError(data?.error || 'Extraction failed');
+        setSchemaOnly(true);
+        setProcessingState('completed');
+        setCurrentStepMessage('');
+        addLog('error', data?.error || 'Extraction failed');
+      } else if (message.type === 'reextraction_stopped') {
+        const data = message.data as { processed_documents?: number; total_documents?: number };
+        setActiveReextractionId(null);
+        setIsStopping(false);
+        setSchemaOnly(false);
+        setProcessingState('completed');
+        const processed = data?.processed_documents ?? 0;
+        setCurrentStepMessage(
+          processed > 0
+            ? `Extraction stopped (${processed} document(s) processed).`
+            : 'Extraction stopped.',
+        );
+        addLog('warning', 'Extraction stopped. Partial results may be available on the Data tab.');
+        queryClient.invalidateQueries(['schematiq-status', sessionId]);
+        queryClient.invalidateQueries(['session', sessionId, 'schematiq']);
+        queryClient.invalidateQueries(['data', sessionId]);
       } else if (message.type === 'stopped') {
         const stoppedData = message.data as StoppedData;
         const schemaSaved = stoppedData?.schema_saved || false;
@@ -437,6 +560,79 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({ sessionId, autoStar
     };
   }, [sessionId, queryClient]);
 
+  // Poll re-extraction status when WebSocket updates are missed
+  useEffect(() => {
+    if (!activeReextractionId) return;
+
+    let cancelled = false;
+
+    const applyTerminalStatus = (status: string, error?: string) => {
+      setActiveReextractionId(null);
+      setIsStopping(false);
+      if (status === 'completed') {
+        setSchemaOnly(false);
+        setProcessingState('completed');
+        setExtractionProgress(prev => ({
+          ...prev,
+          isComplete: true,
+          processedDocs: prev.totalDocs || prev.processedDocs,
+        }));
+        setCurrentStepMessage('Extraction complete.');
+        queryClient.invalidateQueries(['schematiq-status', sessionId]);
+        queryClient.invalidateQueries(['session', sessionId, 'schematiq']);
+        queryClient.invalidateQueries(['data', sessionId]);
+      } else if (status === 'stopped') {
+        setSchemaOnly(false);
+        setProcessingState('completed');
+        setCurrentStepMessage('Extraction stopped.');
+        queryClient.invalidateQueries(['schematiq-status', sessionId]);
+        queryClient.invalidateQueries(['session', sessionId, 'schematiq']);
+        queryClient.invalidateQueries(['data', sessionId]);
+      } else if (status === 'failed') {
+        setSchemaOnly(true);
+        setProcessingState('completed');
+        setDeferredExtractError(error || 'Extraction failed');
+        setCurrentStepMessage('');
+      }
+    };
+
+    const poll = async () => {
+      try {
+        const st = await schemaAPI.getReextractionStatus(sessionId, activeReextractionId);
+        if (cancelled) return;
+
+        if (st.total_documents > 0) {
+          setProcessingState('extraction');
+          const total = st.total_documents;
+          const processed = Math.min(st.processed_documents, total);
+          setExtractionProgress({
+            processedDocs: processed,
+            totalDocs: total,
+            isComplete: st.status === 'completed',
+          });
+          if (st.status === 'running' || st.status === 'starting') {
+            setCurrentStepMessage(
+              `Extracting values (${st.processed_documents}/${st.total_documents})...`,
+            );
+          }
+        }
+
+        if (st.status === 'completed' || st.status === 'failed' || st.status === 'stopped') {
+          applyTerminalStatus(st.status, st.error);
+        }
+      } catch {
+        // Operation may have been cleaned up after completion
+      }
+    };
+
+    poll();
+    const intervalId = setInterval(poll, 2500);
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [activeReextractionId, sessionId, queryClient]);
+
   // Auto-dismiss capacity message after 30 seconds
   useEffect(() => {
     if (!capacityMessage) return;
@@ -466,6 +662,90 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({ sessionId, autoStar
     const m = Math.floor(seconds / 60);
     const s = seconds % 60;
     return m > 0 ? `${m}m ${s}s` : `${s}s`;
+  };
+
+  const handleExtractTableData = async () => {
+    setIsDeferredExtracting(true);
+    setDeferredExtractError('');
+    try {
+      const session = await loadAPI.getSession(sessionId);
+      const columns = (session.columns || [])
+        .filter((c) => c.name && !c.name.toLowerCase().endsWith('_excerpt'))
+        .map((c) => c.name);
+      if (columns.length === 0) {
+        setDeferredExtractError('No schema columns found. Wait for schema discovery to finish or open the Schema tab.');
+        return;
+      }
+
+      const availability = await schemaAPI.precheckDocuments(sessionId, {
+        operation_type: 'reextraction',
+      });
+      if (!availability.can_proceed) {
+        setDeferredExtractError(
+          'No source documents found for this session. Your files should still be on the server from the initial upload — try refreshing, or add documents on the Data tab.',
+        );
+        return;
+      }
+
+      const cfg = await configAPI.getConfig().catch(() => ({ allow_llm_config: true }));
+      const configured = await getConfiguredProviders();
+      const available = getAvailableProviders(configured);
+      const provider: LLMProviderKey = !cfg.allow_llm_config ? 'gemini' : (available[0] ?? 'gemini');
+      const model = getDefaultModelForProvider(provider);
+      const apiKey = await getApiKeyForProvider(provider);
+
+      const request: ReextractionRequest = { columns };
+      if (apiKey) {
+        request.llm_config = { provider, model, api_key: apiKey, temperature: 0 };
+      }
+
+      const response = await schemaAPI.startReextraction(sessionId, request);
+      const docCount = response.rows_to_process || response.estimated_papers || 0;
+      if (docCount === 0) {
+        setDeferredExtractError(
+          'No source documents available to process. Upload documents on the Data tab and try again.',
+        );
+        return;
+      }
+
+      // Ensure progress WebSocket is connected before background work starts
+      if (!webSocketService.isConnected()) {
+        webSocketService.connect(sessionId, 'progress');
+      }
+
+      setSchemaOnly(false);
+      setActiveReextractionId(response.operation_id);
+      setProcessingState('extraction');
+      setCurrentStepMessage(`Extracting values from ${docCount} document(s)...`);
+      setExtractionProgress({
+        processedDocs: 0,
+        totalDocs: docCount,
+        isComplete: false,
+      });
+      if (onExtractionStarted) {
+        onExtractionStarted(response.columns, response.operation_id);
+      }
+      addLog(
+        'info',
+        `Extracting ${response.columns.length} column(s) across ${docCount} document(s). Open the Data tab for live rows.`,
+      );
+    } catch (err: unknown) {
+      const axiosErr = err as { response?: { data?: { detail?: string }; status?: number }; message?: string };
+      const detail = axiosErr.response?.data?.detail;
+      setDeferredExtractError(
+        axiosErr.response?.status === 503
+          ? (detail || 'Server is busy. Try again in a few minutes.')
+          : (detail || axiosErr.message || 'Failed to start extraction'),
+      );
+      addLog(
+        'error',
+        axiosErr.response?.status === 503
+          ? (detail || 'Server is busy')
+          : (detail || axiosErr.message || 'Failed to start extraction'),
+      );
+    } finally {
+      setIsDeferredExtracting(false);
+    }
   };
 
   const handleStart = async () => {
@@ -528,13 +808,19 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({ sessionId, autoStar
   const handleStop = async () => {
     setIsStopping(true);
     try {
-      await schematiqAPI.stop(sessionId);
-      // API returned — stop flag is set. Transition immediately.
-      setProcessingState('stopped');
-      setIsStopping(false);
-      addLog('warning', 'Stop requested — processing will stop at the next checkpoint.');
+      if (activeReextractionId) {
+        await schemaAPI.stopReextraction(sessionId, activeReextractionId);
+        addLog('warning', 'Stop requested — extraction will stop at the next checkpoint.');
+        // UI updates on reextraction_stopped WebSocket (or status poll fallback)
+      } else {
+        await schematiqAPI.stop(sessionId);
+        setProcessingState('stopped');
+        setIsStopping(false);
+        addLog('warning', 'Stop requested — processing will stop at the next checkpoint.');
+      }
     } catch (error: any) {
-      addLog('error', `Failed to stop ScheMatiQ: ${error.message}`);
+      const detail = error?.response?.data?.detail;
+      addLog('error', detail || error.message || 'Failed to stop');
       setIsStopping(false);
     }
   };
@@ -713,11 +999,15 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({ sessionId, autoStar
               <div className="w-14 h-14 rounded-full bg-green-100 flex items-center justify-center mb-4">
                 <CheckCircle2 className="h-8 w-8 text-green-600" />
               </div>
-              <p className="text-xl font-semibold text-green-600 mb-1">Completed Successfully!</p>
+              <p className="text-xl font-semibold text-green-600 mb-1">
+                {schemaOnly ? 'Schema Discovery Complete' : 'Completed Successfully!'}
+              </p>
               <p className="text-muted-foreground text-center max-w-md">
-                {schemaProgress.columnsDiscovered > 0 && extractionProgress.totalDocs > 0
-                  ? `Discovered ${schemaProgress.columnsDiscovered} columns from ${extractionProgress.totalDocs} documents`
-                  : 'Schema discovery and value extraction finished'}
+                {schemaOnly
+                  ? `Discovered ${schemaProgress.columnsDiscovered || status?.columns_discovered || 0} columns. Value extraction was skipped — extract your table below when ready.`
+                  : schemaProgress.columnsDiscovered > 0 && extractionProgress.totalDocs > 0
+                    ? `Discovered ${schemaProgress.columnsDiscovered} columns from ${extractionProgress.totalDocs} documents`
+                    : 'Schema discovery and value extraction finished'}
               </p>
             </>
           )}
@@ -940,6 +1230,51 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({ sessionId, autoStar
         </Card>
       )}
 
+      {/* Deferred extraction (schema-only mode) */}
+      {schemaOnly && processingState === 'completed' && (
+        <Card className="border-2 border-primary/20 bg-primary/5">
+          <CardContent className="pt-5 pb-5">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+              <div className="flex items-start gap-3 flex-1 min-w-0">
+                <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+                  <Table className="h-5 w-5 text-primary" />
+                </div>
+                <div className="min-w-0">
+                  <p className="font-semibold text-foreground">Extract table data</p>
+                  <p className="text-sm text-muted-foreground mt-0.5">
+                    Your documents are already uploaded for this session. Run value extraction to fill the table using the discovered schema — no need to start over.
+                  </p>
+                </div>
+              </div>
+              <Button
+                size="lg"
+                className="shrink-0 w-full sm:w-auto"
+                onClick={handleExtractTableData}
+                disabled={isDeferredExtracting}
+              >
+                {isDeferredExtracting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Starting...
+                  </>
+                ) : (
+                  <>
+                    <RefreshCw className="h-4 w-4 mr-2" />
+                    Extract Table Data
+                  </>
+                )}
+              </Button>
+            </div>
+            {deferredExtractError && (
+              <Alert variant="destructive" className="mt-4">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{deferredExtractError}</AlertDescription>
+              </Alert>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
       {/* Phase Progress Cards - Side by Side */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {/* Phase 1: Schema Discovery */}
@@ -988,7 +1323,11 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({ sessionId, autoStar
 
         {/* Phase 2: Value Extraction */}
         {(() => {
-          const extractionIsComplete = !schemaOnly && (extractionProgress.isComplete || processingState === 'completed');
+          const extractionIsComplete =
+            extractionProgress.isComplete ||
+            (!schemaOnly &&
+              extractionProgress.totalDocs > 0 &&
+              extractionProgress.processedDocs >= extractionProgress.totalDocs);
           return (
             <Card className={`transition-all ${!schemaOnly && processingState === 'extraction' ? 'border-primary border-2 shadow-md' : ''} ${schemaOnly ? 'opacity-60' : ''}`}>
               <CardContent className="pt-4 pb-4">

--- a/frontend/src/components/SchemaEditor/ReextractionDialog.tsx
+++ b/frontend/src/components/SchemaEditor/ReextractionDialog.tsx
@@ -257,8 +257,9 @@ const ReextractionDialog: React.FC<ReextractionDialogProps> = ({
       }
 
       const response = await schemaAPI.startReextraction(sessionId, request);
+      const docCount = response.rows_to_process || response.estimated_papers || 0;
 
-      if (response.rows_to_process === 0) {
+      if (docCount === 0) {
         // No documents available — extraction will complete instantly
         onSuccess(
           `No source documents available to process. Upload the missing documents and try again.`,
@@ -275,7 +276,6 @@ const ReextractionDialog: React.FC<ReextractionDialogProps> = ({
 
       // Show success message and close dialog immediately so user can see the table
       const columnCount = response.columns.length;
-      const docCount = response.rows_to_process;
       onSuccess(
         `Re-extraction started for ${columnCount} column${columnCount !== 1 ? 's' : ''} across ${docCount} documents. View the Data tab for live progress.`,
         false // Don't refresh data yet - WebSocket will handle updates

--- a/frontend/src/components/SchemaViewer/SchemaViewer.tsx
+++ b/frontend/src/components/SchemaViewer/SchemaViewer.tsx
@@ -845,10 +845,11 @@ const SchemaViewer: React.FC<SchemaViewerProps> = ({
         request.llm_config = { provider, model, api_key: apiKey, temperature: 0 };
       }
       const response = await schemaAPI.startReextraction(sessionId, request);
-      if (response.rows_to_process === 0) {
+      const docCount = response.rows_to_process || response.estimated_papers || 0;
+      if (docCount === 0) {
         toast({
           title: 'No documents',
-          description: 'No source documents available to process. Upload documents and try again.',
+          description: 'No source documents available to process. Upload documents on the Data tab and try again.',
           variant: 'destructive',
         });
         return;

--- a/frontend/src/pages/Visualize.tsx
+++ b/frontend/src/pages/Visualize.tsx
@@ -1715,6 +1715,7 @@ const Visualize = () => {
               sessionId={sessionId}
               autoStarted={autoStartState.autoStarted}
               initialCapacityMessage={autoStartState.initialCapacityMessage}
+              onExtractionStarted={handleReextractionStarted}
             />
           </TabsContent>
         )}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -343,11 +343,11 @@ export interface ObservationUnitReadyData {
 }
 
 export interface WebSocketMessage {
-  type: 'progress' | 'log' | 'error' | 'completed' | 'connected' | 'disconnected' | 'reconnecting' | 'pong' | 'heartbeat' | 'schema_completed' | 'schema_progress' | 'row_completed' | 'schema_updated' | 'reprocessing_progress' | 'reprocessing_completed' | 'cell_extracted' | 'stopped' | 'continue_discovery_progress' | 'continue_discovery_completed' | 'continue_discovery_stopped' | 'incremental_extraction_progress' | 'quota_exceeded' | 'observation_unit_ready';
+  type: 'progress' | 'log' | 'error' | 'completed' | 'connected' | 'disconnected' | 'reconnecting' | 'pong' | 'heartbeat' | 'schema_completed' | 'schema_progress' | 'row_completed' | 'schema_updated' | 'reprocessing_progress' | 'reprocessing_completed' | 'reextraction_started' | 'reextraction_progress' | 'reextraction_completed' | 'reextraction_failed' | 'reextraction_stopped' | 'document_started' | 'cell_extracted' | 'stopped' | 'continue_discovery_progress' | 'continue_discovery_completed' | 'continue_discovery_stopped' | 'incremental_extraction_progress' | 'quota_exceeded' | 'observation_unit_ready';
   timestamp?: string;
   session_id?: string;
   message?: string;
-  data?: ProgressData | LogData | ErrorData | CompletionData | SchemaCompletionData | RowCompletionData | SchemaUpdatedData | ReprocessingProgressData | ReprocessingCompletedData | CellExtractedData | StoppedData | ObservationUnitReadyData;
+  data?: ProgressData | LogData | ErrorData | CompletionData | SchemaCompletionData | RowCompletionData | SchemaUpdatedData | ReprocessingProgressData | ReprocessingCompletedData | ReextractionStartedData | ReextractionProgressData | ReextractionCompletedData | ReextractionFailedData | CellExtractedData | StoppedData | ObservationUnitReadyData;
 }
 
 // Schema types
@@ -710,6 +710,7 @@ export interface ReextractionProgressData {
   progress: number;
   processed_documents: number;
   total_documents: number;
+  processed_cells?: number;
   current_row?: string;
 }
 


### PR DESCRIPTION
## Summary
- Lets users who ran with **Discover columns only** extract table data on the same session without re-uploading documents, via a new **Extract Table Data** action on the ScheMatiQ Monitor.
- Fixes re-extraction document discovery when the table has no rows yet (schema-only sessions still find on-disk uploads).
- Persists first-time extraction to `extracted_data.jsonl` instead of no-op merge when no data file exists.
- Corrects progress UI (document counts vs cell counts) and keeps Phase 2 from showing **Skipped** after extraction completes.
- Wires Monitor **Stop** to re-extraction stop and adds re-extraction WebSocket event types.

## Test plan
- [ ] Start ScheMatiQ with **Discover columns only** checked and uploaded DOCX/PDF files; confirm schema completes with empty Data tab.
- [ ] On Monitor, click **Extract Table Data**; confirm progress shows `document N/M` (not cells/M), Phase 2 ends **Complete**, and Data tab fills.
- [ ] Click **Stop** mid-extraction; confirm extraction stops and partial rows may appear.
- [ ] Refresh page after extraction; confirm Phase 2 stays **Complete** and data persists.
- [ ] Verify README lists TXT, MD, PDF, DOC, DOCX, RTF upload formats.


Made with [Cursor](https://cursor.com)