### PR TITLE
fix: preserve ScheMatiQ Monitor logs when switching tabs

### DIFF
--- a/frontend/src/pages/Visualize.tsx
+++ b/frontend/src/pages/Visualize.tsx
@@ -1710,7 +1710,7 @@ const Visualize = () => {
 
         {/* ScheMatiQ Monitor Tab */}
         {mode === 'schematiq' && (
-          <TabsContent value="monitor" className="mt-4">
+          <TabsContent value="monitor" forceMount className="mt-4 data-[state=inactive]:hidden">
             <ScheMatiQMonitor
               sessionId={sessionId}
               autoStarted={autoStartState.autoStarted}


### PR DESCRIPTION
The Monitor's log list lives in component-local useState. Radix
TabsContent unmounts inactive tabs by default, so leaving the Monitor
tab during a run and returning remounted the component and wiped all
logs.

Add forceMount to the Monitor TabsContent so it stays mounted and keeps
its log state, with data-[state=inactive]:hidden to keep it hidden while
another tab is active.
