### PR TITLE
chore: lint cleanup in schematiq-lib (unused imports, f-strings, regex escapes)

### DIFF
--- a/schematiq-lib/schematiq/core/retrievers.py
+++ b/schematiq-lib/schematiq/core/retrievers.py
@@ -486,7 +486,6 @@ class EmbeddingRetriever(Retriever):
 # 2. Prompt-based implementation                                            #
 ##############################################################################
 
-from schematiq.core.llm_backends import LLMInterface   # assumes the base class lives there
 from schematiq.core.llm_call_tracker import LLMCallTracker
 
 

--- a/schematiq-lib/schematiq/core/schematiq.py
+++ b/schematiq-lib/schematiq/core/schematiq.py
@@ -32,7 +32,6 @@ from schematiq.core.schema import Schema, Column, SchemaEvolution, ObservationUn
 from schematiq.core.llm_call_tracker import LLMCallTracker
 from schematiq.core.prompts import (
     get_prompts, get_observation_unit_prompts, SchemaMode, DRAFT_SCHEMA_TMPL,
-    SYSTEM_PROMPT_OBSERVATION_UNIT, USER_PROMPT_TMPL_OBSERVATION_UNIT,
     OBSERVATION_UNIT_CONTEXT_TMPL,
     SYSTEM_PROMPT_COMPLETE_COLUMNS, USER_PROMPT_TMPL_COMPLETE_COLUMNS,
 )
@@ -1101,7 +1100,7 @@ def main(cfg_path: Path) -> None:
 
     # Print results
     print(f"\nSchema discovery completed for {total_docs} documents in {elapsed_time:.2f} seconds ({elapsed_time/60:.2f} minutes)")
-    print(f"\n📊 Document Contributions:")
+    print("\n📊 Document Contributions:")
     print(f"  • Contributing files: {len(contributing_files)}")
     print(f"  • Non-contributing files: {len(non_contributing_files)}")
     if total_docs > 0:
@@ -1109,12 +1108,12 @@ def main(cfg_path: Path) -> None:
         print(f"  • Contribution rate: {contribution_rate:.1f}%")
     
     if contributing_files:
-        print(f"\n✅ Files that contributed to schema:")
+        print("\n✅ Files that contributed to schema:")
         for filename in contributing_files:
             print(f"  • {filename}")
     
     if non_contributing_files:
-        print(f"\n❌ Files that did not contribute:")
+        print("\n❌ Files that did not contribute:")
         for filename in non_contributing_files:
             print(f"  • {filename}")
 

--- a/schematiq-lib/schematiq/core/table_detector.py
+++ b/schematiq-lib/schematiq/core/table_detector.py
@@ -1,7 +1,7 @@
 """Detect and format tables in plain-text documents."""
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List, Optional
 
 

--- a/schematiq-lib/schematiq/core/utils.py
+++ b/schematiq-lib/schematiq/core/utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from schematiq.core.retrievers import Retriever, EmbeddingRetriever, PromptingRetriever, test_retriever_stability
+from schematiq.core.retrievers import Retriever, EmbeddingRetriever, PromptingRetriever
 from schematiq.core.llm_backends import LLMInterface, TogetherLLM, OpenAILLM, HuggingFaceLLM, GeminiLLM
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 from pathlib import Path
 import io, difflib
 import numpy as np

--- a/schematiq-lib/schematiq/evaluation/data_quality_evaluation.py
+++ b/schematiq-lib/schematiq/evaluation/data_quality_evaluation.py
@@ -21,8 +21,7 @@ import json
 from schematiq.core.model_specs import ModelNames
 import pandas as pd
 import numpy as np
-from pathlib import Path
-from typing import Dict, List, Tuple, Any, Optional, Set
+from typing import Dict, List, Tuple, Any, Optional
 import argparse
 from dataclasses import dataclass
 from schematiq.core.embedding_model import load_sentence_transformer
@@ -499,11 +498,11 @@ class ValueEvaluator:
         llm_judge_results = []
         llm_scores = []
 
-        print(f"\n=== Value Evaluation ===")
+        print("\n=== Value Evaluation ===")
         if self.use_llm_judge and self.llm_judge:
-            print(f"Using hybrid evaluation: Semantic similarity + LLM Judge")
+            print("Using hybrid evaluation: Semantic similarity + LLM Judge")
         else:
-            print(f"Using semantic similarity only")
+            print("Using semantic similarity only")
 
         comparison_count = 0
         for row_alignment in row_alignments:
@@ -700,17 +699,17 @@ class DataQualityEvaluator:
 
         metrics = result.summary_metrics
 
-        print(f"\n📊 ROW ALIGNMENT:")
+        print("\n📊 ROW ALIGNMENT:")
         print(f"  Matched rows: {metrics['rows_matched']} / {metrics['total_pred_rows']} predictions")
         print(f"  Row match rate: {metrics['row_match_rate']:.3f}")
 
-        print(f"\n🏗️  SCHEMA SIMILARITY:")
+        print("\n🏗️  SCHEMA SIMILARITY:")
         print(f"  Schema recall: {metrics['schema_recall']:.3f}")
         print(f"  Schema precision: {metrics['schema_precision']:.3f}")
         print(f"  Schema F1: {metrics['schema_f1']:.3f}")
         print(f"  Avg field similarity: {result.schema_similarity['avg_field_similarity']:.3f}")
 
-        print(f"\n💎 VALUE SIMILARITY:")
+        print("\n💎 VALUE SIMILARITY:")
         print(f"  Semantic similarity: {metrics['avg_value_similarity']:.3f}")
         print(f"  Median similarity: {metrics['median_value_similarity']:.3f}")
         print(f"  Total comparisons: {result.value_similarity.get('total_comparisons', 0)}")
@@ -722,23 +721,23 @@ class DataQualityEvaluator:
 
         # Show best/worst performing fields
         if 'best_fields' in result.value_similarity:
-            print(f"\n🏆 BEST PERFORMING FIELDS:")
+            print("\n🏆 BEST PERFORMING FIELDS:")
             for field, score in result.value_similarity['best_fields']:
                 print(f"  {field}: {score:.3f}")
 
         if 'worst_fields' in result.value_similarity:
-            print(f"\n📉 WORST PERFORMING FIELDS:")
+            print("\n📉 WORST PERFORMING FIELDS:")
             for field, score in result.value_similarity['worst_fields']:
                 print(f"  {field}: {score:.3f}")
 
         # Show LLM judge insights if available
         if result.llm_judge_results:
-            print(f"\n🤖 LLM JUDGE INSIGHTS:")
+            print("\n🤖 LLM JUDGE INSIGHTS:")
             high_conf_count = sum(1 for r in result.llm_judge_results if r.confidence == 'High')
             print(f"  High confidence judgments: {high_conf_count}/{len(result.llm_judge_results)}")
 
             # Show a few example judgments
-            print(f"  Sample LLM judgments:")
+            print("  Sample LLM judgments:")
             for i, judge_result in enumerate(result.llm_judge_results[:3]):
                 print(f"    {judge_result.field_name}: {judge_result.judgment_score:.3f} - {judge_result.judgment_reasoning[:60]}...")
 

--- a/schematiq-lib/schematiq/evaluation/few_shot_manager.py
+++ b/schematiq-lib/schematiq/evaluation/few_shot_manager.py
@@ -3,7 +3,7 @@
 import json
 import random
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any
 
 class FewShotManager:
     """Manages few-shot examples from ground truth data for evaluation."""

--- a/schematiq-lib/schematiq/evaluation/gt_comparator.py
+++ b/schematiq-lib/schematiq/evaluation/gt_comparator.py
@@ -1,7 +1,7 @@
 """Ground truth comparison utilities for schema evaluation."""
 
 import re
-from typing import Dict, List, Any, Optional, Union
+from typing import Dict, List, Any, Optional
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 

--- a/schematiq-lib/schematiq/evaluation/metrics.py
+++ b/schematiq-lib/schematiq/evaluation/metrics.py
@@ -2,8 +2,6 @@ from typing import Any, Optional
 
 # from bert_score import BERTScorer
 import numpy as np
-from sacrebleu.metrics import BLEU
-from omegaconf import DictConfig
 
 from table import Table
 

--- a/schematiq-lib/schematiq/evaluation/metrics_utils.py
+++ b/schematiq-lib/schematiq/evaluation/metrics_utils.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from schematiq.core.model_specs import ModelNames
 
-import numpy as np
 import pandas as pd
 import torch
 from nltk import word_tokenize
@@ -20,7 +19,6 @@ from openai import OpenAI
 from sentence_transformers import util
 
 from schematiq.core.embedding_model import load_sentence_transformer
-from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from table import Table
 
@@ -517,7 +515,7 @@ Table 2:
         alignment_str = response.choices[0].message.content
         alignment_str = alignment_str.split("Table 1:\n|")[0]
         try:
-            alignment_json = json.loads(re.search("(\[.+\])", alignment_str, re.DOTALL)[0])
+            alignment_json = json.loads(re.search(r"(\[.+\])", alignment_str, re.DOTALL)[0])
         except json.JSONDecodeError:
             # try again
             if response.choices[0].finish_reason == self._together.types.common.FinishReason.Length:
@@ -528,7 +526,7 @@ Table 2:
                 print(response)
             alignment_str = response.choices[0].message.content
             alignment_str = alignment_str.split("Table 1:\n|")[0]
-            alignment_json = json.loads(re.search("(\[.+\])", alignment_str, re.DOTALL)[0])
+            alignment_json = json.loads(re.search(r"(\[.+\])", alignment_str, re.DOTALL)[0])
 
         for gold_col_name in featurized_gold_col_list:
             for pred_col_name in featurized_pred_col_list:

--- a/schematiq-lib/schematiq/evaluation/query_answering_evaluation.py
+++ b/schematiq-lib/schematiq/evaluation/query_answering_evaluation.py
@@ -56,14 +56,14 @@ def main():
     # Check if config file exists
     if not config_path.exists():
         print(f"❌ Configuration file not found: {config_path}")
-        print(f"💡 Try creating a config file based on evaluation/config/evaluation_config.json")
+        print("💡 Try creating a config file based on evaluation/config/evaluation_config.json")
         return 1
 
     # Create output directory if it doesn't exist
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     try:
-        print(f"🚀 Starting Schema Evaluation")
+        print("🚀 Starting Schema Evaluation")
         print(f"   Config: {config_path}")
         print(f"   Output: {output_path}")
         print()
@@ -83,7 +83,7 @@ def main():
         # Generate additional reports if configured
         _generate_additional_reports(result, output_path, args.verbose)
 
-        print(f"✅ Evaluation completed successfully!")
+        print("✅ Evaluation completed successfully!")
         print(f"📄 Results saved to: {output_path}")
 
         return 0
@@ -110,7 +110,7 @@ def _generate_additional_reports(result, output_path, verbose=False):
     _generate_markdown_report(result, md_path)
 
     if verbose:
-        print(f"📊 Additional reports generated:")
+        print("📊 Additional reports generated:")
         print(f"   CSV Summary: {csv_path}")
         print(f"   Markdown Report: {md_path}")
 

--- a/schematiq-lib/schematiq/evaluation/row_evaluator.py
+++ b/schematiq-lib/schematiq/evaluation/row_evaluator.py
@@ -1,6 +1,6 @@
 """Row-level query evaluation for schema assessment."""
 
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Dict, List, Any
 from dataclasses import dataclass
 
 from ..core.llm_backends import LLMInterface

--- a/schematiq-lib/schematiq/evaluation/run_eval.py
+++ b/schematiq-lib/schematiq/evaluation/run_eval.py
@@ -1,4 +1,3 @@
-from argparse import ArgumentParser
 import json
 from tqdm import tqdm
 import os
@@ -129,7 +128,7 @@ def main(gold_tables, pred_tables, out_file,
         pred_table = pred_table_instance.pop("table_cls")
 
         if len(pred_table_instance["aspects"]) == 0:
-            print(f"W: problem with EMPTY schema! ")
+            print("W: problem with EMPTY schema! ")
             continue
 
         if len(pred_table_instance["aspects"]) == 3 and "rational" in pred_table_instance["aspects"][2]:
@@ -186,7 +185,7 @@ if __name__ == "__main__":
             main(
                 pred_tables=os.path.join(pred_directory, f"{cur_pred}.jsonl"),
                 gold_tables=os.path.join(pred_directory,
-                                         f"arxiv_tables_filtered_4_columns_retrieved_queries_270725.jsonl"),
+                                         "arxiv_tables_filtered_4_columns_retrieved_queries_270725.jsonl"),
                 out_file=os.path.join(out_directory, f"SCORE_{cur_pred}_{featurizer}_{scorer}_{thresh}.jsonl"),
                 featurizer=featurizer,
                 scorer=scorer,

--- a/schematiq-lib/schematiq/evaluation/schema_evaluator.py
+++ b/schematiq-lib/schematiq/evaluation/schema_evaluator.py
@@ -3,7 +3,7 @@
 import json
 import time
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any
 from dataclasses import dataclass, asdict
 
 from ..core import utils
@@ -47,7 +47,7 @@ class SchemaEvaluator:
 
         self.gt_column = self.config["gt_column"]
 
-        print(f"📊 Initialized SchemaEvaluator")
+        print("📊 Initialized SchemaEvaluator")
         print(f"   Query: {self.query[:100]}...")
         print(f"   Data: {self.data_path}")
         print(f"   GT Column: {self.gt_column}")
@@ -61,7 +61,7 @@ class SchemaEvaluator:
         """
         start_time = time.time()
 
-        print(f"🔍 Starting schema evaluation...")
+        print("🔍 Starting schema evaluation...")
 
         # Load data
         data = self._load_evaluation_data()
@@ -357,26 +357,26 @@ class SchemaEvaluator:
 
     def print_summary(self, result: SchemaEvaluationResult) -> None:
         """Print evaluation summary."""
-        print(f"\n📊 SCHEMA EVALUATION SUMMARY")
-        print(f"=" * 50)
+        print("\n📊 SCHEMA EVALUATION SUMMARY")
+        print("=" * 50)
         print(f"Query: {result.query}")
         print(f"Total Rows Evaluated: {result.total_rows}")
         print(f"Evaluation Time: {result.evaluation_time:.2f}s")
 
-        print(f"\n📈 OVERALL METRICS:")
+        print("\n📈 OVERALL METRICS:")
         for metric, value in result.overall_metrics.items():
             if isinstance(value, float):
                 print(f"  {metric}: {value:.3f}")
             else:
                 print(f"  {metric}: {value}")
 
-        print(f"\n🔍 COLUMN ANALYSIS:")
+        print("\n🔍 COLUMN ANALYSIS:")
         ca = result.column_analysis
         print(f"  Total Schema Columns: {ca.get('total_columns', 0)}")
         print(f"  Most Used: {', '.join(ca.get('most_used_columns', [])[:3])}")
         print(f"  Unused: {len(ca.get('unused_columns', []))} columns")
 
-        print(f"\n💡 RECOMMENDATIONS:")
+        print("\n💡 RECOMMENDATIONS:")
         for category, recs in result.recommendations.items():
             if recs:
                 print(f"  {category.title()}:")

--- a/schematiq-lib/schematiq/evaluation/test_evaluation.py
+++ b/schematiq-lib/schematiq/evaluation/test_evaluation.py
@@ -127,8 +127,8 @@ def main():
     passed = sum(results)
     total = len(results)
 
-    print(f"\n📊 TEST SUMMARY")
-    print(f"=" * 30)
+    print("\n📊 TEST SUMMARY")
+    print("=" * 30)
     print(f"Passed: {passed}/{total}")
     print(f"Success Rate: {passed/total*100:.1f}%")
 

--- a/schematiq-lib/schematiq/scripts/create_data.py
+++ b/schematiq-lib/schematiq/scripts/create_data.py
@@ -10,7 +10,6 @@ import io
 import requests
 from PyPDF2 import PdfReader
 from collections import Counter
-import io
 
 
 MIN_COLUMNS_THRESH = 4

--- a/schematiq-lib/schematiq/scripts/download_nes_papers.py
+++ b/schematiq-lib/schematiq/scripts/download_nes_papers.py
@@ -24,7 +24,7 @@ import sys
 import time
 from pathlib import Path
 from typing import Optional
-from urllib.parse import urljoin, urlparse, quote
+from urllib.parse import urljoin, urlparse
 
 import aiofiles
 import difflib

--- a/schematiq-lib/schematiq/scripts/run.py
+++ b/schematiq-lib/schematiq/scripts/run.py
@@ -13,7 +13,6 @@ Write the code as modular as possible, to be able to work on much longer documen
 """
 
 from typing import List
-import torch
 from tqdm import tqdm
 import json
 import re

--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -6,7 +6,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Dict, Any, Set, Callable, Optional, List, Iterator, Tuple
+from typing import Dict, Any, Set, Callable, Optional, List, Iterator
 
 logger = logging.getLogger(__name__)
 from schematiq.core.schema import Schema, Column, ObservationUnit, _embed
@@ -325,7 +325,7 @@ class PaperProcessor:
                 print(f"⚠️  Callback error for {column_name}: {e}")
         else:
             print(
-                f"⚠️  on_value_extracted callback is NOT SET - cell streaming disabled"
+                "⚠️  on_value_extracted callback is NOT SET - cell streaming disabled"
             )
 
     def _attach_source_to_excerpts(
@@ -458,7 +458,7 @@ class PaperProcessor:
         raw = self._generate(trimmed, temperature=0, **self._gemini_kwargs(thinking_budget=0))
         # Check stop immediately after LLM call returns
         if self._check_stop_requested():
-            print(f"🛑 Stop requested after LLM call, returning empty")
+            print("🛑 Stop requested after LLM call, returning empty")
             return {}
         try:
             parsed = self.json_parser.parse_response(raw)
@@ -567,7 +567,7 @@ class PaperProcessor:
         )
         # Check stop immediately after LLM call returns
         if self._check_stop_requested():
-            print(f"🛑 Stop requested after batch LLM call, returning empty")
+            print("🛑 Stop requested after batch LLM call, returning empty")
             return {}
 
         try:
@@ -935,7 +935,7 @@ class PaperProcessor:
             # Check stop immediately after LLM call returns
             if self._check_stop_requested():
                 print(
-                    f"🛑 Stop requested after single-column LLM call, returning empty"
+                    "🛑 Stop requested after single-column LLM call, returning empty"
                 )
                 return {}
             try:
@@ -1091,7 +1091,7 @@ class PaperProcessor:
             # Check for stop request before each column extraction
             if self._check_stop_requested():
                 print(
-                    f"🛑 Stop requested during column extraction, returning partial results"
+                    "🛑 Stop requested during column extraction, returning partial results"
                 )
                 return row
 
@@ -1109,7 +1109,7 @@ class PaperProcessor:
                 # Check for stop before attempt 2
                 if self._check_stop_requested():
                     print(
-                        f"🛑 Stop requested before fallback attempt, returning partial results"
+                        "🛑 Stop requested before fallback attempt, returning partial results"
                     )
                     return row
                 # Attempt 2: Only try expanded retrieval if we have a retriever and got empty result
@@ -1125,7 +1125,7 @@ class PaperProcessor:
                 # Check for stop before attempt 3
                 if self._check_stop_requested():
                     print(
-                        f"🛑 Stop requested before snippet attempt, returning partial results"
+                        "🛑 Stop requested before snippet attempt, returning partial results"
                     )
                     return row
                 third = _single_column_attempt(
@@ -1774,7 +1774,7 @@ class PaperProcessor:
             ident_skip_reason = ident_result.skip_reason
 
         if not units:
-            print(f"  ⚠️ No units found, skipping document")
+            print("  ⚠️ No units found, skipping document")
             if known_units is not None:
                 return ExtractionResult(rows=[], skip_reason=KNOWN_UNITS_EMPTY)
             return ExtractionResult(rows=[], skip_reason=ident_skip_reason)
@@ -1798,7 +1798,7 @@ class PaperProcessor:
         try:
             for i, unit in enumerate(units, 1):
                 if self._check_stop_requested():
-                    print(f"🛑 Stop requested during unit extraction")
+                    print("🛑 Stop requested during unit extraction")
                     break
 
                 unit_name = unit.get("unit_name", f"Unit {i}")

--- a/schematiq-lib/schematiq/value_extraction/core/table_builder.py
+++ b/schematiq-lib/schematiq/value_extraction/core/table_builder.py
@@ -9,9 +9,8 @@ from typing import Any, Callable, Dict, List, Optional, Set
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from tqdm import tqdm
 
-from schematiq.core.schema import Schema, Column
+from schematiq.core.schema import Schema
 from schematiq.core.llm_backends import LLMInterface
-from schematiq.core import utils
 from schematiq.core.results import SkippedDocument
 from schematiq.core.config import config as lib_config
 from schematiq.value_extraction.config.messages import skipped_summary, DEFAULT_SKIP_REASON
@@ -421,7 +420,7 @@ class TableBuilder:
 
         for paper in papers:
             if self.should_stop and self.should_stop():
-                print(f"🛑 Stop requested during observation unit processing")
+                print("🛑 Stop requested during observation unit processing")
                 self._stopped = True
                 return
 
@@ -529,7 +528,7 @@ class TableBuilder:
         for column in schema.columns:
             # Check for stop request
             if self.should_stop and self.should_stop():
-                print(f"🛑 Stop requested during column processing")
+                print("🛑 Stop requested during column processing")
                 self._stopped = True
                 return
 
@@ -545,7 +544,7 @@ class TableBuilder:
             for paper in papers:
                 # Check for stop request
                 if self.should_stop and self.should_stop():
-                    print(f"🛑 Stop requested during paper processing")
+                    print("🛑 Stop requested during paper processing")
                     self._stopped = True
                     return
                 # Note: Don't skip based on processed_papers here - we need to try
@@ -601,7 +600,7 @@ class TableBuilder:
                 for future in concurrent.futures.as_completed(future_to_paper):
                     # Check for stop request
                     if self.should_stop and self.should_stop():
-                        print(f"🛑 Stop requested - cancelling pending futures")
+                        print("🛑 Stop requested - cancelling pending futures")
                         self._stopped = True
                         # Cancel any pending futures
                         for pending_future in future_to_paper:
@@ -624,7 +623,7 @@ class TableBuilder:
             for paper in unprocessed_papers:
                 # Check for stop request
                 if self.should_stop and self.should_stop():
-                    print(f"🛑 Stop requested during sequential processing")
+                    print("🛑 Stop requested during sequential processing")
                     self._stopped = True
                     return
 

--- a/schematiq-lib/schematiq/value_extraction/core/unit_parser.py
+++ b/schematiq-lib/schematiq/value_extraction/core/unit_parser.py
@@ -247,7 +247,7 @@ class UnitIdentificationParser:
                         "relevant_passages": unit.get("relevant_passages", unit.get("passages", [])),
                         "confidence": unit.get("confidence", "medium")
                     })
-                    warnings.append(f"Unit used alternate field name instead of 'unit_name'")
+                    warnings.append("Unit used alternate field name instead of 'unit_name'")
 
                 else:
                     # Dict but no recognizable unit name field

--- a/schematiq-lib/schematiq/value_extraction/utils/excerpt_grounder.py
+++ b/schematiq-lib/schematiq/value_extraction/utils/excerpt_grounder.py
@@ -1,7 +1,7 @@
 """Verify extraction excerpts against source text for hallucination detection."""
 
 import difflib
-from typing import Dict, List, Optional, Tuple
+from typing import Optional, Tuple
 
 
 class ExcerptGrounder:


### PR DESCRIPTION
Ruff autofix over schematiq-lib: unused/duplicate imports, placeholder-less f-strings, and invalid regex escape sequences (now raw strings; they were raising SyntaxWarning). Mechanical, no behavior change.