### PR TITLE
fix: update stale QueryDiscovery references to ScheMatiQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Both services deploy on **Railway** using **Dockerfile-based** builds:
 
 ## Contributing
 
-Contributions are welcome! Please open an issue or pull request on [GitHub](https://github.com/shaharl6000/QueryDiscovery/issues).
+Contributions are welcome! Please open an issue or pull request on [GitHub](https://github.com/shaharl6000/ScheMatiQ/issues).
 
 ## Citation
 

--- a/backend/app/services/uniprot_lookup.py
+++ b/backend/app/services/uniprot_lookup.py
@@ -251,7 +251,7 @@ def query_uniprot(query_str, fields=UNIPROT_FIELDS, size=5):
     url = f"{UNIPROT_SEARCH_URL}?{urllib.parse.urlencode(params)}"
 
     req = urllib.request.Request(url)
-    req.add_header("User-Agent", "ScheMatiQ-Enrichment/1.0 (+https://github.com/shaharl6000/QueryDiscovery)")
+    req.add_header("User-Agent", "ScheMatiQ-Enrichment/1.0 (+https://github.com/shaharl6000/ScheMatiQ)")
 
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:


### PR DESCRIPTION
README Contributing link and the UniProt User-Agent header still pointed at the old `QueryDiscovery` repo name. Both updated to `ScheMatiQ`.