### PR TITLE
fix: guard re-extraction poll when sessionId is undefined

### DIFF
--- a/frontend/src/pages/Visualize.tsx
+++ b/frontend/src/pages/Visualize.tsx
@@ -906,7 +906,7 @@ const Visualize = () => {
   // forever. While an operation is active, poll its status directly and clear
   // the same state the WS handler would, so the bar always resolves.
   useEffect(() => {
-    if (!activeReextractionId) return;
+    if (!sessionId || !activeReextractionId) return;
 
     let cancelled = false;
     let intervalId: ReturnType<typeof setInterval> | null = null;


### PR DESCRIPTION
## Summary
- Fixes a production build failure (`TS2345`) introduced in #152 where `sessionId` from `useParams()` is `string | undefined` but `getReextractionStatus` requires `string`.
- Adds an early return guard in the re-extraction completion poll effect in `Visualize.tsx`, matching the pattern used by other effects on the page.

## Test plan
- [x] `cd frontend && npm run build` completes without TypeScript errors
- [ ] Re-extraction progress bar still clears on completion when WebSocket is connected
- [ ] Re-extraction progress bar still clears via polling fallback when WebSocket drops mid-run


Made with [Cursor](https://cursor.com)