### PR TITLE
Use Gemini 3.5 Flash and 3.1 Flash Lite as defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,8 +108,8 @@ Release mode (default) restricts features for public use. Set `DEVELOPER_MODE=tr
 | Document limit           | 100                    | 10,000                  |
 | Bypass UI toggle         | Hidden                 | Visible                 |
 | LLM configuration        | Locked (Gemini only)   | User-configurable       |
-| Schema creation model    | gemini-2.5-flash       | User's choice           |
-| Value extraction model   | gemini-2.5-flash-lite  | User's choice           |
+| Schema creation model    | gemini-3.5-flash       | User's choice           |
+| Value extraction model   | gemini-3.1-flash-lite  | User's choice           |
 | Research data collection | Enabled (if configured)| Disabled                |
 
 All mode settings in `RELEASE_CONFIG` in `backend/app/core/config.py`. Frontend adapts via `/api/config`.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cd schematiq-lib && pip install -e .
 ```python
 from schematiq import GeminiLLM, EmbeddingRetriever, discover_observation_unit
 
-llm = GeminiLLM(model="gemini-2.5-flash")
+llm = GeminiLLM(model="gemini-3.5-flash")
 retriever = EmbeddingRetriever(k=8)
 documents = [open(f).read() for f in your_files]
 
@@ -165,8 +165,8 @@ Release mode (default) restricts features for public use. Set `DEVELOPER_MODE=tr
 |---------|-------------|----------------|
 | Document limit | 20 | 10,000 |
 | LLM configuration | Locked (Gemini only) | User-configurable |
-| Schema creation model | gemini-2.5-flash | User's choice |
-| Extraction model | gemini-2.5-flash-lite | User's choice |
+| Schema creation model | gemini-3.5-flash | User's choice |
+| Extraction model | gemini-3.1-flash-lite | User's choice |
 | Research data collection | Enabled (if configured) | Disabled |
 
 ### Deployment (Railway)

--- a/backend/app/models/schematiq.py
+++ b/backend/app/models/schematiq.py
@@ -10,7 +10,7 @@ class LLMConfig(BaseModel):
     from model specs when not provided. Explicit values override auto-detection.
     """
     provider: str  # "openai", "together", "gemini"
-    model: str = ""  # Empty string = use provider default (e.g., gemini-2.5-flash-lite for Gemini)
+    model: str = ""  # Empty string = use provider default (e.g., gemini-3.1-flash-lite for Gemini)
     max_output_tokens: Optional[int] = None  # Auto-detected from model specs if None
     temperature: float = 0
     context_window_size: Optional[int] = None  # Auto-detected from model specs if None

--- a/frontend/src/constants/llmModels.ts
+++ b/frontend/src/constants/llmModels.ts
@@ -70,7 +70,6 @@ export const LLM_MODELS: LLMModelDefinition[] = [
     description: 'Best price-performance ratio',
     cost: 'medium',
     speed: 'fast',
-    isDefault: true,
     contextWindow: 1000000,
   },
   {
@@ -101,6 +100,16 @@ export const LLM_MODELS: LLMModelDefinition[] = [
     contextWindow: 1000000,
   },
   {
+    id: 'gemini-3.5-flash',
+    provider: 'gemini',
+    label: 'Gemini 3.5 Flash',
+    description: 'Frontier intelligence for schema discovery and agentic tasks',
+    cost: 'medium',
+    speed: 'fast',
+    isDefault: true,
+    contextWindow: 1000000,
+  },
+  {
     id: 'gemini-3.1-pro-preview',
     provider: 'gemini',
     label: 'Gemini 3.1 Pro (Preview)',
@@ -114,8 +123,8 @@ export const LLM_MODELS: LLMModelDefinition[] = [
 ];
 
 // ── Default model constants ─────────────────────────────────────────
-export const DEFAULT_SCHEMA_MODEL = 'gemini-2.5-flash';
-export const DEFAULT_EXTRACTION_MODEL = 'gemini-2.5-flash-lite';
+export const DEFAULT_SCHEMA_MODEL = 'gemini-3.5-flash';
+export const DEFAULT_EXTRACTION_MODEL = 'gemini-3.1-flash-lite';
 export const DEFAULT_RELEASE_EXTRACTION_MODEL = 'gemini-3.1-flash-lite';
 
 // ============================================================================

--- a/schematiq-lib/schematiq/core/cost_estimator.py
+++ b/schematiq-lib/schematiq/core/cost_estimator.py
@@ -547,7 +547,7 @@ def estimate_schematiq_cost(
     schema_creation_model: str = ModelNames.DEFAULT_SCHEMA_CREATION,
     schema_creation_max_output_tokens: int = 8192,
     value_extraction_provider: str = "gemini",
-    value_extraction_model: str = ModelNames.DEFAULT_SCHEMA_CREATION,
+    value_extraction_model: str = ModelNames.DEFAULT_VALUE_EXTRACTION,
     value_extraction_max_output_tokens: int = 8192,
     initial_schema_columns: int = 0,
     estimated_columns: int = 10,

--- a/schematiq-lib/schematiq/core/llm_backends.py
+++ b/schematiq-lib/schematiq/core/llm_backends.py
@@ -473,7 +473,7 @@ class GeminiLLM(LLMInterface):
     This implementation uses the new google-genai package with client-based architecture.
 
     Usage:
-        llm = GeminiLLM()  # Uses gemini-2.5-flash-lite by default
+        llm = GeminiLLM()  # Uses gemini-3.1-flash-lite by default
         answer = llm.generate("What is the capital of France?")
 
     API Key Loading:

--- a/schematiq-lib/schematiq/core/model_specs.py
+++ b/schematiq-lib/schematiq/core/model_specs.py
@@ -32,6 +32,7 @@ class ModelNames:
     GEMINI_25_FLASH_LITE = "gemini-2.5-flash-lite"
     GEMINI_25_PRO = "gemini-2.5-pro"
     GEMINI_31_FLASH_LITE = "gemini-3.1-flash-lite"
+    GEMINI_35_FLASH = "gemini-3.5-flash"
     GEMINI_31_PRO_PREVIEW = "gemini-3.1-pro-preview"
     GEMINI_15_FLASH = "gemini-1.5-flash"
 
@@ -54,7 +55,7 @@ class ModelNames:
     TIKTOKEN_ENCODING_MODEL = "gpt-4o"
 
     # Role-based defaults
-    DEFAULT_SCHEMA_CREATION = GEMINI_25_FLASH
+    DEFAULT_SCHEMA_CREATION = GEMINI_35_FLASH
     DEFAULT_VALUE_EXTRACTION = GEMINI_31_FLASH_LITE
     DEFAULT_RELEASE_EXTRACTION = GEMINI_31_FLASH_LITE
     DEFAULT_EVALUATION = GEMINI_15_FLASH
@@ -70,6 +71,7 @@ MODEL_SPECS: Dict[str, Dict[str, ModelSpec]] = {
         ModelNames.GEMINI_25_FLASH_LITE: ModelSpec(1_048_576, 65_535, supports_thinking=True),
         ModelNames.GEMINI_25_PRO: ModelSpec(1_048_576, 65_535, supports_thinking=True),
         ModelNames.GEMINI_31_FLASH_LITE: ModelSpec(1_048_576, 65_536, supports_thinking=True),
+        ModelNames.GEMINI_35_FLASH: ModelSpec(1_048_576, 65_536, supports_thinking=True),
         ModelNames.GEMINI_31_PRO_PREVIEW: ModelSpec(1_000_000, 64_000, supports_thinking=True),
         "_default": ModelSpec(1_000_000, 32_000, supports_thinking=False),
     },

--- a/schematiq-lib/schematiq/core/pricing_config.json
+++ b/schematiq-lib/schematiq/core/pricing_config.json
@@ -45,10 +45,20 @@
           "output": 12.00,
           "context_window": 1048576
         },
+        "gemini-3.1-flash-lite": {
+          "input": 0.25,
+          "output": 1.50,
+          "context_window": 1048576
+        },
         "gemini-3.1-flash-lite-preview": {
           "input": 0.25,
           "output": 1.50,
           "context_window": 1000000
+        },
+        "gemini-3.5-flash": {
+          "input": 1.50,
+          "output": 9.00,
+          "context_window": 1048576
         },
         "gemini-3.1-pro-preview": {
           "input": 2.00,

--- a/schematiq-lib/schematiq/value_extraction/utils/schema_builder.py
+++ b/schematiq-lib/schematiq/value_extraction/utils/schema_builder.py
@@ -12,7 +12,7 @@ _SANITIZE_RE = re.compile(r"[^a-zA-Z0-9_]")
 # Gemini rejects response_schema with 400 INVALID_ARGUMENT when total schema
 # complexity is too high.  Each column is an OBJECT with 3 sub-fields (answer,
 # excerpts, suggested_for_allowed_values), so N columns ≈ 4N schema properties.
-# Empirically on gemini-3.1-flash-lite-preview the limit is ~48 columns with
+# Empirically on gemini-3.1-flash-lite the limit is ~48 columns with
 # typical property names; 40 provides a safe margin for longer names.
 # Callers (extract_values_for_unit, extract_values_for_paper) pre-batch columns
 # into chunks of this size so every call gets controlled generation.  The check


### PR DESCRIPTION
## Summary
- Set schema discovery defaults to `gemini-3.5-flash` (replacing `gemini-2.5-flash`).
- Set value extraction defaults to `gemini-3.1-flash-lite` for release and developer mode.
- Add model specs and pricing entries for both models; fix cost estimator to use the extraction default.

## Test plan
- [ ] Run a release-mode ScheMatiQ session and confirm schema calls use `gemini-3.5-flash` and extraction uses `gemini-3.1-flash-lite` in logs.
- [ ] Verify cost estimate endpoint returns non-zero pricing for both models.
- [ ] Smoke-test developer-mode LLM selector shows the new defaults.


Made with [Cursor](https://cursor.com)