### PR TITLE
Disable unused Gemini AFC (Automatic Function Calling)

### DIFF
--- a/schematiq-lib/schematiq/core/llm_backends.py
+++ b/schematiq-lib/schematiq/core/llm_backends.py
@@ -559,6 +559,11 @@ class GeminiLLM(LLMInterface):
             ),
         ]
 
+        # ScheMatiQ uses plain text generation only — disable SDK default AFC.
+        self._disable_automatic_function_calling = (
+            types.AutomaticFunctionCallingConfig(disable=True)
+        )
+
     def _validate_api_key(self, key: str, key_source: str = "unknown") -> bool:
         """Validate that an API key doesn't have invalid characters.
 
@@ -640,6 +645,7 @@ class GeminiLLM(LLMInterface):
             "max_output_tokens": kwargs.get("max_output_tokens", self.max_output_tokens),
             "temperature": kwargs.get("temperature", self.temperature),
             "safety_settings": self.safety_settings,
+            "automatic_function_calling": self._disable_automatic_function_calling,
         }
         # Add system instruction
         if system_instruction:
@@ -836,6 +842,7 @@ class GeminiLLM(LLMInterface):
             "max_output_tokens": kwargs.get("max_output_tokens", self.max_output_tokens),
             "temperature": kwargs.get("temperature", self.temperature),
             "safety_settings": self.safety_settings,
+            "automatic_function_calling": self._disable_automatic_function_calling,
             "cached_content": cache.name,
         }
         if kwargs.get("response_schema") is not None:


### PR DESCRIPTION
## Summary

- Disables Google GenAI SDK automatic function calling (AFC) on all `GeminiLLM` `GenerateContentConfig` instances (`generate` and `generate_with_cache`).
- ScheMatiQ uses Gemini for plain text prompt → response only; AFC was enabled by default and produced noisy startup logs (`AFC is enabled with max remote calls: 10`).

Fixes #136

## Test plan

- [x] Verified `types.AutomaticFunctionCallingConfig(disable=True)` and `GenerateContentConfig` accept the field locally.
- [ ] With `GEMINI_API_KEY` set, start backend and confirm the `google_genai.models` AFC INFO log no longer appears on first Gemini call.


Made with [Cursor](https://cursor.com)