### PR TITLE
chore: remove hardcoded personal paths from eval scripts

### DIFF
--- a/schematiq-lib/schematiq/evaluation/run_eval.py
+++ b/schematiq-lib/schematiq/evaluation/run_eval.py
@@ -39,7 +39,7 @@ def open_gold_tables(tables_path):
 def open_pred_tables(tables_path):
 
     if not MINE:
-        filter_jsonl_path = r"C:\Users\shaharl\Desktop\shahar\Uni\QueryDiscovery\data\schema_6_filtered\arxiv_tables_filtered_4_columns_queries_070725.jsonl"
+        filter_jsonl_path = os.environ.get("SCHEMATIQ_FILTER_JSONL", "")
 
         # Load the set of tabids to keep
         with open(filter_jsonl_path, encoding="utf-8") as f:

--- a/schematiq-lib/schematiq/scripts/create_data.py
+++ b/schematiq-lib/schematiq/scripts/create_data.py
@@ -111,15 +111,6 @@ def get_queries_from_arxivDIGESTables(path_json):
 
 
 
-# # read jsonl
-# data = []
-# with open(r'C:\Users\shaharl\Desktop\shahar\Uni\Information_Extraction\dev_10_1.jsonl', 'r', encoding='utf-8') as f:
-#     for line in f:
-#         cur = json.loads(line)
-#         data.append(cur)
-#
-# # Now `data` is a list of Python dictionaries
-# print(data)
 
 def text_from_url_s2orc(url):
     # modify these
@@ -194,11 +185,6 @@ def pdf_to_json(pdf_path, output_txt_path):
 if __name__ == "__main__":
     print("start")
 
-    # pdf_path = r"C:\Users\shaharl\Desktop\shahar\Uni\Information_Extraction\QueryDiscovery\data\NES_DATA" \
-    #            r"\pdf\Structural_prerequisites_for_CRM1.pdf"
-    # output_txt_path = r"C:\Users\shaharl\Desktop\shahar\Uni\Information_Extraction\QueryDiscovery\data\NES_DATA" \
-    #                   r"\text\Structural_prerequisites_for_CRM1.txt"
-    # text_from_pdf(pdf_path, output_txt_path)
 
     arxivDIGESTables_data()
 


### PR DESCRIPTION
Drops `C:\Users\shaharl\...` absolute paths from run_eval.py (now `SCHEMATIQ_FILTER_JSONL` env var, behavior-preserving for the MINE=True default) and removes two dead personal-path comment blocks in create_data.py.