### PR TITLE
chore: clear exhaustive-deps warning in Workspace

### DIFF
--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -1152,7 +1152,7 @@ function SpreadsheetSurface({
       // Schema and Data tabs in sync with a single source of truth.
       return false;
     },
-    [activeSheet, onEditFollowUp, onRefresh, schemaColumns, sessionId, toast],
+    [activeSheet, onRefresh, schemaColumns, sessionId, toast],
   );
 
   if (!sessionId) {


### PR DESCRIPTION
Removes the unused onEditFollowUp dependency from handleBeforeRemoveRow (deletion does not trigger the follow-up). eslint + tsc clean. No behavior change.