### PR TITLE
chore: prune dead .gitignore entries + harden against stray artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,12 +59,6 @@ venv.bak/
 ehthumbs.db
 Thumbs.db
 
-# Data directories in src/
-src/abstracts/
-src/full_text/
-src/full_text_test/
-src/manually/
-
 # Logs
 *.log
 
@@ -86,15 +80,6 @@ cache/
 .env.development
 config/secrets.*
 /test/
-
-# Add visualization specific ignores (legacy paths)
-ScheMatiQ/visualization/frontend/build/
-ScheMatiQ/visualization/frontend/node_modules/
-
-# Backend data and session directories (legacy location)
-ScheMatiQ/visualization/backend/data/
-ScheMatiQ/visualization/backend/sessions/
-ScheMatiQ/visualization/backend/schematiq_work/
 
 # New structure ignores
 # Frontend
@@ -149,3 +134,10 @@ backend/test_*.py
 
 # Local evaluation scripts
 evaluate_schematiq.py
+
+# --- repo hygiene (prevent stray artifacts recurring) ---
+*.patch
+Untitled
+* copy.*
+*\ copy.*
+backend/debug


### PR DESCRIPTION
Drops dead old-layout ignore rules (src/*, ScheMatiQ/visualization/*) and adds hygiene rules. Research-data entries deliberately left for a local pass.