### PR TITLE
chore: prune dead research-data .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,9 +126,6 @@ schematiq-lib/dist/
 # Root-level data/research files
 *.txt
 !requirements.txt
-Immigration_ground_truth.csv
-different Presidents ScheMatiQ meeting results_*.csv
-missing_from_SM/
 
 # Test scripts at root
 # Test scripts at root (ad-hoc scripts, not the real suite)
@@ -146,6 +143,3 @@ backend/test_*.py
 
 # Local dev runner instance storage (dev.sh multi-instance isolation)
 .dev-data/
-
-# Local evaluation scripts
-evaluate_schematiq.py


### PR DESCRIPTION
## Summary

Follow-up to `chore/gitignore-cleanup`: reviewed the five remaining research-data ignore rules against the local tree and codebase.

**Kept**
- `research/` — still the documented datasets/experiments directory (`README.md`, `backend/app/storage/local_backend.py`, `scripts/upload_datasets.py`, API routes, etc.). Not present in this clone, but part of the active local-dev layout.

**Removed** (no matching ignored files, no code references, not produced by current workflow)
- `Immigration_ground_truth.csv` — one-off CSV added at public-release prep; absent from tree and never referenced outside `.gitignore`.
- `different Presidents ScheMatiQ meeting results_*.csv` — same; ad-hoc meeting-results export pattern with no live producer.
- `missing_from_SM/` — directory rule with no on-disk dir and no references in code or scripts.
- `evaluate_schematiq.py` — root evaluation script was removed from tracking in prior commits; file no longer exists and nothing in the repo recreates it.

No other `.gitignore` lines were changed (`!requirements.txt` and all other rules untouched).

## Test plan

- [x] Ran local live-match check (`git ls-files --others --ignored --exclude-standard`); none of the removed patterns matched ignored files in this working tree.
- [x] Grep confirmed removed entries are not referenced in application code or scripts.
- [x] Verified `research/` remains referenced across backend storage, upload scripts, and docs.

Made with [Cursor](https://cursor.com)