### PR TITLE
chore: audit backend requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,6 @@ pydantic>=2.5.0
 python-multipart>=0.0.6
 aiofiles>=23.2.1
 websockets>=13.0
-python-json-logger>=2.0.7
 
 # Data processing
 pandas>=2.2.0
@@ -31,7 +30,6 @@ tiktoken>=0.5.0
 # Utilities
 requests>=2.31.0
 tqdm>=4.65.0
-PyYAML>=6.0.0
 
 # Cloud Storage
 supabase>=2.0.0
@@ -39,4 +37,5 @@ supabase>=2.0.0
 # Google Drive/Sheets (optional, for research data collection)
 google-api-python-client>=2.100.0
 google-auth>=2.25.0
+google-auth-oauthlib>=1.0.0
 python-dotenv


### PR DESCRIPTION
## Summary

Audited `backend/requirements.txt` against the real import surface under `backend/app/`. Baseline and post-change verification: fresh Python 3.12 venv, `pip install -e schematiq-lib/`, `pip install -r backend/requirements.txt`, `python -c "import app.main"` from `backend/`, and `pytest tests/` (98 passed).

## Classification table

| Package | Action | Rationale |
|---------|--------|-----------|
| `fastapi` | **kept** | Direct import across 12 route/service modules |
| `uvicorn[standard]` | **kept** | ASGI server (`Dockerfile` CMD, `main.py` dev entry); `[standard]` pulls `uvloop`, `httptools`, `watchfiles` |
| `pydantic` | **kept** | Direct import in models and routes |
| `python-multipart` | **kept** | FastAPI `UploadFile` / `File(...)` on load, cloud_data, schema routes |
| `aiofiles` | **kept** | Direct import in `local_backend.py`, `file_parser.py` |
| `websockets` | **kept** | Required by `uvicorn[standard]` for WebSocket support (`/ws` route) |
| `pandas` | **kept** | Direct import in `file_parser.py`, `supabase_backend.py` |
| `numpy` | **kept** | Runtime via `schematiq` (retrievers, utils) when backend runs discovery/extraction |
| `pymupdf4llm` | **kept** | Direct import in `pdf_utils.py` |
| `PyPDF2` | **kept** | Runtime via `schematiq.core.utils.PdfReader` during document processing |
| `python-docx` | **kept** | Direct import (`from docx import Document`) in `convert_to_txt.py` |
| `pdfplumber` | **kept** | Direct import in `convert_to_txt.py` |
| `pdf2image` | **kept** | Direct import in `convert_to_txt.py`; shells out to poppler (`Dockerfile` installs `poppler-utils`) |
| `pytesseract` | **kept** | Direct import in `convert_to_txt.py`; shells out to tesseract (`Dockerfile` installs `tesseract-ocr`) |
| `openai` | **kept** | Runtime LLM provider via `schematiq.core.llm_backends.OpenAILLM` / `llm_factory.py` |
| `together` | **kept** | Runtime LLM provider via `TogetherLLM` |
| `google-genai` | **kept** | Runtime LLM provider via `GeminiLLM` (release-mode default) |
| `sentence-transformers` | **kept** | Loaded at import via `schematiq.core.retrievers` shared singleton |
| `transformers` | **kept** | Transitive runtime dep of `sentence-transformers` / embedding pipeline |
| `torch` | **kept** | ML runtime dep (CPU wheel installed first in `Dockerfile`) |
| `tiktoken` | **kept** | Runtime via `schematiq` cost estimation / token counting |
| `requests` | **kept** | Direct import in `pubmed_enrichment_service.py` |
| `tqdm` | **kept** | Runtime via `schematiq` value extraction (`table_builder.py`) |
| `supabase` | **kept** | Direct import in `supabase_backend.py` |
| `google-api-python-client` | **kept** | Lazy import `googleapiclient.discovery` in Drive/Sheets/email modules |
| `google-auth` | **kept** | Lazy import `google.oauth2.*` in Drive/Sheets/email modules |
| `python-dotenv` | **kept** | Direct import in `main.py` for local `.env` loading |
| `google-auth-oauthlib` | **added** | Direct import in `google_drive.py` `__main__` OAuth CLI (`InstalledAppFlow`); not a transitive dep of `google-api-python-client` |
| `python-json-logger` | **removed** | Zero references in repo; `Required-by:` empty; logging uses `logging.basicConfig` with plain text format |
| `PyYAML` | **removed** | Never imported in `backend/app/`; still installed transitively via `transformers` / `huggingface-hub` |

**schematiq-lib imports (not PyPI deps):** `schematiq.core.*`, `schematiq.value_extraction.*` — provided by editable `schematiq-lib` install, same as production `Dockerfile`.

## Test plan

- [x] Fresh venv: `python3.12 -m venv`, install torch (CPU), `pip install -e schematiq-lib/`, `pip install -r backend/requirements.txt`
- [x] `cd backend && python -c "import app.main"` — boots successfully
- [x] `cd backend && pytest tests/` — 98 passed
- [x] Confirmed `google-auth-oauthlib` present and `python-json-logger` absent after install; `PyYAML` still present transitively


Made with [Cursor](https://cursor.com)