### PR TITLE
Suppress SentenceTransformer embeddings.position_ids load report

### DIFF
--- a/schematiq-lib/schematiq/core/embedding_model.py
+++ b/schematiq-lib/schematiq/core/embedding_model.py
@@ -1,0 +1,41 @@
+"""Load SentenceTransformer models without noisy HuggingFace state-dict load reports."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sentence_transformers import SentenceTransformer
+
+
+@contextmanager
+def _suppress_transformers_load_noise():
+    """Silence harmless HF load reports (e.g. embeddings.position_ids UNEXPECTED)."""
+    try:
+        from transformers.utils import logging as hf_logging
+    except ImportError:
+        yield
+        return
+
+    prev_verbosity = hf_logging.get_verbosity()
+    hf_logging.set_verbosity_error()
+    transformers_logger = logging.getLogger("transformers")
+    prev_level = transformers_logger.level
+    transformers_logger.setLevel(logging.ERROR)
+    try:
+        yield
+    finally:
+        hf_logging.set_verbosity(prev_verbosity)
+        transformers_logger.setLevel(prev_level)
+
+
+def load_sentence_transformer(
+    model_name: str = "all-MiniLM-L6-v2", **kwargs: Any
+) -> SentenceTransformer:
+    """Load a SentenceTransformer, suppressing known-harmless HF checkpoint warnings."""
+    from sentence_transformers import SentenceTransformer
+
+    with _suppress_transformers_load_noise():
+        return SentenceTransformer(model_name, **kwargs)

--- a/schematiq-lib/schematiq/core/retrievers.py
+++ b/schematiq-lib/schematiq/core/retrievers.py
@@ -279,7 +279,9 @@ class EmbeddingRetriever(Retriever):
             self.batch_size = 2
 
         else:
-            self.model = SentenceTransformer(model_name, device=device)
+            from schematiq.core.embedding_model import load_sentence_transformer
+
+            self.model = load_sentence_transformer(model_name, device=device)
         self.max_words = max_words
         self.max_words_chunk = max(int(max_words / self.k), 128)
 

--- a/schematiq-lib/schematiq/core/schema.py
+++ b/schematiq-lib/schematiq/core/schema.py
@@ -3,12 +3,14 @@ from dataclasses import dataclass, field
 from typing import List, Dict, Optional, Any
 import json
 
-from sentence_transformers import SentenceTransformer, util
+from sentence_transformers import util
+
+from schematiq.core.embedding_model import load_sentence_transformer
 
 # -------------------------------------------------------------------- #
 # Globals                                                              #
 # -------------------------------------------------------------------- #
-EMB_MODEL = SentenceTransformer("all-MiniLM-L6-v2")
+EMB_MODEL = load_sentence_transformer("all-MiniLM-L6-v2")
 SIM_THRESHOLD = 0.9            # paraphrase deduplication
 MAX_KEYS_DEFAULT = None         # unlimited unless specified
 

--- a/schematiq-lib/schematiq/evaluation/data_quality_evaluation.py
+++ b/schematiq-lib/schematiq/evaluation/data_quality_evaluation.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple, Any, Optional, Set
 import argparse
 from dataclasses import dataclass
-from sentence_transformers import SentenceTransformer
+from schematiq.core.embedding_model import load_sentence_transformer
 import torch
 import re
 
@@ -218,7 +218,7 @@ class FieldAligner:
     """Handles alignment between GT and prediction field names."""
 
     def __init__(self):
-        self.sentence_model = SentenceTransformer('all-MiniLM-L6-v2')
+        self.sentence_model = load_sentence_transformer('all-MiniLM-L6-v2')
         self.similarity_threshold = 0.6
 
     def align_fields(self, gt_columns: List[str], pred_columns: List[str]) -> List[FieldAlignment]:
@@ -472,7 +472,7 @@ class ValueEvaluator:
     """Evaluates similarity between GT and prediction values."""
 
     def __init__(self, use_llm_judge: bool = False, llm_model: str = ModelNames.DEFAULT_EVALUATION):
-        self.sentence_model = SentenceTransformer('all-MiniLM-L6-v2')
+        self.sentence_model = load_sentence_transformer('all-MiniLM-L6-v2')
         self.use_llm_judge = use_llm_judge
         self.llm_judge = None
 

--- a/schematiq-lib/schematiq/evaluation/metrics_utils.py
+++ b/schematiq-lib/schematiq/evaluation/metrics_utils.py
@@ -17,7 +17,9 @@ from nltk import word_tokenize
 from nltk.corpus import stopwords
 from nltk.stem import PorterStemmer
 from openai import OpenAI
-from sentence_transformers import SentenceTransformer, util
+from sentence_transformers import util
+
+from schematiq.core.embedding_model import load_sentence_transformer
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from table import Table
@@ -405,7 +407,7 @@ class SentenceTransformerAlignmentScorer(BaseAlignmentScorer):
         """We can choose which sentence transformer model to use while initializing."""
         super().__init__("sentence_transformer")
         self.metadata["model"] = model
-        self.model = SentenceTransformer(model)
+        self.model = load_sentence_transformer(model)
 
     # For better efficiency, the pair similarity calculation function takes batches of strings
     def calculate_pair_similarity(self, predictions: list[str], targets: list[str]) -> float:


### PR DESCRIPTION
## Summary

- Adds `load_sentence_transformer()` in `schematiq/core/embedding_model.py` that temporarily sets HuggingFace Transformers logging to ERROR during model load.
- Routes all `all-MiniLM-L6-v2` loads through this helper (schema globals, `EmbeddingRetriever`, evaluation utilities).

This suppresses the harmless `embeddings.position_ids | UNEXPECTED` BertModel LOAD REPORT printed on startup when newer Transformers loads older SentenceTransformer checkpoints.

Closes #138

## Test plan

- [ ] Start backend locally and confirm the BertModel LOAD REPORT no longer appears when the embedding retriever initializes.
- [ ] Run a short ScheMatiQ session to confirm embedding retrieval still works.

Made with [Cursor](https://cursor.com)