### PR TITLE
Fix Pydantic schema field shadowing BaseModel (#135)

### DIFF
--- a/backend/app/models/upload.py
+++ b/backend/app/models/upload.py
@@ -48,21 +48,27 @@ class LLMBackendConfig(BaseModel):
 
 class ScheMatiQSchemaFormat(BaseModel):
     """ScheMatiQ schema file format."""
+
+    model_config = {"populate_by_name": True, "serialize_by_alias": True}
+
     query: Optional[str] = None
     docs_path: Optional[str] = None
     backend: Optional[Dict[str, Any]] = None  # Legacy single backend support
     retriever: Optional[Dict[str, Any]] = None
-    schema: List[SchemaColumn]
+    columns: List[SchemaColumn] = Field(..., alias="schema")
     llm_configuration: Optional[Dict[str, Any]] = None  # New dual LLM config
 
 class SchemaValidationResult(BaseModel):
     """Result of schema file validation."""
+
+    model_config = {"populate_by_name": True, "serialize_by_alias": True}
+
     is_valid: bool
     errors: List[str] = []
     warnings: List[str] = []
     detected_columns: List[str] = []
     query: Optional[str] = None
-    schema: Optional[List[SchemaColumn]] = None
+    columns: Optional[List[SchemaColumn]] = Field(default=None, alias="schema")
 
 class CompatibilityCheck(BaseModel):
     """Result of schema-data compatibility check."""

--- a/backend/app/services/file_parser.py
+++ b/backend/app/services/file_parser.py
@@ -1255,7 +1255,7 @@ class FileParser:
             return CompatibilityCheck(
                 is_compatible=False,
                 detailed_errors=["Cannot check compatibility: schema or data validation failed"],
-                schema_count=len(schema_validation.detected_columns) if schema_validation.schema else 0,
+                schema_count=len(schema_validation.detected_columns) if schema_validation.columns else 0,
                 data_count=len(data_columns)
             )
         
@@ -1358,10 +1358,10 @@ class FileParser:
             await f.write(content)
         
         # Save parsed schema for easy access
-        if validation.schema:
+        if validation.columns:
             parsed_schema = {
                 "query": validation.query,
-                "schema": [col.model_dump() for col in validation.schema]
+                "schema": [col.model_dump() for col in validation.columns]
             }
             
             # Include LLM configuration if available


### PR DESCRIPTION
## Summary

Fixes [#135](https://github.com/shaharl6000/ScheMatiQ/issues/135) by renaming the Python attribute `schema` to `columns` on `ScheMatiQSchemaFormat` and `SchemaValidationResult`, while keeping the serialized JSON key as `schema` via Pydantic field aliases.

- Eliminates startup `UserWarning` about shadowing `BaseModel.schema`
- Preserves API/JSON compatibility (`model_dump()` still emits `"schema"`)
- Updates internal references in `file_parser.py` to use `.columns`

## Test plan

- [x] `python -W default` import test: models instantiate without warnings; alias round-trip works
- [x] Start backend and confirm no Pydantic shadow warnings in logs
- [x] Upload a schema JSON file via load flow and verify validation/upload still works


Made with [Cursor](https://cursor.com)