### PR TITLE
fix: observation unit review resume and mid-run Edit & Rediscover

### DIFF
--- a/backend/app/api/routes/schematiq.py
+++ b/backend/app/api/routes/schematiq.py
@@ -355,7 +355,7 @@ async def resume_schematiq(session_id: str, background_tasks: BackgroundTasks):
         await concurrency_limiter.acquire(session_id, "schematiq")
 
         # Start resumed ScheMatiQ in background
-        background_tasks.add_task(schematiq_runner.resume_schematiq, session_id)
+        background_tasks.add_task(schematiq_runner.resume_qbsd, session_id)
 
         return {"message": "ScheMatiQ execution resumed", "session_id": session_id}
 

--- a/backend/app/api/routes/schematiq.py
+++ b/backend/app/api/routes/schematiq.py
@@ -328,12 +328,21 @@ async def resume_schematiq(session_id: str, background_tasks: BackgroundTasks):
             SessionStatus.COMPLETED,
             SessionStatus.STOPPED,
             SessionStatus.SCHEMA_READY,
+            SessionStatus.PROCESSING,
         }
         if session.status not in allowed_statuses:
             raise HTTPException(
                 status_code=400,
                 detail=f"Session cannot be resumed from status '{session.status}'. "
                        f"Allowed: {', '.join(s.value for s in allowed_statuses)}"
+            )
+        if (
+            session.status == SessionStatus.PROCESSING
+            and not session.metadata.pending_observation_unit_rediscovery
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="Session is still processing. Stop the run before resuming.",
             )
 
         # Pre-check global LLM quota before starting background task
@@ -351,11 +360,19 @@ async def resume_schematiq(session_id: str, background_tasks: BackgroundTasks):
                     detail="The system has reached its processing capacity. Please try again later."
                 )
 
-        # Reserve concurrency slot before starting background task
-        await concurrency_limiter.acquire(session_id, "schematiq")
+        # Stop + prepare synchronously so resume cannot race the active pipeline.
+        try:
+            await schematiq_runner.prepare_resume(session_id)
+        except RuntimeError as e:
+            msg = str(e)
+            if "already has an active operation" in msg or "Timed out waiting" in msg:
+                raise HTTPException(
+                    status_code=409,
+                    detail="Pipeline is still stopping. Wait a few seconds and try Save & Rediscover again.",
+                ) from e
+            raise HTTPException(status_code=500, detail=msg) from e
 
-        # Start resumed ScheMatiQ in background
-        background_tasks.add_task(schematiq_runner.resume_qbsd, session_id)
+        background_tasks.add_task(schematiq_runner.run_schematiq, session_id)
 
         return {"message": "ScheMatiQ execution resumed", "session_id": session_id}
 

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -131,6 +131,10 @@ class SessionMetadata(BaseModel):
     # While True, re-extraction must not reuse row names from existing data as known_units (that
     # would skip LLM unit discovery and ignore the new definition).
     pending_observation_unit_rediscovery: bool = False
+    # Set when resume_qbsd resets artifacts; cleared with pending flag after that run completes.
+    observation_unit_rediscovery_run: bool = False
+    # Suppress partial data-collection archive when stop is only preparing rediscovery.
+    skip_stop_data_collection: bool = False
 
 class SkippedDocumentInfo(BaseModel):
     """Metadata for a document that was skipped during extraction."""

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -80,6 +80,10 @@ class ConcurrencyLimiter:
         async with self._lock:
             return len(self._active)
 
+    def is_session_active(self, session_id: str) -> bool:
+        """Return True if this session currently holds a concurrency slot."""
+        return session_id in self._active
+
 
 concurrency_limiter = ConcurrencyLimiter(MAX_CONCURRENT_SESSIONS)
 logger.info("[concurrency] Concurrency limiter initialized: max %d sessions", MAX_CONCURRENT_SESSIONS)

--- a/backend/app/services/observation_unit_manager.py
+++ b/backend/app/services/observation_unit_manager.py
@@ -11,7 +11,7 @@ from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
-from app.models.session import VisualizationSession
+from app.models.session import VisualizationSession, SessionStatus
 from app.services.session_manager import SessionManager
 from app.services.websocket_manager import WebSocketManager
 
@@ -364,7 +364,14 @@ class ObservationUnitManager:
         # Update session
         session.observation_unit = updated_observation_unit
         session.metadata.last_modified = datetime.now()
-        session.metadata.pending_observation_unit_rediscovery = True
+        # Only flag rediscovery after schema exists — initial review pause just resumes forward.
+        session.metadata.pending_observation_unit_rediscovery = (
+            session.status != SessionStatus.OBSERVATION_UNIT_REVIEW
+            and (
+                session.metadata.schema_discovery_completed
+                or bool(session.columns)
+            )
+        )
         self.session_manager.update_session(session)
 
         # Update schema JSON file on disk

--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -300,8 +300,35 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
             self.clear_stop_flag(session_id)
             await concurrency_limiter.release(session_id)
 
-    async def resume_qbsd(self, session_id: str):
-        """Resume ScheMatiQ after observation unit review."""
+    async def _reset_for_observation_unit_rediscovery(self, session_id: str) -> None:
+        """Clear schema/data artifacts so a full rediscovery run starts clean."""
+        session_dir = self.work_dir / session_id
+        for fname in (
+            "extracted_data.jsonl",
+            "discovered_schema.json",
+            "value_extraction_schema.json",
+            "llm_call_stats.json",
+        ):
+            artifact = session_dir / fname
+            if artifact.exists():
+                artifact.unlink()
+                logger.info("Removed %s for observation unit rediscovery", fname)
+
+        session = self.session_manager.get_session(session_id)
+        if not session:
+            return
+
+        session.columns = []
+        session.statistics = None
+        session.error_message = None
+        session.metadata.schema_discovery_completed = False
+        session.metadata.processed_documents = 0
+        session.metadata.total_documents = 0
+        session.metadata.processing_stats = {}
+        self.session_manager.update_session(session)
+
+    async def prepare_resume(self, session_id: str) -> None:
+        """Stop any in-flight run, reset for rediscovery if needed, update config, acquire slot."""
         set_session_context(session_id)
 
         config_file = self.work_dir / session_id / "config.json"
@@ -315,17 +342,95 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         if not session:
             raise RuntimeError(f"Session {session_id} not found")
 
-        if session.observation_unit:
+        rediscover = bool(session.metadata.pending_observation_unit_rediscovery)
+
+        with self._state_lock:
+            is_running = session_id in self.running_sessions
+
+        slot_held = concurrency_limiter.is_session_active(session_id)
+        if is_running or self.is_stop_requested(session_id):
+            if rediscover:
+                session.metadata.skip_stop_data_collection = True
+                self.session_manager.update_session(session)
+            logger.info(
+                "Stopping in-flight pipeline before resume for session %s (rediscover=%s)",
+                session_id,
+                rediscover,
+            )
+            await self.stop_execution(session_id)
+        elif slot_held:
+            logger.warning(
+                "Concurrency slot still held for session %s without running task — waiting to clear",
+                session_id,
+            )
+            for _ in range(120):
+                if not concurrency_limiter.is_session_active(session_id):
+                    break
+                await asyncio.sleep(1)
+            if concurrency_limiter.is_session_active(session_id):
+                await concurrency_limiter.release(session_id)
+
+        if rediscover:
+            await self._reset_for_observation_unit_rediscovery(session_id)
+            session = self.session_manager.get_session(session_id)
+            if session:
+                session.metadata.observation_unit_rediscovery_run = True
+                self.session_manager.update_session(session)
+                logger.info("Prepared session %s for observation unit rediscovery", session_id)
+
+        session = self.session_manager.get_session(session_id)
+        if session and session.observation_unit:
+            obs_unit = session.observation_unit
             config_data["initial_observation_unit"] = {
-                "name": session.observation_unit.name,
-                "definition": session.observation_unit.definition,
+                "name": obs_unit.name,
+                "definition": obs_unit.definition,
             }
+            if obs_unit.example_names:
+                config_data["initial_observation_unit"]["example_names"] = obs_unit.example_names
+
+            examples_suffix = ""
+            if obs_unit.example_names:
+                examples_suffix = f" (examples: {', '.join(obs_unit.example_names)})"
+            resume_log = (
+                f'Resuming with observation unit: "{obs_unit.name}": '
+                f'{obs_unit.definition}{examples_suffix}'
+            )
+            logger.info(resume_log)
+            await self.websocket_manager.broadcast_to_session(session_id, {
+                "type": "log",
+                "timestamp": datetime.now().isoformat(),
+                "data": {
+                    "level": "info",
+                    "message": resume_log,
+                },
+            })
 
         config_data["review_observation_unit"] = False
 
         with open(config_file, 'w') as f:
             json.dump(config_data, f, indent=2)
 
+        for attempt in range(120):
+            try:
+                await concurrency_limiter.acquire(session_id, "schematiq")
+                return
+            except RuntimeError as exc:
+                if "already has an active operation" not in str(exc):
+                    raise
+                if attempt == 0:
+                    logger.info(
+                        "Waiting for session %s pipeline slot to free before resume",
+                        session_id,
+                    )
+                await asyncio.sleep(1)
+
+        raise RuntimeError(
+            f"Timed out waiting for session {session_id} to stop before resume"
+        )
+
+    async def resume_qbsd(self, session_id: str, acquire_slot: bool = False):
+        """Resume ScheMatiQ after observation unit review or post-edit rediscovery."""
+        await self.prepare_resume(session_id)
         await self.run_schematiq(session_id)
 
     async def _execute_schematiq(self, session_id: str, config: ScheMatiQConfig):
@@ -655,6 +760,10 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
                 "estimated_cost_usd": initial_cost_estimate_usd,
                 "estimated_calls": initial_calls_estimate,
             }
+            if session.metadata.observation_unit_rediscovery_run:
+                session.metadata.pending_observation_unit_rediscovery = False
+                session.metadata.observation_unit_rediscovery_run = False
+                logger.info("Cleared pending_observation_unit_rediscovery after successful rediscovery")
             self.session_manager.update_session(session)
             self.session_manager.capture_schema_baseline(session_id)
 
@@ -880,11 +989,15 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
             "data_rows_saved": rows_saved,
             "message": "Processing stopped during value extraction"
         })
-        if self._data_collection_service and rows_saved > 0:
+        skip_archive = bool(session.metadata.skip_stop_data_collection)
+        if skip_archive:
+            session.metadata.skip_stop_data_collection = False
+            self.session_manager.update_session(session)
+        elif self._data_collection_service and rows_saved > 0:
             await self._data_collection_service.trigger_archive(session_id, "schematiq_stopped_partial")
-        if self._pubmed_enrichment_service and rows_saved > 0:
+        if not skip_archive and self._pubmed_enrichment_service and rows_saved > 0:
             await self._pubmed_enrichment_service.enrich_session(session_id)
-        if self._uniprot_enrichment_service and rows_saved > 0:
+        if not skip_archive and self._uniprot_enrichment_service and rows_saved > 0:
             await self._uniprot_enrichment_service.enrich_session(session_id)
 
     def _move_pending_documents(self, session_id: str):

--- a/backend/app/services/unit_view_service.py
+++ b/backend/app/services/unit_view_service.py
@@ -18,7 +18,7 @@ from app.models.unit import (
     AutoMergeResult,
 )
 from app.models.session import DataRow
-from app.core.config import DEFAULT_DATA_DIR
+from app.core.config import DEFAULT_DATA_DIR, DEFAULT_SCHEMATIQ_WORK_DIR
 from app.services import row_filtering
 
 logger = logging.getLogger(__name__)
@@ -27,42 +27,116 @@ logger = logging.getLogger(__name__)
 class UnitViewService:
     """Service for managing observation unit views and merges."""
 
-    # In-memory row cache: session_id -> (rows, file_mtimes, cached_at)
-    _row_cache: Dict[str, Tuple[List[Dict], Dict[str, float], float]] = {}
+    # In-memory row cache: session_id -> (rows, file_signatures, cached_at)
+    _row_cache: Dict[str, Tuple[List[Dict], Dict[str, Tuple[float, int]], float]] = {}
     _CACHE_TTL = 30  # seconds
 
     def __init__(self, data_dir: str = DEFAULT_DATA_DIR):
         self.data_dir = Path(data_dir)
-        self.work_dir = Path("./schematiq_work")
+        self.work_dir = Path(DEFAULT_SCHEMATIQ_WORK_DIR)
+
+    def _dev_instance_work_dirs(self) -> List[Path]:
+        """schematiq_work dirs from dev.sh isolation (.dev-data/instance-N/)."""
+        from app.services.data_utils import _BACKEND_DIR
+
+        dev_root = _BACKEND_DIR.parent / ".dev-data"
+        if not dev_root.is_dir():
+            return []
+
+        seen: set[Path] = set()
+        dirs: List[Path] = []
+        for instance_work in sorted(dev_root.glob("instance-*/schematiq_work")):
+            resolved = instance_work.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                dirs.append(instance_work)
+        return dirs
+
+    def _candidate_work_dirs(self) -> List[Path]:
+        """Work dirs to search — CWD-relative, module-relative, and dev.sh instances."""
+        from app.services.data_utils import get_schematiq_work_dir
+
+        seen: set[Path] = set()
+        candidates: List[Path] = []
+        for d in (self.work_dir, get_schematiq_work_dir(), *self._dev_instance_work_dirs()):
+            resolved = d.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                candidates.append(d)
+        return candidates
+
+    def _dev_instance_data_dirs(self) -> List[Path]:
+        """data dirs from dev.sh isolation (.dev-data/instance-N/data)."""
+        from app.services.data_utils import _BACKEND_DIR
+
+        dev_root = _BACKEND_DIR.parent / ".dev-data"
+        if not dev_root.is_dir():
+            return []
+
+        seen: set[Path] = set()
+        dirs: List[Path] = []
+        for instance_data in sorted(dev_root.glob("instance-*/data")):
+            resolved = instance_data.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                dirs.append(instance_data)
+        return dirs
+
+    def _candidate_data_dirs(self) -> List[Path]:
+        """Data dirs to search — CWD-relative, module-relative, and dev.sh instances."""
+        from app.services.data_utils import get_data_dir
+
+        seen: set[Path] = set()
+        candidates: List[Path] = []
+        for d in (self.data_dir, get_data_dir(), *self._dev_instance_data_dirs()):
+            resolved = d.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                candidates.append(d)
+        return candidates
 
     def _get_all_data_files(self, session_id: str) -> List[Path]:
         """Get all data file paths for a session, checking multiple locations.
+
+        Checks both CWD-relative paths (where schematiq_runner writes under dev.sh)
+        and module-relative paths (backend/schematiq_work) so units are found
+        regardless of process working directory.
 
         Returns list of existing files from:
         1. schematiq_work/{session_id}/extracted_data.jsonl (ScheMatiQ sessions)
         2. schematiq_work/{session_id}/data.jsonl (fallback if extracted_data doesn't exist)
         3. data/{session_id}/data.jsonl (always check - may have additional docs)
         """
-        data_files = []
+        data_files: List[Path] = []
+        resolved_files: set[Path] = set()
 
-        # Check ScheMatiQ work directory (original ScheMatiQ extraction)
-        schematiq_extracted = self.work_dir / session_id / "extracted_data.jsonl"
-        if schematiq_extracted.exists():
-            data_files.append(schematiq_extracted)
+        # Check ScheMatiQ work directories (original ScheMatiQ extraction)
+        for work_dir in self._candidate_work_dirs():
+            schematiq_extracted = work_dir / session_id / "extracted_data.jsonl"
+            if schematiq_extracted.exists():
+                resolved = schematiq_extracted.resolve()
+                if resolved not in resolved_files:
+                    resolved_files.add(resolved)
+                    data_files.append(schematiq_extracted)
 
         # Check schematiq_work for data.jsonl (only if extracted_data.jsonl doesn't exist)
         if not data_files:
-            schematiq_data = self.work_dir / session_id / "data.jsonl"
-            if schematiq_data.exists():
-                data_files.append(schematiq_data)
+            for work_dir in self._candidate_work_dirs():
+                schematiq_data = work_dir / session_id / "data.jsonl"
+                if schematiq_data.exists():
+                    resolved = schematiq_data.resolve()
+                    if resolved not in resolved_files:
+                        resolved_files.add(resolved)
+                        data_files.append(schematiq_data)
 
-        # Always check data directory - may contain additional documents
-        data_file = self.data_dir / session_id / "data.jsonl"
-        if data_file.exists():
-            # Use resolve() to handle symlinks and relative paths correctly
-            resolved_files = [f.resolve() for f in data_files]
-            if data_file.resolve() not in resolved_files:
-                data_files.append(data_file)
+        # Always check data directories — may contain additional documents
+        for data_dir in self._candidate_data_dirs():
+            data_file = data_dir / session_id / "data.jsonl"
+            if data_file.exists():
+                resolved = data_file.resolve()
+                if resolved not in resolved_files:
+                    resolved_files.add(resolved)
+                    data_files.append(data_file)
 
         return data_files
 
@@ -79,7 +153,7 @@ class UnitViewService:
         """Load all data rows from all session data files (cached).
 
         Uses an in-memory cache keyed by session_id. Cache is invalidated when:
-        - Any data file's mtime changes (file was modified)
+        - Any data file's mtime or size changes (file was modified/appended)
         - TTL expires (30s)
         - Explicitly invalidated after mutations (merge, add, delete)
 
@@ -89,18 +163,19 @@ class UnitViewService:
         if not data_files:
             return []
 
-        # Check cache validity
+        # Check cache validity (mtime + size catches JSONL appends in the same second)
         now = time.monotonic()
-        current_mtimes = {}
+        current_signatures: Dict[str, Tuple[float, int]] = {}
         for f in data_files:
             try:
-                current_mtimes[str(f)] = f.stat().st_mtime
+                st = f.stat()
+                current_signatures[str(f)] = (st.st_mtime, st.st_size)
             except OSError:
                 pass
 
         if session_id in self._row_cache:
-            cached_rows, cached_mtimes, cached_at = self._row_cache[session_id]
-            if (now - cached_at) < self._CACHE_TTL and cached_mtimes == current_mtimes:
+            cached_rows, cached_signatures, cached_at = self._row_cache[session_id]
+            if (now - cached_at) < self._CACHE_TTL and cached_signatures == current_signatures:
                 return cached_rows
 
         # Cache miss — read from disk
@@ -125,7 +200,7 @@ class UnitViewService:
                 logger.warning(f"Error reading {data_file}: {e}")
             seen_keys.update(file_keys)
 
-        self._row_cache[session_id] = (rows, current_mtimes, now)
+        self._row_cache[session_id] = (rows, current_signatures, now)
         return rows
 
     def _save_all_rows(self, session_id: str, rows: List[Dict]) -> None:
@@ -148,7 +223,17 @@ class UnitViewService:
         # Check for unit_name with and without underscore prefix at root level
         for field in ['_unit_name', 'unit_name']:
             if field in row and row[field]:
-                return str(row[field]).strip()
+                value = row[field]
+                if isinstance(value, dict):
+                    value = value.get('value') or value.get('answer')
+                if value:
+                    return str(value).strip()
+
+        # Multi-unit extraction rows: instance name is often stored as _row_name
+        if row.get('_observation_unit') or row.get('_unit_confidence'):
+            for field in ('_row_name', 'row_name'):
+                if row.get(field):
+                    return str(row[field]).strip()
 
         # Also check within the 'data' field for unit-related columns
         # This handles cases where the observation unit is stored as a regular column

--- a/frontend/src/components/ScheMatiQMonitor/ScheMatiQMonitor.tsx
+++ b/frontend/src/components/ScheMatiQMonitor/ScheMatiQMonitor.tsx
@@ -17,6 +17,7 @@ import {
   X,
   Pencil,
   RefreshCw,
+  ChevronLeft,
   Table,
 } from 'lucide-react';
 import { useQuery, useQueryClient } from 'react-query';
@@ -45,6 +46,7 @@ import {
   getDefaultModelForProvider,
   getAvailableProviders,
 } from '@/constants/llmModels';
+import { extractApiErrorMessage } from '../../utils/apiHelpers';
 
 interface ScheMatiQMonitorProps {
   sessionId: string;
@@ -52,6 +54,21 @@ interface ScheMatiQMonitorProps {
   initialCapacityMessage?: string;
   /** Notify parent when deferred extraction starts (schema-only → full table fill). */
   onExtractionStarted?: (columns: string[], operationId?: string) => void;
+  /** Keep WebSocket alive before resume so extraction events stream incrementally. */
+  onResumeStarted?: () => void;
+}
+
+/** Format observation unit for monitor logs and summary surfaces. */
+function formatObservationUnitSummary(obs: {
+  name: string;
+  definition: string;
+  example_names?: string[];
+}): string {
+  let summary = `"${obs.name}": ${obs.definition}`;
+  if (obs.example_names && obs.example_names.length > 0) {
+    summary += ` (examples: ${obs.example_names.join(', ')})`;
+  }
+  return summary;
 }
 
 interface LogEntry {
@@ -60,6 +77,8 @@ interface LogEntry {
   message: string;
   details?: any;
 }
+
+type ReviewEntryMode = 'initial' | 'mid_run' | 'post_run';
 
 // Processing state that changes IMMEDIATELY on user action
 type ProcessingState = 'idle' | 'starting' | 'schema' | 'extraction' | 'completed' | 'error' | 'stopped' | 'observation_unit_review';
@@ -76,6 +95,7 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
   autoStarted = false,
   initialCapacityMessage = '',
   onExtractionStarted,
+  onResumeStarted,
 }) => {
   const queryClient = useQueryClient();
   const llmStatsCacheKey = ['schematiq-llm-stats', sessionId];
@@ -106,6 +126,7 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
     return '';
   });
   const [errorMessage, setErrorMessage] = useState<string>('');
+  const [reviewSaveError, setReviewSaveError] = useState<string>('');
   const [capacityMessage, setCapacityMessage] = useState<string>(initialCapacityMessage);
   const [quotaExceeded, setQuotaExceeded] = useState(false);
 
@@ -139,6 +160,10 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
   const [newExample, setNewExample] = useState('');
   const [isResuming, setIsResuming] = useState(false);
   const [obsUnitEdited, setObsUnitEdited] = useState(false);
+  // How the user entered observation-unit review (initial pause vs mid-run vs post-run edit)
+  const [reviewEntryMode, setReviewEntryMode] = useState<ReviewEntryMode | null>(null);
+  const [processingStateBeforeEdit, setProcessingStateBeforeEdit] = useState<ProcessingState | null>(null);
+  const [editBaseline, setEditBaseline] = useState<ObservationUnitReadyData | null>(null);
 
   // LLM Stats state
   const [llmStats, setLlmStats] = useState<LlmStats | null>(cachedLlmStats || null);
@@ -195,6 +220,9 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
             setEditDefinition(obsData.definition);
             setEditExamples(obsData.example_names || []);
             setObsUnitEdited(false);
+            setEditBaseline(obsData);
+            setReviewEntryMode('initial');
+            setProcessingStateBeforeEdit(null);
           }
         }).catch(() => { /* ignore - will retry on next poll */ });
       }
@@ -407,7 +435,12 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
         addLog(logData?.level || 'info', logData?.message || 'Log message', message.data);
       } else if (message.type === 'observation_unit_ready') {
         const obsData = message.data as ObservationUnitReadyData;
-        addLog('info', `Observation unit discovered: "${obsData?.name}". Review before continuing.`);
+        addLog(
+          'info',
+          obsData
+            ? `Observation unit discovered: ${formatObservationUnitSummary(obsData)}. Review before continuing.`
+            : 'Observation unit discovered. Review before continuing.',
+        );
         setProcessingState('observation_unit_review');
         if (obsData) {
           setReviewObsUnit(obsData);
@@ -415,6 +448,9 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
           setEditDefinition(obsData.definition);
           setEditExamples(obsData.example_names || []);
           setObsUnitEdited(false);
+          setEditBaseline(obsData);
+          setReviewEntryMode('initial');
+          setProcessingStateBeforeEdit(null);
         }
         queryClient.invalidateQueries(['schematiq-status', sessionId]);
       } else if (message.type === 'reextraction_started') {
@@ -730,18 +766,17 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
         `Extracting ${response.columns.length} column(s) across ${docCount} document(s). Open the Data tab for live rows.`,
       );
     } catch (err: unknown) {
-      const axiosErr = err as { response?: { data?: { detail?: string }; status?: number }; message?: string };
-      const detail = axiosErr.response?.data?.detail;
+      const message = extractApiErrorMessage(err, 'Failed to start extraction');
       setDeferredExtractError(
-        axiosErr.response?.status === 503
-          ? (detail || 'Server is busy. Try again in a few minutes.')
-          : (detail || axiosErr.message || 'Failed to start extraction'),
+        (err as { response?: { status?: number } })?.response?.status === 503
+          ? (message || 'Server is busy. Try again in a few minutes.')
+          : message,
       );
       addLog(
         'error',
-        axiosErr.response?.status === 503
-          ? (detail || 'Server is busy')
-          : (detail || axiosErr.message || 'Failed to start extraction'),
+        (err as { response?: { status?: number } })?.response?.status === 503
+          ? (message || 'Server is busy')
+          : message,
       );
     } finally {
       setIsDeferredExtracting(false);
@@ -782,9 +817,8 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
       await schematiqAPI.run(sessionId);
       addLog('info', 'ScheMatiQ execution started');
       // Stay in 'starting' state until we receive progress updates
-    } catch (error: any) {
-      const status = error?.response?.status;
-      const detail = error?.response?.data?.detail;
+    } catch (error: unknown) {
+      const status = (error as { response?: { status?: number } })?.response?.status;
 
       if (status === 429) {
         // Quota exceeded — show orange banner
@@ -794,11 +828,12 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
       } else if (status === 503) {
         // Server busy — show friendly amber banner, not error state
         setProcessingState('idle');
-        setCapacityMessage(detail || 'The server is currently busy processing other requests. Please try again in a few minutes.');
+        const message = extractApiErrorMessage(error, 'The server is currently busy processing other requests. Please try again in a few minutes.');
+        setCapacityMessage(message);
         addLog('warning', 'Server busy — please retry shortly');
       } else {
         setProcessingState('error');
-        const message = detail || error.message || 'Failed to start ScheMatiQ';
+        const message = extractApiErrorMessage(error, 'Failed to start ScheMatiQ');
         setErrorMessage(message);
         addLog('error', `Failed to start ScheMatiQ: ${message}`);
       }
@@ -818,9 +853,9 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
         setIsStopping(false);
         addLog('warning', 'Stop requested — processing will stop at the next checkpoint.');
       }
-    } catch (error: any) {
-      const detail = error?.response?.data?.detail;
-      addLog('error', detail || error.message || 'Failed to stop');
+    } catch (error: unknown) {
+      const message = extractApiErrorMessage(error, 'Failed to stop');
+      addLog('error', message);
       setIsStopping(false);
     }
   };
@@ -839,24 +874,122 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
     setObsUnitEdited(true);
   }, []);
 
+  const examplesEqual = (a: string[], b: string[]) =>
+    a.length === b.length && a.every((val, i) => val === b[i]);
+
+  const hasObsUnitChanges = useCallback(() => {
+    const baseline = editBaseline || reviewObsUnit;
+    if (!baseline) return false;
+    return (
+      editName.trim() !== baseline.name.trim() ||
+      editDefinition.trim() !== baseline.definition.trim() ||
+      !examplesEqual(editExamples, baseline.example_names || [])
+    );
+  }, [editBaseline, reviewObsUnit, editName, editDefinition, editExamples]);
+
+  const closeMidRunEditor = useCallback((restoreState?: ProcessingState | null) => {
+    const baseline = editBaseline || reviewObsUnit;
+    if (baseline) {
+      setEditName(baseline.name);
+      setEditDefinition(baseline.definition);
+      setEditExamples(baseline.example_names || []);
+    }
+    setObsUnitEdited(false);
+    setReviewEntryMode(null);
+    setEditBaseline(null);
+    setProcessingStateBeforeEdit(null);
+    if (restoreState) {
+      setProcessingState(restoreState);
+    }
+  }, [editBaseline, reviewObsUnit]);
+
+  const handleCloseReviewPanel = () => {
+    if (reviewEntryMode === 'mid_run') {
+      closeMidRunEditor(processingStateBeforeEdit || 'schema');
+      addLog('info', 'Returned to monitor — pipeline continues.');
+      return;
+    }
+    if (reviewEntryMode === 'post_run') {
+      const baseline = editBaseline || reviewObsUnit;
+      if (baseline) {
+        setEditName(baseline.name);
+        setEditDefinition(baseline.definition);
+        setEditExamples(baseline.example_names || []);
+      }
+      setObsUnitEdited(false);
+      setReviewEntryMode(null);
+      setEditBaseline(null);
+      setProcessingState(processingStateBeforeEdit || 'completed');
+      setProcessingStateBeforeEdit(null);
+    }
+  };
+
+  const handleDiscardObsUnitChanges = () => {
+    const baseline = editBaseline || reviewObsUnit;
+    if (baseline) {
+      setEditName(baseline.name);
+      setEditDefinition(baseline.definition);
+      setEditExamples(baseline.example_names || []);
+    }
+    setObsUnitEdited(false);
+  };
+
   const handleResume = async (skipEdit = false) => {
     setIsResuming(true);
+    setReviewSaveError('');
     try {
+      let confirmedObsUnit: ObservationUnitReadyData | null = reviewObsUnit
+        ? {
+            name: editName.trim() || reviewObsUnit.name,
+            definition: editDefinition.trim() || reviewObsUnit.definition,
+            example_names: editExamples.length > 0 ? editExamples : (reviewObsUnit.example_names || []),
+          }
+        : null;
+
+      const shouldPersistEdit = !skipEdit && hasObsUnitChanges() && editName.trim() && editDefinition.trim();
+
       // If the user edited the observation unit, save changes first
-      if (!skipEdit && obsUnitEdited && editName.trim() && editDefinition.trim()) {
-        await observationUnitAPI.updateDefinition(sessionId, {
+      if (shouldPersistEdit) {
+        const response = await observationUnitAPI.updateDefinition(sessionId, {
           name: editName.trim(),
           definition: editDefinition.trim(),
           example_names: editExamples.length > 0 ? editExamples : undefined,
         });
-        addLog('success', `Observation unit updated to "${editName.trim()}"`);
+        confirmedObsUnit = {
+          name: response.observation_unit.name,
+          definition: response.observation_unit.definition,
+          example_names: response.observation_unit.example_names || [],
+        };
+        setReviewObsUnit(confirmedObsUnit);
+        setEditName(confirmedObsUnit.name);
+        setEditDefinition(confirmedObsUnit.definition);
+        setEditExamples(confirmedObsUnit.example_names);
+        addLog('success', `Observation unit updated: ${formatObservationUnitSummary(confirmedObsUnit)}`);
       }
 
-      // Resume the pipeline
+      const isRediscover =
+        (reviewEntryMode === 'mid_run' || reviewEntryMode === 'post_run') && shouldPersistEdit;
+      if (isRediscover) {
+        addLog('info', 'Stopping current run and rediscovering schema with updated observation unit...');
+        setReviewEntryMode(null);
+        setEditBaseline(null);
+        setProcessingStateBeforeEdit(null);
+      }
+
+      // Keep WebSocket connected before backend resumes extraction
+      onResumeStarted?.();
+
+      // Resume waits for any in-flight pipeline to stop, then restarts (backend resume_qbsd)
       await schematiqAPI.resume(sessionId);
-      addLog('info', 'Resuming schema generation...');
+      if (confirmedObsUnit) {
+        addLog('info', `Resuming with observation unit: ${formatObservationUnitSummary(confirmedObsUnit)}`);
+      } else {
+        addLog('info', 'Resuming schema generation...');
+      }
 
       // Transition to starting/schema state
+      setReviewEntryMode(null);
+      setEditBaseline(null);
       setProcessingState('starting');
       setCurrentStepMessage('Resuming pipeline...');
       startTimeRef.current = Date.now();
@@ -874,11 +1007,9 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
         totalDocs: 0,
         isComplete: false
       });
-    } catch (error: any) {
-      const detail = error?.response?.data?.detail;
-      const message = detail || error.message || 'Failed to resume';
-      setErrorMessage(message);
-      setProcessingState('error');
+    } catch (error: unknown) {
+      const message = extractApiErrorMessage(error, 'Failed to resume');
+      setReviewSaveError(message);
       addLog('error', `Failed to resume: ${message}`);
     } finally {
       setIsResuming(false);
@@ -895,6 +1026,16 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
   };
 
   const isProcessing = processingState === 'starting' || processingState === 'schema' || processingState === 'extraction';
+
+  // While mid-run review panel is open, backend phase is not `observation_unit_review` — keep phase cards live
+  const phaseDisplayState: ProcessingState =
+    processingState === 'observation_unit_review' && reviewEntryMode === 'mid_run'
+      ? (schemaProgress.isComplete || status?.schema_completed
+          ? 'extraction'
+          : (processingStateBeforeEdit || 'schema'))
+      : processingState === 'observation_unit_review' && reviewEntryMode === 'post_run'
+        ? (processingStateBeforeEdit || 'completed')
+        : processingState;
 
   if (isLoading && !autoStarted) {
     return (
@@ -1060,16 +1201,57 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
           )}
 
           {/* OBSERVATION UNIT REVIEW STATE */}
-          {processingState === 'observation_unit_review' && reviewObsUnit && (
-            <div className="w-full max-w-lg">
-              <div className="flex flex-col items-center mb-4">
+          {processingState === 'observation_unit_review' && reviewObsUnit && (() => {
+            const hasChanges = hasObsUnitChanges();
+            const schemaAlreadyDiscovered = schemaProgress.isComplete || !!status?.schema_completed;
+            const isMidRunReview = reviewEntryMode === 'mid_run';
+            const isPostRunReview = reviewEntryMode === 'post_run';
+            const isInitialReview = reviewEntryMode === 'initial';
+            const trimmedDefinition = editDefinition.trim();
+            const formValid = !!editName.trim()
+              && trimmedDefinition.length >= 10
+              && trimmedDefinition.length <= 500
+              && editName.trim().length <= 100;
+            const primaryLabel = schemaAlreadyDiscovered
+              ? 'Save & Rediscover'
+              : (isInitialReview && !hasChanges
+                ? 'Continue to Schema Generation'
+                : 'Save & Continue to Schema Generation');
+            const primaryEnabled = isResuming
+              ? false
+              : isInitialReview
+                ? formValid
+                : formValid && hasChanges;
+            const discardEnabled = !isResuming && hasChanges;
+            const showCloseControl = isMidRunReview || isPostRunReview;
+
+            return (
+            <div className="w-full max-w-lg relative">
+              {showCloseControl && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="absolute left-0 top-0 h-8 w-8 text-muted-foreground hover:text-foreground"
+                  onClick={handleCloseReviewPanel}
+                  disabled={isResuming}
+                  aria-label="Back to monitor"
+                >
+                  <ChevronLeft className="h-5 w-5" />
+                </Button>
+              )}
+
+              <div className="flex flex-col items-center mb-4 pt-1">
                 <div className="w-14 h-14 rounded-full bg-purple-100 flex items-center justify-center mb-3">
                   <Layers className="h-7 w-7 text-purple-600" />
                 </div>
                 <p className="text-xl font-semibold text-purple-700 mb-1">Review Observation Unit</p>
                 <p className="text-sm text-muted-foreground text-center">
-                  The observation unit defines what each row in your table represents.
-                  Review and optionally edit before schema generation.
+                  {isMidRunReview
+                    ? 'Review or edit the observation unit. The pipeline keeps running until you save a change.'
+                    : isPostRunReview
+                      ? 'Edit the observation unit to rediscover the schema with your changes.'
+                      : 'The observation unit defines what each row in your table represents. Review and optionally edit before schema generation.'}
                 </p>
               </div>
 
@@ -1080,7 +1262,7 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
                   <Input
                     id="obs-name"
                     value={editName}
-                    onChange={(e) => { setEditName(e.target.value); setObsUnitEdited(true); }}
+                    onChange={(e) => { setEditName(e.target.value); setObsUnitEdited(true); setReviewSaveError(''); }}
                     placeholder="e.g., Model, Protein, Study"
                   />
                 </div>
@@ -1091,13 +1273,13 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
                   <Textarea
                     id="obs-definition"
                     value={editDefinition}
-                    onChange={(e) => { setEditDefinition(e.target.value); setObsUnitEdited(true); }}
+                    onChange={(e) => { setEditDefinition(e.target.value); setObsUnitEdited(true); setReviewSaveError(''); }}
                     placeholder="Describe what constitutes a single row..."
                     rows={3}
                     className="resize-none"
                   />
                   <p className="text-xs text-muted-foreground">
-                    {editDefinition.length}/500 characters
+                    {trimmedDefinition.length}/500 characters (minimum 10)
                   </p>
                 </div>
 
@@ -1134,45 +1316,44 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
                 </div>
               </div>
 
-              {/* Action Buttons */}
+              {/* Action Buttons — always mounted; only enabled state and label change */}
+              {reviewSaveError && (
+                <Alert variant="destructive" className="mt-4">
+                  <AlertDescription>{reviewSaveError}</AlertDescription>
+                </Alert>
+              )}
               <div className="flex flex-col gap-2 mt-5">
                 <Button
                   size="lg"
                   onClick={() => handleResume(false)}
-                  disabled={isResuming || !editName.trim() || !editDefinition.trim()}
+                  disabled={!primaryEnabled}
                   className="w-full"
                 >
                   {isResuming ? (
                     <>
                       <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      Resuming...
+                      {(isMidRunReview || isPostRunReview) && hasChanges ? 'Rediscovering...' : 'Resuming...'}
                     </>
                   ) : (
                     <>
                       <ArrowRight className="h-4 w-4 mr-2" />
-                      {obsUnitEdited ? 'Save & Continue to Schema Generation' : 'Continue to Schema Generation'}
+                      {primaryLabel}
                     </>
                   )}
                 </Button>
-                {obsUnitEdited && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      // Reset edits to original values
-                      setEditName(reviewObsUnit.name);
-                      setEditDefinition(reviewObsUnit.definition);
-                      setEditExamples(reviewObsUnit.example_names || []);
-                      setObsUnitEdited(false);
-                    }}
-                    className="text-muted-foreground"
-                  >
-                    Discard changes
-                  </Button>
-                )}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleDiscardObsUnitChanges}
+                  disabled={!discardEnabled}
+                  className="text-muted-foreground"
+                >
+                  Discard changes
+                </Button>
               </div>
             </div>
-          )}
+            );
+          })()}
         </CardContent>
       </Card>
 
@@ -1181,10 +1362,18 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
         <Card className="bg-purple-50/50 border-purple-200">
           <CardContent className="py-3 px-4 flex items-center justify-between">
             <div className="flex items-center gap-2 min-w-0">
-              <Layers className="h-4 w-4 text-purple-600 shrink-0" />
+              <Layers className="h-4 w-4 text-purple-600 shrink-0 mt-0.5" />
               <div className="min-w-0">
                 <span className="text-xs text-purple-600 font-medium">Observation Unit</span>
-                <p className="text-sm font-semibold text-purple-900 truncate">{editName || reviewObsUnit.name}</p>
+                <p className="text-sm font-semibold text-purple-900">{editName || reviewObsUnit.name}</p>
+                <p className="text-xs text-purple-800/80 mt-0.5 line-clamp-2">
+                  {editDefinition || reviewObsUnit.definition}
+                </p>
+                {(editExamples.length > 0 || (reviewObsUnit.example_names?.length ?? 0) > 0) && (
+                  <p className="text-xs text-purple-700/70 mt-0.5 truncate">
+                    Examples: {(editExamples.length > 0 ? editExamples : reviewObsUnit.example_names || []).join(', ')}
+                  </p>
+                )}
               </div>
             </div>
             <Button
@@ -1193,15 +1382,9 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
               className="text-purple-600 hover:text-purple-800 hover:bg-purple-100 shrink-0"
               disabled={isResuming}
               onClick={async () => {
-                // If pipeline is running, stop it first
-                if (isProcessing) {
-                  try {
-                    await schematiqAPI.stop(sessionId);
-                    addLog('info', 'Stopped pipeline to edit observation unit');
-                  } catch (e) {
-                    // Ignore stop errors — might already be stopped
-                  }
-                }
+                // Enter edit mode without stopping the pipeline — stop only happens on confirmed change
+                setProcessingStateBeforeEdit(processingState);
+                setReviewEntryMode(isProcessing ? 'mid_run' : 'post_run');
                 // Load fresh observation unit from session
                 try {
                   const session = await loadAPI.getSession(sessionId);
@@ -1216,9 +1399,17 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
                     setEditDefinition(obsData.definition);
                     setEditExamples(obsData.example_names || []);
                     setObsUnitEdited(false);
+                    setEditBaseline(obsData);
                   }
                 } catch (e) {
                   // Fall back to the cached observation unit data
+                  if (reviewObsUnit) {
+                    setEditBaseline({
+                      name: reviewObsUnit.name,
+                      definition: reviewObsUnit.definition,
+                      example_names: reviewObsUnit.example_names || [],
+                    });
+                  }
                 }
                 setProcessingState('observation_unit_review');
               }}
@@ -1282,37 +1473,37 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
         {(() => {
           const schemaIsComplete = schemaProgress.isComplete || processingState === 'completed';
           return (
-            <Card className={`transition-all ${processingState === 'schema' ? 'border-primary border-2 shadow-md' : ''}`}>
+            <Card className={`transition-all ${phaseDisplayState === 'schema' || phaseDisplayState === 'starting' ? 'border-primary border-2 shadow-md' : ''}`}>
               <CardContent className="pt-4 pb-4">
                 <div className="flex items-center justify-between mb-3">
                   <span className="font-medium flex items-center gap-2">
                     {schemaIsComplete ? (
                       <CheckCircle2 className="h-5 w-5 text-green-500" />
-                    ) : processingState === 'schema' ? (
+                    ) : phaseDisplayState === 'schema' || phaseDisplayState === 'starting' ? (
                       <Loader2 className="h-5 w-5 animate-spin text-primary" />
                     ) : (
                       <div className="h-5 w-5 rounded-full border-2 border-muted-foreground/30" />
                     )}
                     Phase 1: Schema
                   </span>
-                  <Badge variant={schemaIsComplete ? 'success' : processingState === 'schema' ? 'default' : 'secondary'}>
+                  <Badge variant={schemaIsComplete ? 'success' : phaseDisplayState === 'schema' || phaseDisplayState === 'starting' ? 'default' : 'secondary'}>
                     {schemaIsComplete
                       ? 'Complete'
-                      : processingState === 'schema'
+                      : phaseDisplayState === 'schema' || phaseDisplayState === 'starting'
                         ? 'In Progress'
                         : 'Pending'}
                   </Badge>
                 </div>
                 <Progress
-                  value={schemaIsComplete ? 100 : (processingState === 'schema' ? Math.max(10, (schemaProgress.iteration / schemaProgress.maxIterations) * 100) : 0)}
-                  className={`h-2 ${processingState === 'schema' && !schemaIsComplete ? 'animate-pulse' : ''}`}
+                  value={schemaIsComplete ? 100 : (phaseDisplayState === 'schema' || phaseDisplayState === 'starting' ? Math.max(10, (schemaProgress.iteration / schemaProgress.maxIterations) * 100) : 0)}
+                  className={`h-2 ${(phaseDisplayState === 'schema' || phaseDisplayState === 'starting') && !schemaIsComplete ? 'animate-pulse' : ''}`}
                 />
                 <p className="text-xs text-muted-foreground mt-2">
                   {schemaIsComplete
                     ? `${schemaProgress.columnsDiscovered} columns discovered`
-                    : processingState === 'schema' && schemaProgress.iteration > 0
+                    : (phaseDisplayState === 'schema' || phaseDisplayState === 'starting') && schemaProgress.iteration > 0
                       ? `Iteration ${schemaProgress.iteration}/${schemaProgress.maxIterations}`
-                      : processingState === 'schema'
+                      : phaseDisplayState === 'schema' || phaseDisplayState === 'starting'
                         ? 'Analyzing documents...'
                         : 'Waiting to start'}
                 </p>
@@ -1329,7 +1520,7 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
               extractionProgress.totalDocs > 0 &&
               extractionProgress.processedDocs >= extractionProgress.totalDocs);
           return (
-            <Card className={`transition-all ${!schemaOnly && processingState === 'extraction' ? 'border-primary border-2 shadow-md' : ''} ${schemaOnly ? 'opacity-60' : ''}`}>
+            <Card className={`transition-all ${!schemaOnly && phaseDisplayState === 'extraction' ? 'border-primary border-2 shadow-md' : ''} ${schemaOnly ? 'opacity-60' : ''}`}>
               <CardContent className="pt-4 pb-4">
                 <div className="flex items-center justify-between mb-3">
                   <span className="font-medium flex items-center gap-2">
@@ -1339,19 +1530,19 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
                       </div>
                     ) : extractionIsComplete ? (
                       <CheckCircle2 className="h-5 w-5 text-green-500" />
-                    ) : processingState === 'extraction' ? (
+                    ) : phaseDisplayState === 'extraction' ? (
                       <Loader2 className="h-5 w-5 animate-spin text-primary" />
                     ) : (
                       <div className="h-5 w-5 rounded-full border-2 border-muted-foreground/30" />
                     )}
                     Phase 2: Extraction
                   </span>
-                  <Badge variant={schemaOnly ? 'secondary' : extractionIsComplete ? 'success' : processingState === 'extraction' ? 'default' : 'secondary'}>
+                  <Badge variant={schemaOnly ? 'secondary' : extractionIsComplete ? 'success' : phaseDisplayState === 'extraction' ? 'default' : 'secondary'}>
                     {schemaOnly
                       ? 'Skipped'
                       : extractionIsComplete
                         ? 'Complete'
-                        : processingState === 'extraction'
+                        : phaseDisplayState === 'extraction'
                           ? 'In Progress'
                           : 'Pending'}
                   </Badge>
@@ -1363,17 +1554,17 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
                       ? 100
                       : extractionProgress.totalDocs > 0
                         ? (extractionProgress.processedDocs / extractionProgress.totalDocs) * 100
-                        : processingState === 'extraction' ? 10 : 0}
-                  className={`h-2 ${!schemaOnly && processingState === 'extraction' && !extractionIsComplete ? 'animate-pulse' : ''}`}
+                        : phaseDisplayState === 'extraction' ? 10 : 0}
+                  className={`h-2 ${!schemaOnly && phaseDisplayState === 'extraction' && !extractionIsComplete ? 'animate-pulse' : ''}`}
                 />
                 <p className="text-xs text-muted-foreground mt-2">
                   {schemaOnly
                     ? 'Extraction was skipped'
                     : extractionIsComplete
                       ? `${extractionProgress.totalDocs} documents processed`
-                      : processingState === 'extraction' && extractionProgress.totalDocs > 0
+                      : phaseDisplayState === 'extraction' && extractionProgress.totalDocs > 0
                         ? `${extractionProgress.processedDocs}/${extractionProgress.totalDocs} documents`
-                        : processingState === 'extraction'
+                        : phaseDisplayState === 'extraction'
                           ? 'Starting extraction...'
                           : 'Waiting for schema'}
                 </p>

--- a/frontend/src/pages/Visualize.tsx
+++ b/frontend/src/pages/Visualize.tsx
@@ -269,6 +269,8 @@ const Visualize = () => {
               queryClient.invalidateQueries(['session', sessionId]);
               queryClient.invalidateQueries({ queryKey: ['unitData', sessionId], exact: false });
               queryClient.invalidateQueries(['documentList', sessionId]);
+              // Re-read units from disk as each row lands (unit list API is file-based)
+              refreshUnits();
               setTimeout(() => {
                 setNewlyAddedRows(prev => {
                   const newSet = new Set(Array.from(prev));
@@ -574,6 +576,9 @@ const Visualize = () => {
   // This allows showing the "By Unit" toggle even when the API doesn't detect unit names
   // Check for _unit_name metadata field OR columns with "unit"/"observation" in the name
   const hasUnitColumn = useMemo(() => {
+    // During live extraction, row keys in streamingCells are observation-unit instance names
+    if (streamingCells.size > 0) return true;
+
     if (!dataResponse?.rows?.length) return false;
 
     // Check for _unit_name field (observation unit metadata) - same as DataTable's hasObservationUnits
@@ -586,7 +591,7 @@ const Visualize = () => {
       header.toLowerCase().includes('unit') ||
       header.toLowerCase().includes('observation')
     );
-  }, [dataResponse]);
+  }, [dataResponse, streamingCells]);
 
   // WebSocket effect for re-extraction and document processing
   // Uses wsRef to maintain connection across effect re-runs
@@ -644,6 +649,8 @@ const Visualize = () => {
                 queryClient.invalidateQueries(['session', sessionId]);
                 queryClient.invalidateQueries({ queryKey: ['unitData', sessionId], exact: false });
               queryClient.invalidateQueries(['documentList', sessionId]);
+                // Re-read units from disk as each row lands (unit list API is file-based)
+                refreshUnits();
                 setTimeout(() => {
                   setNewlyAddedRows(prev => {
                     const newSet = new Set(Array.from(prev));
@@ -854,9 +861,13 @@ const Visualize = () => {
     };
 
     // Determine if we should connect
+    const isSchematiqSessionActive =
+      mode === 'schematiq' &&
+      (session?.status === 'processing' || session?.status === 'observation_unit_review');
+
     const shouldConnect = forceWebSocketConnect ||
       session?.status === 'processing_documents' ||
-      (mode === 'schematiq' && session?.status === 'processing');
+      isSchematiqSessionActive;
 
     if (shouldConnect) {
       connectWebSocket();
@@ -874,8 +885,11 @@ const Visualize = () => {
 
   // Separate effect to close WebSocket when no longer needed
   useEffect(() => {
-    if (!forceWebSocketConnect && session?.status !== 'processing_documents' &&
-        !(mode === 'schematiq' && session?.status === 'processing')) {
+    const isSchematiqSessionActive =
+      mode === 'schematiq' &&
+      (session?.status === 'processing' || session?.status === 'observation_unit_review');
+
+    if (!forceWebSocketConnect && session?.status !== 'processing_documents' && !isSchematiqSessionActive) {
       // No longer need WebSocket, close it
       if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
         debug.log('Closing WebSocket - no longer needed');
@@ -1710,12 +1724,13 @@ const Visualize = () => {
 
         {/* ScheMatiQ Monitor Tab */}
         {mode === 'schematiq' && (
-          <TabsContent value="monitor" className="mt-4">
+          <TabsContent value="monitor" forceMount className="mt-4 data-[state=inactive]:hidden">
             <ScheMatiQMonitor
               sessionId={sessionId}
               autoStarted={autoStartState.autoStarted}
               initialCapacityMessage={autoStartState.initialCapacityMessage}
               onExtractionStarted={handleReextractionStarted}
+              onResumeStarted={() => setForceWebSocketConnect(true)}
             />
           </TabsContent>
         )}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -140,7 +140,7 @@ export interface VisualizationSession {
   id: string;
   type: 'load' | 'schematiq';
   status: 'created' | 'processing' | 'schema_ready' | 'completed' | 'error' | 'stopped' |
-          'schema_extracted' | 'documents_uploaded' | 'processing_documents';
+          'schema_extracted' | 'documents_uploaded' | 'processing_documents' | 'observation_unit_review';
   metadata: SessionMetadata;
   schema_query?: string;
   columns: ColumnInfo[];

--- a/frontend/src/utils/apiHelpers.ts
+++ b/frontend/src/utils/apiHelpers.ts
@@ -3,18 +3,40 @@
  */
 
 /**
+ * Normalize FastAPI/Pydantic error `detail` to a display string.
+ */
+export const formatApiErrorDetail = (detail: unknown): string | null => {
+  if (typeof detail === 'string') {
+    return detail;
+  }
+  if (Array.isArray(detail) && detail.length > 0) {
+    return detail
+      .map((err: { msg?: string }) => (typeof err?.msg === 'string' ? err.msg : String(err)))
+      .join('; ');
+  }
+  if (detail && typeof detail === 'object' && 'msg' in detail) {
+    const msg = (detail as { msg?: string }).msg;
+    if (typeof msg === 'string') {
+      return msg;
+    }
+  }
+  return null;
+};
+
+/**
  * Extract error message from API response
  */
 export const extractApiErrorMessage = (error: unknown, fallbackMessage: string): string => {
-  if (error && typeof error === 'object' && 'response' in error) {
-    const apiError = error as any;
-    if (apiError?.response?.data?.detail) {
-      return apiError.response.data.detail;
-    }
+  const detail = (error as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail;
+  const formatted = formatApiErrorDetail(detail);
+  if (formatted) {
+    return formatted;
   }
   if (error && typeof error === 'object' && 'message' in error) {
     const errorWithMessage = error as { message: string };
-    return errorWithMessage.message;
+    if (errorWithMessage.message) {
+      return errorWithMessage.message;
+    }
   }
   return fallbackMessage;
 };

--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -1319,6 +1319,11 @@ class PaperProcessor:
         Returns:
             UnitParseResult from the parser
         """
+        if self._check_stop_requested():
+            from .unit_parser import UnitParseResult
+
+            return UnitParseResult(success=False, error="Stop requested")
+
         # Build the prompt for unit identification
         example_names_str = (
             ", ".join(observation_unit.example_names or []) or "None provided"
@@ -1419,6 +1424,9 @@ class PaperProcessor:
         last_format = None
 
         for attempt in range(max_retries + 1):
+            if self._check_stop_requested():
+                return UnitIdentificationResult(units=[], skip_reason="Stop requested")
+
             try:
                 is_retry = attempt > 0
                 if is_retry:
@@ -1519,6 +1527,9 @@ class PaperProcessor:
                 # Parse failed - record error for retry
                 last_error = result.error
                 last_format = result.detected_format
+
+                if result.error == "Stop requested":
+                    return UnitIdentificationResult(units=[], skip_reason="Stop requested")
 
                 if result.detected_format == "value_extraction":
                     logging.warning(


### PR DESCRIPTION
## Summary
- Fix `/schematiq/resume` to call `resume_qbsd` so the pipeline actually continues after the observation-unit review step.
- **Edit & Rediscover** no longer stops the run on open; saving with changes stops the pipeline, resets schema/data artifacts, and restarts discovery with the updated observation unit via synchronous `prepare_resume()`.
- Review panel UX: fixed action buttons (no layout jump), context-aware primary labels, top-left close for mid/post-run edit, and phase cards keep showing live progress while the review panel is open.
- Safer API error display (Pydantic validation arrays), live unit list refresh during extraction, and honor stop requests during unit identification (no retries after stop).

## Test plan
- [ ] Start a run with **Review before schema generation**; confirm review panel labels/buttons; continue without edit and with edit.
- [ ] During extraction, open **Edit & Rediscover**, close without saving — pipeline keeps running; phase cards stay active.
- [ ] Mid-run **Save & Rediscover** with a definition change — logs show stop → artifact reset → fresh schema discovery → re-extraction; no concurrency slot error.
- [ ] Post-completion **Edit & Rediscover** — primary label is "Save & Rediscover"; full rediscovery completes.
- [ ] Confirm Units column populates during live extraction (not only at end).
- [ ] Save failure shows a readable error in the review panel (no React crash).