### PR TITLE
feat: allow JSON files as document uploads

### DIFF
--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -877,7 +877,7 @@ async def add_documents(session_id: str, files: List[UploadFile] = File(...), by
             total_size += file.size
             
             # Validate file type (text files, PDFs, docs, etc.)
-            allowed_extensions = {'.txt', '.md', '.pdf', '.doc', '.docx', '.rtf'}
+            allowed_extensions = {'.txt', '.md', '.pdf', '.doc', '.docx', '.rtf', '.json'}
             file_ext = Path(file.filename).suffix.lower()
             
             if file_ext not in allowed_extensions:

--- a/backend/app/services/document_preprocessor.py
+++ b/backend/app/services/document_preprocessor.py
@@ -16,7 +16,7 @@ from app.services.document_conversion.convert_to_txt import (
 
 logger = logging.getLogger(__name__)
 
-PLAIN_EXTENSIONS = {".txt", ".md"}
+PLAIN_EXTENSIONS = {".txt", ".md", ".json"}
 CONVERT_EXTENSIONS = {".pdf", ".docx", ".doc", ".rtf"}
 
 _soffice_lock = threading.Lock()
@@ -82,23 +82,32 @@ def _status_from_message(ext: str, success: bool, message: str) -> tuple[str, st
 
 
 def _normalize_plain_text(source_path: Path, original_filename: str) -> ExtractionResult:
-    """Normalize .txt/.md uploads to .txt in the same directory."""
+    """Normalize .txt/.md/.json uploads to .txt in the same directory.
+
+    JSON is not parsed — the file bytes are used as-is so any schema works.
+    """
+    ext = source_path.suffix.lower()
     text = source_path.read_text(encoding="utf-8", errors="replace")
     if not text.strip():
-        return _fail(source_path, "failed: empty text file", original_filename)
+        return _fail(source_path, "failed: empty file", original_filename)
 
-    if source_path.suffix.lower() == ".txt":
+    if ext == ".txt":
         output_path = source_path
     else:
         output_path = source_path.with_suffix(".txt")
         output_path.write_text(text, encoding="utf-8")
         source_path.unlink(missing_ok=True)
 
+    if ext == ".json":
+        method, status = "json", "extracted from json"
+    else:
+        method, status = "plain", "extracted from text"
+
     return ExtractionResult(
         output_path=output_path,
         display_name=output_path.name,
-        method="plain",
-        status="extracted from text",
+        method=method,
+        status=status,
         success=True,
         original_filename=original_filename,
     )

--- a/backend/docs/document-preprocessing.md
+++ b/backend/docs/document-preprocessing.md
@@ -13,7 +13,7 @@ Convert every upload to plain `.txt` at upload time—one entry point, same logi
 | DOCX | python-docx | LibreOffice headless |
 | PDF | pdfplumber | OCR (pdf2image + tesseract) |
 | DOC / RTF | LibreOffice | — |
-| TXT / MD | Normalize to `.txt` | — |
+| TXT / MD / JSON | Read as UTF-8 text; JSON is not parsed (rename to `.txt` for pipeline) | — |
 
 ## Code touchpoints
 

--- a/frontend/src/components/DocumentUpload/DocumentUpload.tsx
+++ b/frontend/src/components/DocumentUpload/DocumentUpload.tsx
@@ -81,6 +81,7 @@ const DocumentUpload: React.FC<DocumentUploadProps> = ({
       'application/msword': ['.doc'],
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['.docx'],
       'application/rtf': ['.rtf'],
+      'application/json': ['.json'],
     },
     maxSize: 25 * 1024 * 1024, // 25MB per file
     onFilesSelected: onFilesChange,

--- a/frontend/src/components/SchemaEditor/ContinueDiscoveryDialog.tsx
+++ b/frontend/src/components/SchemaEditor/ContinueDiscoveryDialog.tsx
@@ -662,7 +662,7 @@ const ContinueDiscoveryDialog: React.FC<ContinueDiscoveryDialogProps> = ({
                     <input
                       type="file"
                       multiple
-                      accept=".txt,.md,.pdf"
+                      accept=".txt,.md,.pdf,.doc,.docx,.rtf,.json"
                       onChange={(e) => {
                         const files = Array.from(e.target.files || []);
                         setUploadedFiles(files);

--- a/frontend/src/pages/ScheMatiQConfig.tsx
+++ b/frontend/src/pages/ScheMatiQConfig.tsx
@@ -158,6 +158,7 @@ const ScheMatiQConfigPage = () => {
       'application/msword': ['.doc'],
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['.docx'],
       'application/rtf': ['.rtf'],
+      'application/json': ['.json'],
     },
     maxSize: 25 * 1024 * 1024, // 25MB per file
     onFilesSelected: setUploadedFiles,
@@ -847,7 +848,7 @@ const ScheMatiQConfigPage = () => {
                     {isDragActive ? 'Drop files here...' : 'Drag and drop files here, or click to browse'}
                   </p>
                   <p className="text-xs text-muted-foreground mt-1">
-                    Supports: .txt, .md, .pdf, .doc, .docx, .rtf (max 25MB each)
+                    Supports: .txt, .md, .pdf, .doc, .docx, .rtf, .json (max 25MB each)
                   </p>
                 </div>
 


### PR DESCRIPTION
## Summary
- Accept `.json` on document upload (config page, add documents, continue discovery)
- Treat JSON like text: read UTF-8 bytes as-is, save as `{stem}.txt` for the pipeline (no schema-specific parsing)
- Backend allows `.json` in `add_documents` validation

## Test plan
- [x] `pytest backend/tests/test_json_document_preprocessor.py` (2 passed locally)
- [ ] Upload a `.json` file on ScheMatiQ Config — status shows `extracted from json`, file stored as `.txt`
- [ ] Run schema discovery / extraction on session with uploaded JSON
- [ ] Confirm arbitrary JSON shapes work (not only committee-protocol format)


Made with [Cursor](https://cursor.com)