### PR TITLE
feat(debug): extend SCHEMATIQ_DEBUG_DIR to all discovery stages

### DIFF
--- a/schematiq-lib/schematiq/core/llm_debug.py
+++ b/schematiq-lib/schematiq/core/llm_debug.py
@@ -1,0 +1,102 @@
+"""Persist raw LLM responses when SCHEMATIQ_DEBUG_DIR is set.
+
+Set SCHEMATIQ_DEBUG_DIR to a directory path to enable (zero cost when unset).
+Optional SCHEMATIQ_DEBUG_INCLUDE_INPUT=1 saves full prompt messages alongside metadata.
+
+Each call writes:
+  <slug>__<stage>__<label>__batch<n>__<timestamp_ms>.response.txt  (full raw output)
+  <slug>__<stage>__<label>__batch<n>__<timestamp_ms>.meta.json     (stage, label, parsed summary, extra)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_DEBUG_DIR: Optional[Path] = None
+_INCLUDE_INPUT = False
+
+_debug_env = os.environ.get("SCHEMATIQ_DEBUG_DIR")
+if _debug_env:
+    _DEBUG_DIR = Path(_debug_env)
+    _DEBUG_DIR.mkdir(parents=True, exist_ok=True)
+    _INCLUDE_INPUT = os.environ.get("SCHEMATIQ_DEBUG_INCLUDE_INPUT", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    logging.info("Debug dump enabled -> %s", _DEBUG_DIR)
+
+
+def is_enabled() -> bool:
+    return _DEBUG_DIR is not None
+
+
+def _safe_slug(text: str, max_len: int = 60) -> str:
+    slug = "".join(c if c.isalnum() or c in "-_ " else "_" for c in (text or ""))
+    return (slug[:max_len].strip() or "unknown")
+
+
+def dump_llm_call(
+    stage: str,
+    *,
+    label: str = "",
+    raw_response: Optional[str] = None,
+    parsed: Optional[Any] = None,
+    extra: Optional[Dict[str, Any]] = None,
+    prompt_messages: Optional[List[Dict[str, str]]] = None,
+    batch_idx: int = 0,
+) -> None:
+    """Write raw LLM output and metadata to SCHEMATIQ_DEBUG_DIR. No-op when disabled."""
+    if _DEBUG_DIR is None:
+        return
+
+    slug = _safe_slug(label or stage)
+    stage_part = _safe_slug(stage, max_len=40)
+    label_part = _safe_slug(label, max_len=40) if label else ""
+    ts = int(time.time() * 1000)
+    parts = [slug, stage_part]
+    if label_part and label_part != slug:
+        parts.append(label_part)
+    parts.extend([f"batch{batch_idx}", str(ts)])
+    stem = "__".join(parts)
+
+    meta: Dict[str, Any] = {
+        "stage": stage,
+        "label": label or None,
+        "batch_idx": batch_idx,
+        "timestamp_ms": ts,
+        "raw_response_len": len(raw_response) if raw_response else 0,
+    }
+    if parsed is not None:
+        meta["parsed"] = parsed
+    if extra:
+        meta.update(extra)
+    if _INCLUDE_INPUT and prompt_messages:
+        meta["prompt_messages"] = prompt_messages
+    elif prompt_messages:
+        meta["prompt_user_len"] = sum(
+            len(m.get("content", "")) for m in prompt_messages if m.get("role") == "user"
+        )
+        system_msgs = [m for m in prompt_messages if m.get("role") == "system"]
+        if system_msgs:
+            content = system_msgs[0].get("content", "")
+            meta["prompt_system_prefix"] = content[:500] + ("..." if len(content) > 500 else "")
+
+    try:
+        if raw_response is not None:
+            (_DEBUG_DIR / f"{stem}.response.txt").write_text(
+                raw_response, encoding="utf-8", errors="replace"
+            )
+        (_DEBUG_DIR / f"{stem}.meta.json").write_text(
+            json.dumps(meta, ensure_ascii=False, indent=2, default=str),
+            encoding="utf-8",
+        )
+    except Exception as e:
+        logger.warning("Debug dump failed for %s: %s", stem, e)

--- a/schematiq-lib/schematiq/core/schematiq.py
+++ b/schematiq-lib/schematiq/core/schematiq.py
@@ -30,6 +30,7 @@ import random
 from pathlib import Path
 from schematiq.core.schema import Schema, Column, SchemaEvolution, ObservationUnit
 from schematiq.core.llm_call_tracker import LLMCallTracker
+from schematiq.core.llm_debug import dump_llm_call
 from schematiq.core.prompts import (
     get_prompts, get_observation_unit_prompts, SchemaMode, DRAFT_SCHEMA_TMPL,
     SYSTEM_PROMPT_OBSERVATION_UNIT, USER_PROMPT_TMPL_OBSERVATION_UNIT,
@@ -387,7 +388,30 @@ def _discover_observation_unit(
             generate_kwargs["thinking_budget"] = 1024
             generate_kwargs["response_schema"] = OBSERVATION_UNIT_RESPONSE_SCHEMA
         llm_response = llm.generate(trimmed, **generate_kwargs)
-        observation_unit = _parse_observation_unit_from_llm(llm_response)
+        try:
+            observation_unit = _parse_observation_unit_from_llm(llm_response)
+            dump_llm_call(
+                "observation_unit_discovery",
+                label=source_document or mode.value,
+                raw_response=llm_response,
+                parsed={
+                    "name": observation_unit.name,
+                    "definition": observation_unit.definition,
+                    "example_names": observation_unit.example_names,
+                },
+                prompt_messages=trimmed,
+                extra={"mode": mode.value},
+            )
+        except ObservationUnitDiscoveryError:
+            dump_llm_call(
+                "observation_unit_discovery",
+                label=source_document or mode.value,
+                raw_response=llm_response,
+                parsed={"parse_error": True},
+                prompt_messages=trimmed,
+                extra={"mode": mode.value},
+            )
+            raise
 
         # Add source tracking
         if source_document:
@@ -517,6 +541,26 @@ def generate_schema(
     # For query-only mode, document_helpful doesn't apply
     schema, document_helpful, suggested_value_additions = _parse_schema_from_llm(
         llm_response, query=query or "", max_keys_schema=max_keys_schema
+    )
+    dump_llm_call(
+        "schema_discovery",
+        label=mode.value,
+        raw_response=llm_response,
+        parsed={
+            "document_helpful": document_helpful,
+            "column_count": len(schema.columns),
+            "columns": [
+                {
+                    "name": c.name,
+                    "definition": c.definition,
+                    "has_rationale": bool(c.rationale),
+                }
+                for c in schema.columns
+            ],
+            "suggested_value_additions_count": len(suggested_value_additions),
+        },
+        prompt_messages=trimmed,
+        extra={"mode": mode.value},
     )
 
     # In QUERY_ONLY mode, there are no documents to assess helpfulness

--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -1,11 +1,7 @@
 """Paper processing for value extraction."""
 from __future__ import annotations
 
-import json
 import logging
-import os
-import time
-from pathlib import Path
 from typing import Dict, Any, Set, Callable, Optional, List, Iterator, Tuple
 
 logger = logging.getLogger(__name__)
@@ -18,14 +14,7 @@ from schematiq.core.llm_backends import LLMInterface
 from sentence_transformers import util as st_util
 from schematiq.core.llm_call_tracker import LLMCallTracker
 from schematiq.core import utils
-
-# Set SCHEMATIQ_DEBUG_DIR to a directory path to save LLM inputs/outputs per pass.
-_DEBUG_DIR: Optional[Path] = None
-_debug_env = os.environ.get("SCHEMATIQ_DEBUG_DIR")
-if _debug_env:
-    _DEBUG_DIR = Path(_debug_env)
-    _DEBUG_DIR.mkdir(parents=True, exist_ok=True)
-    logging.info("Debug dump enabled -> %s", _DEBUG_DIR)
+from schematiq.core.llm_debug import dump_llm_call
 
 from .llm_cache import LLMCache
 from .json_parser import JSONResponseParser
@@ -128,7 +117,7 @@ class PaperProcessor:
         return flat
 
     @staticmethod
-    def _debug_dump(
+    def _dump_extraction_call(
         pass_name: str,
         paper_title: str,
         batch_idx: int,
@@ -139,37 +128,25 @@ class PaperProcessor:
         cleaned: Dict[str, Any],
         already_extracted: Dict[str, str] | None = None,
     ) -> None:
-        """Save a debug snapshot of one LLM call to SCHEMATIQ_DEBUG_DIR.
-
-        Set the SCHEMATIQ_DEBUG_DIR environment variable to a directory path
-        to enable. Each call writes a JSON file named:
-          <title>__<pass>__batch<n>__<timestamp_ms>.json
-        No-op when the env var is not set.
-        """
-        if _DEBUG_DIR is None:
-            return
-        safe_title = "".join(c if c.isalnum() or c in "-_ " else "_" for c in paper_title)[:60]
-        ts = int(time.time() * 1000)
-        fname = f"{safe_title}__{pass_name}__batch{batch_idx}__{ts}.json"
-        payload = {
+        extra = {
             "pass": pass_name,
             "paper_title": paper_title,
-            "batch_idx": batch_idx,
             "columns_requested": columns_requested,
             "columns_filled": list(cleaned.keys()),
             "columns_missing": [c for c in columns_requested if c not in cleaned],
-            "prompt_system": prompt_msgs[0]["content"][:500] + "..." if prompt_msgs else None,
-            "prompt_user_len": len(prompt_msgs[1]["content"]) if len(prompt_msgs) > 1 else 0,
-            "raw_response": raw_response[:5000] if raw_response else None,
             "parsed": {k: v for k, v in (parsed or {}).items()},
             "cleaned": {k: v for k, v in (cleaned or {}).items()},
         }
         if already_extracted:
-            payload["already_extracted_context"] = already_extracted
-        try:
-            (_DEBUG_DIR / fname).write_text(json.dumps(payload, ensure_ascii=False, indent=2, default=str))
-        except Exception as e:
-            logging.warning("Debug dump failed: %s", e)
+            extra["already_extracted_context"] = already_extracted
+        dump_llm_call(
+            pass_name,
+            label=paper_title,
+            raw_response=raw_response,
+            prompt_messages=prompt_msgs,
+            batch_idx=batch_idx,
+            extra=extra,
+        )
 
     def _check_stop_requested(self) -> bool:
         """Check if stop was requested. Returns True if should stop."""
@@ -583,7 +560,7 @@ class PaperProcessor:
             # Track unmatched values for schema evolution
             self._track_unmatched_values(unmatched, paper_title)
 
-            self._debug_dump(
+            self._dump_extraction_call(
                 pass_name="pass3_batch_fallback",
                 paper_title=paper_title,
                 batch_idx=0,
@@ -708,7 +685,7 @@ class PaperProcessor:
                         cleaned_re, paper_title
                     )
 
-                    self._debug_dump(
+                    self._dump_extraction_call(
                         pass_name="pass2_reordered",
                         paper_title=paper_title,
                         batch_idx=p2_batch_idx,
@@ -1037,7 +1014,7 @@ class PaperProcessor:
                     batch_cleaned, paper_title
                 )
 
-                self._debug_dump(
+                self._dump_extraction_call(
                     pass_name="pass1_paper",
                     paper_title=paper_title,
                     batch_idx=batch_idx,
@@ -1376,6 +1353,22 @@ class PaperProcessor:
         # Parse using dedicated unit parser
         result = self.unit_parser.parse_response(raw_response)
 
+        dump_llm_call(
+            "unit_identification",
+            label=paper_title,
+            raw_response=raw_response,
+            parsed={
+                "success": result.success,
+                "detected_format": result.detected_format,
+                "unit_count": len(result.units) if result.units else 0,
+                "unit_names": [u.get("unit_name", "?") for u in (result.units or [])],
+                "error": result.error,
+                "notes": result.notes,
+            },
+            prompt_messages=trimmed,
+            extra={"is_retry": is_retry},
+        )
+
         # Log parse result for diagnostics
         if result.success:
             unit_names = (
@@ -1651,7 +1644,7 @@ class PaperProcessor:
                 self._track_unmatched_values(unmatched, paper_title)
                 cleaned = self._attach_source_to_excerpts(cleaned, paper_title)
 
-                self._debug_dump(
+                self._dump_extraction_call(
                     pass_name="pass1_unit",
                     paper_title=f"{paper_title} - {unit_name}",
                     batch_idx=batch_idx,


### PR DESCRIPTION
## Summary

- Adds centralized `schematiq/core/llm_debug.py` for env-gated LLM response persistence (`SCHEMATIQ_DEBUG_DIR`).
- Writes full raw output to `*.response.txt` (no truncation) and metadata to `*.meta.json`.
- Instruments **observation unit discovery**, **schema discovery**, **unit identification**, and **value extraction** (refactors existing `PaperProcessor` dumps to use the shared helper).
- Optional `SCHEMATIQ_DEBUG_INCLUDE_INPUT=1` saves full prompt messages; default is output-only with prompt length/prefix hints.

## Usage

```bash
export SCHEMATIQ_DEBUG_DIR=/tmp/schematiq-debug
# optional: export SCHEMATIQ_DEBUG_INCLUDE_INPUT=1
cd backend && uvicorn app.main:app --reload --port 8000
```

Compare `*.response.txt` files between a failing first pass and a succeeding re-upload for the same document.

## Test plan

- [ ] Set `SCHEMATIQ_DEBUG_DIR`, run a short schema discovery session, confirm `observation_unit_discovery` and `schema_discovery` files appear.
- [ ] Run value extraction on one document, confirm `unit_identification` and `pass1_paper` dumps.
- [ ] Verify backend starts cleanly with env var unset (no-op).


Made with [Cursor](https://cursor.com)