### PR TITLE
refactor: use module loggers instead of print() in backend

### DIFF
--- a/backend/app/api/routes/schematiq.py
+++ b/backend/app/api/routes/schematiq.py
@@ -1,5 +1,6 @@
 """ScheMatiQ API endpoints."""
 
+import logging
 import uuid
 import asyncio
 import csv
@@ -23,6 +24,7 @@ from app.services.file_parser import format_column_header
 
 from schematiq.core.cost_estimator import estimate_from_config
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 # Create shared ScheMatiQ runner instance with shared managers
 from app.services import pubmed_enrichment_service, uniprot_enrichment_service
@@ -112,12 +114,12 @@ async def configure_schematiq(config: ScheMatiQConfig):
     """Configure a new ScheMatiQ session."""
     from app.core.config import DEVELOPER_MODE
     try:
-        print(f"DEBUG: Received ScheMatiQ config: {config}")
+        logger.debug(f"Received ScheMatiQ config: {config}")
         
         # Validate configuration
         validation = await schematiq_runner.validate_config(config)
         
-        print(f"DEBUG: Validation result: {validation}")
+        logger.debug(f"Validation result: {validation}")
         
         if not validation["is_valid"]:
             raise HTTPException(status_code=400, detail=validation["errors"])
@@ -145,7 +147,7 @@ async def configure_schematiq(config: ScheMatiQConfig):
         }
         
     except Exception as e:
-        print(f"DEBUG: Exception in configure_schematiq: {e}")
+        logger.error(f"Exception in configure_schematiq: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -548,7 +550,7 @@ async def list_document_directories():
                 break
 
         if research_data_path is None:
-            print(f"DEBUG: Could not find research/data directory. Tried: {[str(c) for c in candidates]}")
+            logger.warning(f"Could not find research/data directory. Tried: {[str(c) for c in candidates]}")
             return []
 
         directories = []
@@ -562,7 +564,7 @@ async def list_document_directories():
         return directories
 
     except Exception as e:
-        print(f"DEBUG: Error listing directories: {e}")
+        logger.error(f"Error listing directories: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -589,7 +591,7 @@ async def list_schema_files():
                 break
 
         if config_path is None:
-            print(f"DEBUG: Could not find research/experiments/configurations directory. Tried: {[str(c) for c in candidates]}")
+            logger.warning(f"Could not find research/experiments/configurations directory. Tried: {[str(c) for c in candidates]}")
             return []
 
         schema_files = []
@@ -630,7 +632,7 @@ async def list_schema_files():
         return schema_files
 
     except Exception as e:
-        print(f"DEBUG: Error listing schema files: {e}")
+        logger.error(f"Error listing schema files: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -770,7 +772,7 @@ async def export_complete_schematiq_data(
                         "value_extraction_backend": schematiq_config.get("value_extraction_backend")
                     }
             except Exception as e:
-                print(f"DEBUG: Could not load LLM configuration for complete export: {e}")
+                logger.warning(f"Could not load LLM configuration for complete export: {e}")
         
         # Prepare complete export data structure
         export_data = {
@@ -974,7 +976,7 @@ async def export_complete_schematiq_data(
             raise HTTPException(status_code=400, detail="Unsupported format. Use 'json' or 'zip'")
         
     except Exception as e:
-        print(f"DEBUG: Exception in export_complete_schematiq_data: {e}")
+        logger.error(f"Exception in export_complete_schematiq_data: {e}")
         import traceback
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -1139,7 +1141,7 @@ async def export_schematiq_schema_only(
                         "value_extraction_backend": schematiq_config.get("value_extraction_backend")
                     }
             except Exception as e:
-                print(f"DEBUG: Could not load LLM configuration: {e}")
+                logger.warning(f"Could not load LLM configuration: {e}")
 
         # Create ScheMatiQ schema export
         schema_columns = []
@@ -1200,5 +1202,5 @@ async def export_schematiq_schema_only(
         )
         
     except Exception as e:
-        print(f"DEBUG: Exception in export_schematiq_schema_only: {e}")
+        logger.error(f"Exception in export_schematiq_schema_only: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/storage/local_backend.py
+++ b/backend/app/storage/local_backend.py
@@ -1,6 +1,7 @@
 """Local filesystem storage backend implementation."""
 
 import json
+import logging
 import os
 import shutil
 from pathlib import Path
@@ -10,6 +11,8 @@ import aiofiles
 import aiofiles.os
 
 from app.storage.interface import StorageInterface, DatasetInfo, FileInfo, TemplateInfo, InitialSchemaInfo
+
+logger = logging.getLogger(__name__)
 
 
 class LocalStorageBackend(StorageInterface):
@@ -94,7 +97,7 @@ class LocalStorageBackend(StorageInterface):
                 await f.write(json.dumps(data, indent=2, default=str))
             return True
         except Exception as e:
-            print(f"Error saving session {session_id}: {e}")
+            logger.error(f"Error saving session {session_id}: {e}")
             return False
 
     async def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
@@ -107,7 +110,7 @@ class LocalStorageBackend(StorageInterface):
                 content = await f.read()
                 return json.loads(content)
         except Exception as e:
-            print(f"Error loading session {session_id}: {e}")
+            logger.error(f"Error loading session {session_id}: {e}")
             return None
 
     async def delete_session(self, session_id: str) -> bool:
@@ -130,7 +133,7 @@ class LocalStorageBackend(StorageInterface):
 
             return True
         except Exception as e:
-            print(f"Error deleting session {session_id}: {e}")
+            logger.error(f"Error deleting session {session_id}: {e}")
             return False
 
     async def list_sessions(self) -> List[str]:
@@ -139,7 +142,7 @@ class LocalStorageBackend(StorageInterface):
             session_files = list(self.sessions_dir.glob("*.json"))
             return [f.stem for f in session_files]
         except Exception as e:
-            print(f"Error listing sessions: {e}")
+            logger.error(f"Error listing sessions: {e}")
             return []
 
     # ================
@@ -165,7 +168,7 @@ class LocalStorageBackend(StorageInterface):
 
             return str(file_path)
         except Exception as e:
-            print(f"Error uploading file {bucket}/{path}: {e}")
+            logger.error(f"Error uploading file {bucket}/{path}: {e}")
             raise
 
     async def download_file(self, bucket: str, path: str) -> Optional[bytes]:
@@ -179,7 +182,7 @@ class LocalStorageBackend(StorageInterface):
             async with aiofiles.open(file_path, 'rb') as f:
                 return await f.read()
         except Exception as e:
-            print(f"Error downloading file {bucket}/{path}: {e}")
+            logger.error(f"Error downloading file {bucket}/{path}: {e}")
             return None
 
     async def delete_file(self, bucket: str, path: str) -> bool:
@@ -190,7 +193,7 @@ class LocalStorageBackend(StorageInterface):
                 file_path.unlink()
             return True
         except Exception as e:
-            print(f"Error deleting file {bucket}/{path}: {e}")
+            logger.error(f"Error deleting file {bucket}/{path}: {e}")
             return False
 
     async def file_exists(self, bucket: str, path: str) -> bool:
@@ -217,7 +220,7 @@ class LocalStorageBackend(StorageInterface):
                 return set()
             return {f.name for f in folder_path.iterdir() if f.is_file()}
         except Exception as e:
-            print(f"Error listing folder {bucket}/{folder}: {e}")
+            logger.error(f"Error listing folder {bucket}/{folder}: {e}")
             return set()
 
     async def list_files(self, bucket: str, prefix: str = "") -> List[str]:
@@ -241,7 +244,7 @@ class LocalStorageBackend(StorageInterface):
 
             return files
         except Exception as e:
-            print(f"Error listing files {bucket}/{prefix}: {e}")
+            logger.error(f"Error listing files {bucket}/{prefix}: {e}")
             return []
 
     # =====================
@@ -256,7 +259,7 @@ class LocalStorageBackend(StorageInterface):
                 shutil.rmtree(dir_path)
             return True
         except Exception as e:
-            print(f"Error deleting directory {bucket}/{prefix}: {e}")
+            logger.error(f"Error deleting directory {bucket}/{prefix}: {e}")
             return False
 
     # =================
@@ -271,7 +274,7 @@ class LocalStorageBackend(StorageInterface):
                 json.dump(data, f, indent=2, default=str)
             return True
         except Exception as e:
-            print(f"Error saving session {session_id}: {e}")
+            logger.error(f"Error saving session {session_id}: {e}")
             return False
 
     def get_session_sync(self, session_id: str) -> Optional[Dict[str, Any]]:
@@ -283,7 +286,7 @@ class LocalStorageBackend(StorageInterface):
             with open(session_file, 'r') as f:
                 return json.load(f)
         except Exception as e:
-            print(f"Error loading session {session_id}: {e}")
+            logger.error(f"Error loading session {session_id}: {e}")
             return None
 
     def upload_file_sync(
@@ -301,7 +304,7 @@ class LocalStorageBackend(StorageInterface):
                 f.write(data)
             return str(file_path)
         except Exception as e:
-            print(f"Error uploading file {bucket}/{path}: {e}")
+            logger.error(f"Error uploading file {bucket}/{path}: {e}")
             raise
 
     def download_file_sync(self, bucket: str, path: str) -> Optional[bytes]:
@@ -313,7 +316,7 @@ class LocalStorageBackend(StorageInterface):
             with open(file_path, 'rb') as f:
                 return f.read()
         except Exception as e:
-            print(f"Error downloading file {bucket}/{path}: {e}")
+            logger.error(f"Error downloading file {bucket}/{path}: {e}")
             return None
 
     def file_exists_sync(self, bucket: str, path: str) -> bool:
@@ -327,7 +330,7 @@ class LocalStorageBackend(StorageInterface):
             session_files = list(self.sessions_dir.glob("*.json"))
             return [f.stem for f in session_files]
         except Exception as e:
-            print(f"Error listing sessions: {e}")
+            logger.error(f"Error listing sessions: {e}")
             return []
 
     def get_local_path(self, bucket: str, path: str) -> Path:
@@ -365,7 +368,7 @@ class LocalStorageBackend(StorageInterface):
         """List available datasets from research/data directory."""
         datasets_path = self._resolve_datasets_dir()
         if not datasets_path or not datasets_path.exists():
-            print(f"Datasets directory not found: {self.datasets_dir}")
+            logger.warning(f"Datasets directory not found: {self.datasets_dir}")
             return []
 
         datasets = []
@@ -385,7 +388,7 @@ class LocalStorageBackend(StorageInterface):
                             description=f"Document collection: {item.name}"
                         ))
         except Exception as e:
-            print(f"Error listing datasets: {e}")
+            logger.error(f"Error listing datasets: {e}")
 
         return sorted(datasets, key=lambda d: d.name)
 
@@ -420,7 +423,7 @@ class LocalStorageBackend(StorageInterface):
                         content_type=content_type
                     ))
         except Exception as e:
-            print(f"Error listing dataset files: {e}")
+            logger.error(f"Error listing dataset files: {e}")
 
         return sorted(files, key=lambda f: f.name)
 
@@ -438,7 +441,7 @@ class LocalStorageBackend(StorageInterface):
             async with aiofiles.open(file_path, 'rb') as f:
                 return await f.read()
         except Exception as e:
-            print(f"Error downloading dataset file {dataset_name}/{filename}: {e}")
+            logger.error(f"Error downloading dataset file {dataset_name}/{filename}: {e}")
             return None
 
     async def download_dataset_to_local(self, dataset_name: str, local_dir: str) -> List[str]:
@@ -465,7 +468,7 @@ class LocalStorageBackend(StorageInterface):
                     shutil.copy2(file_path, dest_path)
                     created_files.append(str(dest_path))
         except Exception as e:
-            print(f"Error copying dataset to local: {e}")
+            logger.error(f"Error copying dataset to local: {e}")
 
         return created_files
 
@@ -561,7 +564,7 @@ class LocalStorageBackend(StorageInterface):
                             column_count=column_count
                         ))
         except Exception as e:
-            print(f"Error listing templates: {e}")
+            logger.error(f"Error listing templates: {e}")
 
         return sorted(templates, key=lambda t: t.name)
 
@@ -578,7 +581,7 @@ class LocalStorageBackend(StorageInterface):
                     async with aiofiles.open(file_path, 'rb') as f:
                         return await f.read()
                 except Exception as e:
-                    print(f"Error downloading template {template_name}: {e}")
+                    logger.error(f"Error downloading template {template_name}: {e}")
                     return None
 
         # Try exact filename
@@ -588,7 +591,7 @@ class LocalStorageBackend(StorageInterface):
                 async with aiofiles.open(file_path, 'rb') as f:
                     return await f.read()
             except Exception as e:
-                print(f"Error downloading template {template_name}: {e}")
+                logger.error(f"Error downloading template {template_name}: {e}")
 
         return None
 
@@ -629,7 +632,7 @@ class LocalStorageBackend(StorageInterface):
                             if columns_count > 3:
                                 preview += f", ... (+{columns_count - 3} more)"
                         except Exception as e:
-                            print(f"Error parsing schema {file_path.name}: {e}")
+                            logger.error(f"Error parsing schema {file_path.name}: {e}")
                             continue
 
                         if columns_count > 0:
@@ -642,7 +645,7 @@ class LocalStorageBackend(StorageInterface):
                                 columns=columns
                             ))
         except Exception as e:
-            print(f"Error listing initial schemas: {e}")
+            logger.error(f"Error listing initial schemas: {e}")
 
         return sorted(schemas, key=lambda s: s.name)
 
@@ -658,7 +661,7 @@ class LocalStorageBackend(StorageInterface):
                 async with aiofiles.open(file_path, 'rb') as f:
                     return await f.read()
             except Exception as e:
-                print(f"Error downloading initial schema {schema_name}: {e}")
+                logger.error(f"Error downloading initial schema {schema_name}: {e}")
                 return None
 
         # Try exact filename
@@ -668,7 +671,7 @@ class LocalStorageBackend(StorageInterface):
                 async with aiofiles.open(file_path, 'rb') as f:
                     return await f.read()
             except Exception as e:
-                print(f"Error downloading initial schema {schema_name}: {e}")
+                logger.error(f"Error downloading initial schema {schema_name}: {e}")
 
         return None
 
@@ -694,5 +697,5 @@ class LocalStorageBackend(StorageInterface):
 
             return str(file_path)
         except Exception as e:
-            print(f"Error uploading initial schema {schema_name}: {e}")
+            logger.error(f"Error uploading initial schema {schema_name}: {e}")
             raise

--- a/backend/app/storage/supabase_backend.py
+++ b/backend/app/storage/supabase_backend.py
@@ -91,7 +91,7 @@ class SupabaseStorageBackend(StorageInterface):
             )
             return True
         except Exception as e:
-            print(f"Error saving session {session_id} to Supabase: {e}")
+            logger.error(f"Error saving session {session_id} to Supabase: {e}")
             return False
 
     async def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
@@ -103,7 +103,7 @@ class SupabaseStorageBackend(StorageInterface):
         except Exception as e:
             # Session not found is expected for new sessions
             if "not found" not in str(e).lower():
-                print(f"Error loading session {session_id} from Supabase: {e}")
+                logger.error(f"Error loading session {session_id} from Supabase: {e}")
             return None
 
     async def delete_session(self, session_id: str) -> bool:
@@ -121,7 +121,7 @@ class SupabaseStorageBackend(StorageInterface):
 
             return True
         except Exception as e:
-            print(f"Error deleting session {session_id} from Supabase: {e}")
+            logger.error(f"Error deleting session {session_id} from Supabase: {e}")
             return False
 
     async def list_sessions(self) -> List[str]:
@@ -134,7 +134,7 @@ class SupabaseStorageBackend(StorageInterface):
                 if f["name"].endswith(".json")
             ]
         except Exception as e:
-            print(f"Error listing sessions from Supabase: {e}")
+            logger.error(f"Error listing sessions from Supabase: {e}")
             return []
 
     # ================
@@ -170,7 +170,7 @@ class SupabaseStorageBackend(StorageInterface):
 
             return f"{bucket}/{storage_path}"
         except Exception as e:
-            print(f"Error uploading file {bucket}/{path} to Supabase: {e}")
+            logger.error(f"Error uploading file {bucket}/{path} to Supabase: {e}")
             raise
 
     async def download_file(self, bucket: str, path: str) -> Optional[bytes]:
@@ -180,7 +180,7 @@ class SupabaseStorageBackend(StorageInterface):
             return self.client.storage.from_(bucket).download(storage_path)
         except Exception as e:
             if "not found" not in str(e).lower():
-                print(f"Error downloading file {bucket}/{path} from Supabase: {e}")
+                logger.error(f"Error downloading file {bucket}/{path} from Supabase: {e}")
             return None
 
     async def delete_file(self, bucket: str, path: str) -> bool:
@@ -190,7 +190,7 @@ class SupabaseStorageBackend(StorageInterface):
             self.client.storage.from_(bucket).remove([storage_path])
             return True
         except Exception as e:
-            print(f"Error deleting file {bucket}/{path} from Supabase: {e}")
+            logger.error(f"Error deleting file {bucket}/{path} from Supabase: {e}")
             return False
 
     async def file_exists(self, bucket: str, path: str) -> bool:
@@ -245,7 +245,7 @@ class SupabaseStorageBackend(StorageInterface):
                 offset += page_size
             return result
         except Exception as e:
-            print(f"Error listing folder {bucket}/{folder}: {e}")
+            logger.error(f"Error listing folder {bucket}/{folder}: {e}")
             return set()
 
     async def list_files(self, bucket: str, prefix: str = "") -> List[str]:
@@ -282,7 +282,7 @@ class SupabaseStorageBackend(StorageInterface):
 
             return result
         except Exception as e:
-            print(f"Error listing files {bucket}/{prefix} from Supabase: {e}")
+            logger.error(f"Error listing files {bucket}/{prefix} from Supabase: {e}")
             return []
 
     # =====================
@@ -301,7 +301,7 @@ class SupabaseStorageBackend(StorageInterface):
 
             return True
         except Exception as e:
-            print(f"Error deleting directory {bucket}/{prefix} from Supabase: {e}")
+            logger.error(f"Error deleting directory {bucket}/{prefix} from Supabase: {e}")
             return False
 
     # =================
@@ -315,7 +315,7 @@ class SupabaseStorageBackend(StorageInterface):
             response = self.client.storage.from_(bucket).get_public_url(storage_path)
             return response
         except Exception as e:
-            print(f"Error getting public URL for {bucket}/{path}: {e}")
+            logger.error(f"Error getting public URL for {bucket}/{path}: {e}")
             return None
 
     def get_signed_url(
@@ -342,7 +342,7 @@ class SupabaseStorageBackend(StorageInterface):
             )
             return response.get("signedURL")
         except Exception as e:
-            print(f"Error creating signed URL for {bucket}/{path}: {e}")
+            logger.error(f"Error creating signed URL for {bucket}/{path}: {e}")
             return None
 
     # =================
@@ -428,7 +428,7 @@ class SupabaseStorageBackend(StorageInterface):
                 if f["name"].endswith(".json")
             ]
         except Exception as e:
-            print(f"Error listing sessions from Supabase: {e}")
+            logger.error(f"Error listing sessions from Supabase: {e}")
             return []
 
     # =======================
@@ -533,7 +533,7 @@ class SupabaseStorageBackend(StorageInterface):
 
             return sorted(result, key=lambda f: f.name)
         except Exception as e:
-            print(f"Error listing dataset files from Supabase: {e}")
+            logger.error(f"Error listing dataset files from Supabase: {e}")
             return []
 
     async def download_dataset_file(self, dataset_name: str, filename: str) -> Optional[bytes]:
@@ -542,7 +542,7 @@ class SupabaseStorageBackend(StorageInterface):
             path = f"{dataset_name}/{filename}"
             return self.client.storage.from_("datasets").download(path)
         except Exception as e:
-            print(f"Error downloading dataset file {dataset_name}/{filename}: {e}")
+            logger.error(f"Error downloading dataset file {dataset_name}/{filename}: {e}")
             return None
 
     async def download_dataset_to_local(self, dataset_name: str, local_dir: str) -> List[str]:
@@ -565,7 +565,7 @@ class SupabaseStorageBackend(StorageInterface):
                         f.write(content)
                     created_files.append(str(dest_path))
         except Exception as e:
-            print(f"Error downloading dataset to local: {e}")
+            logger.error(f"Error downloading dataset to local: {e}")
 
         return created_files
 
@@ -663,7 +663,7 @@ class SupabaseStorageBackend(StorageInterface):
 
             return sorted(templates, key=lambda t: t.name)
         except Exception as e:
-            print(f"Error listing templates from Supabase: {e}")
+            logger.error(f"Error listing templates from Supabase: {e}")
             return []
 
     async def download_template(self, template_name: str) -> Optional[bytes]:
@@ -685,7 +685,7 @@ class SupabaseStorageBackend(StorageInterface):
 
             return None
         except Exception as e:
-            print(f"Error downloading template {template_name}: {e}")
+            logger.error(f"Error downloading template {template_name}: {e}")
             return None
 
     # =======================
@@ -765,7 +765,7 @@ class SupabaseStorageBackend(StorageInterface):
 
             return None
         except Exception as e:
-            print(f"Error downloading initial schema {schema_name}: {e}")
+            logger.error(f"Error downloading initial schema {schema_name}: {e}")
             return None
 
     async def upload_initial_schema(
@@ -796,5 +796,5 @@ class SupabaseStorageBackend(StorageInterface):
 
             return f"initial_schemas/{schema_name}"
         except Exception as e:
-            print(f"Error uploading initial schema {schema_name} to Supabase: {e}")
+            logger.error(f"Error uploading initial schema {schema_name} to Supabase: {e}")
             raise


### PR DESCRIPTION
Server-side prints in the storage backends and the schematiq route now go through `logging` (levels + session context + integrates with logging_utils). CLI helper prints in google_drive.py left untouched.