### PR TITLE
Fix monitor spinner not stopping when Stop is clicked

### DIFF
--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -118,6 +118,28 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
             self.stop_flags[session_id] = True
 
         logger.info("Stop requested for session %s", session_id)
+
+        # Emit an immediate optimistic 'stopped' so the monitor leaves the spinner
+        # state right away. The pipeline can't cancel an in-flight LLM call mid-thread,
+        # so its own stop handler (_handle_stop_after_*) may be delayed by up to one
+        # long LLM call; without this the UI hangs on "Wrapping up...". The task's
+        # later 'stopped' event refines these counts with the final numbers.
+        try:
+            session_dir = self.work_dir / session_id
+            schema_saved = (session_dir / "discovered_schema.json").exists()
+            rows_saved = 0
+            data_file = session_dir / "extracted_data.jsonl"
+            if data_file.exists():
+                with open(data_file, 'r') as f:
+                    rows_saved = sum(1 for _ in f)
+            await self.broadcast_stopped(session_id, {
+                "schema_saved": schema_saved,
+                "data_rows_saved": rows_saved,
+                "message": "Stop requested",
+            })
+        except Exception as e:
+            logger.warning("Could not send optimistic stopped broadcast for %s: %s", session_id, e)
+
         return {"accepted": True, "message": "Stop signal sent"}
 
     async def stop_execution(self, session_id: str) -> Dict[str, Any]:

--- a/backend/test_request_stop_broadcast.py
+++ b/backend/test_request_stop_broadcast.py
@@ -1,0 +1,159 @@
+"""Unit tests for ScheMatiQRunner.request_stop optimistic 'stopped' broadcast.
+
+These verify the fix for the bug where the monitor stayed in the
+"Wrapping up current operation..." spinner state after Stop was clicked:
+request_stop must now emit an immediate 'stopped' broadcast (with current
+schema/row counts read from disk) so the UI leaves the spinner state right
+away, instead of waiting for the pipeline task to reach its next checkpoint.
+
+The runner module pulls in a heavy dependency chain (fastapi, the schematiq
+library, sentence-transformers, ...) that is not needed to exercise this
+logic, so those modules are stubbed in sys.modules before import. Run with:
+
+    pytest backend/test_request_stop_broadcast.py
+"""
+import sys
+import types
+import threading
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ──────────────────────────────────────────────────────────────────
+# Stub the heavy / environment-specific imports so we can import the
+# ScheMatiQRunner class without installing the full backend stack.
+# ──────────────────────────────────────────────────────────────────
+def _install_import_stubs():
+    class _AutoModule(types.ModuleType):
+        """Module whose every attribute access returns a fresh MagicMock.
+
+        Lets arbitrary `from schematiq.core.x import Y` succeed without us having
+        to enumerate every imported name the backend pulls at import time.
+        """
+        def __getattr__(self, name):
+            if name in ("__path__", "__all__", "__spec__", "__loader__"):
+                raise AttributeError(name)
+            val = MagicMock(name=f"{self.__name__}.{name}")
+            setattr(self, name, val)
+            return val
+
+    def stub(name, is_pkg=False, auto=False):
+        if name not in sys.modules:
+            mod = _AutoModule(name) if auto else types.ModuleType(name)
+            if is_pkg:
+                mod.__path__ = []  # mark as a package so submodule imports resolve
+            sys.modules[name] = mod
+        return sys.modules[name]
+
+    # schematiq library surface used at import time across the backend.
+    core = stub("schematiq", is_pkg=True, auto=True)
+    stub("schematiq.core", is_pkg=True, auto=True)
+    stub("schematiq.core.model_specs", auto=True)
+    stub("schematiq.core.retrievers", auto=True)
+    stub("schematiq.core.schema", auto=True)
+    stub("schematiq.core.llm_backends", auto=True)
+    stub("schematiq.core.cost_estimator", auto=True)
+    # Exception types must be real classes (used in `except`/`raise`).
+    tracker_mod = stub("schematiq.core.llm_call_tracker", auto=True)
+    tracker_mod.QuotaExceededError = type("QuotaExceededError", (Exception,), {})
+    core.ObservationUnitDiscoveryError = type("ObservationUnitDiscoveryError", (Exception,), {})
+
+    # value_extraction subpackage (pulled in via the pipeline package __init__).
+    stub("schematiq.value_extraction", is_pkg=True, auto=True)
+    stub("schematiq.value_extraction.main", auto=True)
+    stub("schematiq.value_extraction.core", is_pkg=True, auto=True)
+    stub("schematiq.value_extraction.core.table_builder", auto=True)
+
+
+@pytest.fixture(scope="module")
+def runner_cls():
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    _install_import_stubs()
+    try:
+        from app.services.schematiq_runner import ScheMatiQRunner
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Could not import ScheMatiQRunner in this environment: {exc}")
+    return ScheMatiQRunner
+
+
+def _make_runner(runner_cls, tmp_path):
+    """Build a runner without running __init__ (avoids real WS/session managers)."""
+    runner = runner_cls.__new__(runner_cls)
+    runner.work_dir = Path(tmp_path)
+    runner.running_sessions = {}
+    runner.stop_flags = {}
+    runner._state_lock = threading.Lock()
+    runner.broadcast_stopped = AsyncMock()
+    return runner
+
+
+# ──────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_no_running_session_does_not_broadcast(runner_cls, tmp_path):
+    runner = _make_runner(runner_cls, tmp_path)
+
+    result = await runner.request_stop("missing-session")
+
+    assert result["accepted"] is False
+    runner.broadcast_stopped.assert_not_called()
+    assert "missing-session" not in runner.stop_flags
+
+
+@pytest.mark.asyncio
+async def test_running_session_sets_flag_and_broadcasts_immediately(runner_cls, tmp_path):
+    runner = _make_runner(runner_cls, tmp_path)
+    session_id = "sess-1"
+    runner.running_sessions[session_id] = MagicMock()  # pretend a task is running
+
+    result = await runner.request_stop(session_id)
+
+    assert result["accepted"] is True
+    assert runner.stop_flags[session_id] is True
+    # The optimistic broadcast must happen during request_stop, not later.
+    runner.broadcast_stopped.assert_awaited_once()
+    sid_arg, payload = runner.broadcast_stopped.await_args.args
+    assert sid_arg == session_id
+    # No artifacts on disk yet → conservative defaults.
+    assert payload["schema_saved"] is False
+    assert payload["data_rows_saved"] == 0
+
+
+@pytest.mark.asyncio
+async def test_broadcast_reflects_partial_artifacts_on_disk(runner_cls, tmp_path):
+    runner = _make_runner(runner_cls, tmp_path)
+    session_id = "sess-2"
+    runner.running_sessions[session_id] = MagicMock()
+
+    # Simulate a partially-completed run: schema saved + 3 extracted rows.
+    session_dir = Path(tmp_path) / session_id
+    session_dir.mkdir(parents=True)
+    (session_dir / "discovered_schema.json").write_text('{"schema": []}')
+    (session_dir / "extracted_data.jsonl").write_text(
+        '{"row": 1}\n{"row": 2}\n{"row": 3}\n'
+    )
+
+    await runner.request_stop(session_id)
+
+    runner.broadcast_stopped.assert_awaited_once()
+    _sid, payload = runner.broadcast_stopped.await_args.args
+    assert payload["schema_saved"] is True
+    assert payload["data_rows_saved"] == 3
+
+
+@pytest.mark.asyncio
+async def test_broadcast_failure_does_not_break_stop(runner_cls, tmp_path):
+    """A failed broadcast must not prevent the stop flag from being honored."""
+    runner = _make_runner(runner_cls, tmp_path)
+    session_id = "sess-3"
+    runner.running_sessions[session_id] = MagicMock()
+    runner.broadcast_stopped = AsyncMock(side_effect=RuntimeError("ws down"))
+
+    result = await runner.request_stop(session_id)
+
+    assert result["accepted"] is True
+    assert runner.stop_flags[session_id] is True

--- a/frontend/src/components/ScheMatiQMonitor/ScheMatiQMonitor.tsx
+++ b/frontend/src/components/ScheMatiQMonitor/ScheMatiQMonitor.tsx
@@ -151,6 +151,10 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
 
   // Stop button loading state - shows immediate feedback when user clicks stop
   const [isStopping, setIsStopping] = useState(false);
+  // Tracks that the user requested a stop. Read inside the WebSocket handler
+  // (which closes over stale state) to ignore late progress events that would
+  // otherwise revive the spinner after we've moved to the stopped state.
+  const stopRequestedRef = useRef(false);
 
   // Observation unit review state
   const [reviewObsUnit, setReviewObsUnit] = useState<ObservationUnitReadyData | null>(null);
@@ -282,6 +286,21 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
   // WebSocket connection for real-time updates
   useEffect(() => {
     const handleMessage = async (message: WebSocketMessage) => {
+      // Once the user has requested a stop, the pipeline keeps emitting progress
+      // events while it winds down (it can't cancel an in-flight LLM call mid-thread).
+      // Those late events would flip processingState back to 'schema'/'extraction'
+      // and restart the spinner. Drop progress-moving events; let only terminal/log
+      // events through so the stopped/completed/error state can still settle.
+      if (stopRequestedRef.current) {
+        const allowedWhileStopping = new Set([
+          'stopped', 'reextraction_stopped', 'completed', 'reextraction_completed',
+          'reextraction_failed', 'error', 'log', 'connected', 'disconnected', 'reconnecting',
+        ]);
+        if (!allowedWhileStopping.has(message.type)) {
+          return;
+        }
+      }
+
       if (message.type === 'connected') {
         setConnectionStatus('connected');
         // Don't log — connection status is shown by the indicator
@@ -546,6 +565,7 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
         const data = message.data as { processed_documents?: number; total_documents?: number };
         setActiveReextractionId(null);
         setIsStopping(false);
+        stopRequestedRef.current = false;
         setSchemaOnly(false);
         setProcessingState('completed');
         const processed = data?.processed_documents ?? 0;
@@ -575,6 +595,7 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
         // THEN update processing state (after data is available)
         setProcessingState('stopped');
         setIsStopping(false);  // Reset stop button state
+        stopRequestedRef.current = false;  // pipeline has fully stopped
         setStoppedInfo({
           schemaSaved: schemaSaved,
           dataRowsSaved: rows
@@ -799,6 +820,7 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
     queryClient.removeQueries(llmStatsCacheKey, { exact: true });
     startTimeRef.current = Date.now();
     lastLoggedPhaseRef.current = null;
+    stopRequestedRef.current = false;
 
     // Reset progress
     setSchemaProgress({
@@ -842,6 +864,7 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
 
   const handleStop = async () => {
     setIsStopping(true);
+    stopRequestedRef.current = true;
     try {
       if (activeReextractionId) {
         await schemaAPI.stopReextraction(sessionId, activeReextractionId);
@@ -849,14 +872,23 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
         // UI updates on reextraction_stopped WebSocket (or status poll fallback)
       } else {
         await schematiqAPI.stop(sessionId);
-        setProcessingState('stopped');
-        setIsStopping(false);
         addLog('warning', 'Stop requested — processing will stop at the next checkpoint.');
+        // Move to stopped immediately. Seed stoppedInfo with what we know NOW so the
+        // hero card shows a final message instead of the "Wrapping up..." spinner,
+        // which would otherwise hang if the authoritative 'stopped' WS event is
+        // delayed by an in-flight LLM call. The 'stopped' event refines these numbers.
+        setProcessingState('stopped');
+        setStoppedInfo(prev => prev ?? {
+          schemaSaved: schemaProgress.isComplete,
+          dataRowsSaved: extractionProgress.processedDocs,
+        });
+        setIsStopping(false);
       }
     } catch (error: unknown) {
       const message = extractApiErrorMessage(error, 'Failed to stop');
       addLog('error', message);
       setIsStopping(false);
+      stopRequestedRef.current = false;  // allow retry
     }
   };
 
@@ -994,6 +1026,7 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
       setCurrentStepMessage('Resuming pipeline...');
       startTimeRef.current = Date.now();
       lastLoggedPhaseRef.current = null;
+      stopRequestedRef.current = false;
 
       // Reset progress for the new run
       setSchemaProgress({


### PR DESCRIPTION
The monitor stayed in the 'Wrapping up current operation...' spinner state after the user clicked Stop, even though the backend pipeline had stopped.

Two independent causes:

1. Frontend: handleStop set processingState='stopped' but left stoppedInfo null, which renders the spinner fallback. stoppedInfo was only populated by the 'stopped' WS event, which can be delayed by an in-flight LLM call. Late 'progress' events also flipped processingState back to schema/extraction, restarting the spinner.

2. Backend: request_stop only set the stop flag and returned; the authoritative 'stopped' broadcast was sent only once the task reached its next checkpoint, which can be one long LLM call away.

Fixes:
- Add stopRequestedRef; drop progress-moving WS events after a stop request, letting only terminal/log events settle the final state.
- Seed stoppedInfo in handleStop so the hero card shows a final message instead of the spinner; the 'stopped' event later refines the counts.
- request_stop now emits an immediate optimistic 'stopped' broadcast with current schema/row counts; the task's later event refines them.