### PR TITLE
Fix observation-unit rediscovery: re-extract data + drop duplicate toast

### DIFF
--- a/backend/app/services/pipeline/config_handler.py
+++ b/backend/app/services/pipeline/config_handler.py
@@ -44,14 +44,20 @@ async def resolve_docs_paths(config: ScheMatiQConfig, session_id: str, work_dir:
     session_dir = work_dir / session_id
     session_dir.mkdir(parents=True, exist_ok=True)
 
-    # Check for uploaded documents in data/{session_id}/pending_documents/ directory
-    data_dir = Path("./data") / session_id / "pending_documents"
-    if data_dir.exists():
-        uploaded_files = [f for f in sorted(data_dir.iterdir())
-                        if f.is_file() and not f.name.startswith('.')]
-        if uploaded_files:
-            logger.info("Using %d uploaded documents from %s", len(uploaded_files), data_dir)
-            return [str(data_dir.absolute())]
+    # Check for session-local source documents. Newly uploaded files land in
+    # pending_documents/; once a run completes they are moved to documents/
+    # (see SchematiqRunner._move_pending_documents). On an observation-unit
+    # rediscovery the source docs therefore live in documents/, so we must
+    # check both locations — otherwise the pipeline finds no documents, runs
+    # in schema-only mode, and silently skips value extraction.
+    session_data_dir = Path("./data") / session_id
+    for candidate in (session_data_dir / "pending_documents", session_data_dir / "documents"):
+        if candidate.exists():
+            local_files = [f for f in sorted(candidate.iterdir())
+                           if f.is_file() and not f.name.startswith('.')]
+            if local_files:
+                logger.info("Using %d documents from %s", len(local_files), candidate)
+                return [str(candidate.absolute())]
 
     # No uploaded files - resolve from config.docs_path
     docs_paths = config.docs_path if isinstance(config.docs_path, list) else [config.docs_path]

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -2567,17 +2567,10 @@ function Workspace() {
     markRerunNeeded(kind, columns);
 
     if (kind === 'unit') {
-      toast({
-        title: 'Observation unit updated',
-        description: sessionMode === 'schematiq'
-          ? 'Changing the unit changes row granularity. Rediscover the schema, then re-extract all data.'
-          : 'Imported static projects can edit the unit, but rediscovery needs a ScheMatiQ project with source documents.',
-        action: sessionMode === 'schematiq' ? (
-          <ToastAction altText="Rediscover schema and re-extract" onClick={() => startSchemaRediscovery()}>
-            Rediscover &amp; re-extract
-          </ToastAction>
-        ) : undefined,
-      });
+      // The persistent top banner (driven by markRerunNeeded above) already
+      // surfaces the "Rediscover schema & re-extract" action. We intentionally
+      // do not also fire a toast here to avoid two competing prompts for the
+      // same action.
       return;
     }
 


### PR DESCRIPTION
Changing the observation unit now runs schema rediscovery **and** value extraction (observation unit → schema → data), and only the top banner is shown.

Root causes:
1. resolve_docs_paths only checked pending_documents/, but completed runs move docs to documents/ — so rediscovery found no documents, ran schema-only, and skipped extraction.
2. notifyEditFollowUp fired a toast in addition to the persistent banner for the same action.

Verification: config_handler.py parses cleanly; patch applies cleanly. TODO before merge: npx tsc --noEmit -p tsconfig.json in frontend/ + backend test suite.