### PR TITLE
Harden chat get_schema result truncation and column editing

### DIFF
--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -33,6 +33,7 @@ Terminology (do not confuse these):
 Rules:
 - Call read tools before edits: get_schema for columns, get_observation_unit for the row entity definition.
 - Never guess column names. If the user mentions the Observation Unit tab or what a row represents, use edit_observation_unit — not edit_column.
+- edit_column can update a column's name, definition, and/or rationale (why the column matters / how to extract it). When the user asks to add or change a rationale, pass the `rationale` argument — do not claim it is unsupported. Confirm WHICH column they mean from get_schema before editing, and never edit several columns unless the user explicitly asked for all of them.
 - After edit_observation_unit or schema definition changes (edit_column, add_column, delete_column), existing table values may be stale. Offer reextract to refresh values from documents, or run_schematiq / continue_discovery when the user wants schema rediscovery.
 - Manual update_cell edits do not require re-extraction unless the user asks to repopulate from documents.
 - Cheap tools run immediately. Expensive tools (reextract, reprocess, continue_discovery, run_schematiq) require user confirmation.
@@ -463,7 +464,9 @@ class ChatAgentService:
             names = result.get("column_names") or [
                 col.get("name") for col in result.get("schema", []) if col.get("name")
             ]
-            count = len(names)
+            count = result.get("column_count")
+            if count is None:
+                count = len(names)
             preview = ", ".join(names[:8])
             suffix = f": {preview}" if preview else ""
             return f"...schema loaded ({count} columns{suffix})"

--- a/backend/app/services/chat/deps.py
+++ b/backend/app/services/chat/deps.py
@@ -74,8 +74,63 @@ def get_gemini_api_key() -> str:
     return key
 
 
-def truncate_result(value: Any, max_chars: int = 4000) -> Any:
+def truncate_result(value: Any, max_chars: int = 8000) -> Any:
     text = json.dumps(value, ensure_ascii=False, default=str)
     if len(text) <= max_chars:
         return value
+
+    def _size(item: Any) -> int:
+        return len(json.dumps(item, ensure_ascii=False, default=str))
+
+    # Preserve structure instead of collapsing the whole payload into an opaque
+    # preview string. Callers (and the model) rely on specific keys — e.g.
+    # get_schema's `column_names`/`column_count` drive the "(N columns)" summary
+    # and tell the agent which columns exist. A blunt preview drops those keys
+    # and reports 0 columns while feeding the model a JSON string cut mid-object.
+    if isinstance(value, dict):
+        # Small, high-signal keys are always kept verbatim first; the rest of the
+        # budget is filled with heavier keys (lists are kept partially).
+        summary_keys = (
+            "status", "message", "error", "hint", "truncated",
+            "column_names", "column_count", "total_count", "query",
+            "observation_unit", "format", "operation", "reprocessing",
+        )
+        kept: dict[str, Any] = {}
+        for key in summary_keys:
+            if key in value:
+                kept[key] = value[key]
+        remaining = max(max_chars - _size(kept), 0)
+        for key, item in value.items():
+            if key in kept:
+                continue
+            chunk = _size(item)
+            if chunk <= remaining:
+                kept[key] = item
+                remaining -= chunk
+            elif isinstance(item, list):
+                subset: list[Any] = []
+                for entry in item:
+                    entry_size = _size(entry)
+                    if entry_size > remaining:
+                        break
+                    subset.append(entry)
+                    remaining -= entry_size
+                kept[key] = subset
+                if len(subset) < len(item):
+                    kept[f"{key}_omitted"] = len(item) - len(subset)
+            # Oversized non-list values are dropped (key omitted) to stay in budget.
+        kept["truncated"] = True
+        return kept
+
+    if isinstance(value, list):
+        subset = []
+        remaining = max_chars
+        for entry in value:
+            entry_size = _size(entry)
+            if entry_size > remaining:
+                break
+            subset.append(entry)
+            remaining -= entry_size
+        return {"truncated": True, "items": subset, "omitted": len(value) - len(subset)}
+
     return {"truncated": True, "preview": text[:max_chars]}

--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -101,10 +101,28 @@ class ToolExecutor:
   ) -> dict[str, Any]:
       session = session_manager.get_session(session_id)
       if session and session.columns:
+          # Return a compact, agent-focused view (name/definition/rationale/
+          # allowed_values) instead of the full model_dump. Dropping noise fields
+          # (counts, timestamps, pending/value details) keeps the payload small so
+          # the whole schema survives result-size limits and reaches the model
+          # intact — a truncated schema is what makes the agent mis-handle edits.
+          def _compact(col: ColumnInfo) -> dict[str, Any]:
+              entry: dict[str, Any] = {"name": col.name}
+              if col.display_name:
+                  entry["display_name"] = col.display_name
+              if col.definition:
+                  entry["definition"] = col.definition
+              if col.rationale:
+                  entry["rationale"] = col.rationale
+              if col.allowed_values:
+                  entry["allowed_values"] = col.allowed_values
+              return entry
+
           return {
               "query": session.schema_query or "",
-              "schema": [col.model_dump() for col in session.columns],
+              "column_count": len(session.columns),
               "column_names": [col.name for col in session.columns],
+              "schema": [_compact(col) for col in session.columns],
               "observation_unit": (
                   session.observation_unit.model_dump() if session.observation_unit else None
               ),
@@ -292,7 +310,16 @@ class ToolExecutor:
           try:
               await data_editor.rename_column(session_id, old_name, new_name)
           except FileNotFoundError:
-              pass
+              # Expected on storage backends with no local data file yet (e.g. a
+              # freshly created session, or the Supabase backend where this path
+              # no-ops). The schema rename already succeeded above; the data-file
+              # rename is best-effort. Log rather than swallow silently so a real
+              # failure is visible in diagnostics.
+              logger.warning(
+                  "rename_column: no data file to rename for session %s (%s -> %s); "
+                  "schema updated, data rename skipped.",
+                  session_id, old_name, new_name,
+              )
       await websocket_manager.broadcast_schema_updated(
           session_id,
           {

--- a/backend/tests/test_chat_result_truncation.py
+++ b/backend/tests/test_chat_result_truncation.py
@@ -1,0 +1,139 @@
+"""Regression tests for chat tool-result truncation.
+
+A large get_schema result must never be collapsed into an opaque preview.
+Doing so silently reported "0 columns" to the UI and fed the model a JSON
+string cut mid-object, which made the agent mishandle column edits (e.g.
+claiming rationale was unsupported, or editing every column at once).
+
+truncate_result must keep the high-signal summary keys (column_count,
+column_names) and preserve as many full schema entries as the budget allows,
+so both the UI label and the model still see an accurate schema.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.models.session import (
+    ColumnInfo,
+    SessionMetadata,
+    SessionStatus,
+    SessionType,
+    VisualizationSession,
+)
+from app.services.chat.agent_service import ChatAgentService
+from app.services.chat.deps import truncate_result
+from app.services.chat.tool_executor import ToolExecutor
+
+_LONG_DEF = (
+    "A deliberately long column definition sentence used to inflate the "
+    "serialized schema payload well beyond the truncation budget so the "
+    "truncation branch is actually exercised by this test."
+)
+_LONG_RATIONALE = (
+    "An equally verbose rationale describing why this column matters for the "
+    "research query and how its values should be extracted from documents."
+)
+
+
+def _big_schema_result(n: int = 40) -> dict:
+    cols = [
+        {
+            "name": f"column_{i}",
+            "definition": _LONG_DEF,
+            "rationale": _LONG_RATIONALE,
+        }
+        for i in range(n)
+    ]
+    return {
+        "query": "some research query",
+        "column_count": n,
+        "column_names": [c["name"] for c in cols],
+        "schema": cols,
+        "observation_unit": None,
+    }
+
+
+def test_small_result_is_returned_unchanged():
+    payload = {
+        "query": "q",
+        "column_count": 1,
+        "column_names": ["a"],
+        "schema": [{"name": "a", "definition": "short"}],
+    }
+    assert truncate_result(payload) is payload
+
+
+def test_large_schema_preserves_count_and_names():
+    payload = _big_schema_result(40)
+    # Sanity check: the payload genuinely exceeds the budget, so we are testing
+    # the truncation path and not the pass-through path.
+    assert len(json.dumps(payload, ensure_ascii=False)) > 8000
+
+    out = truncate_result(payload)
+
+    assert out["truncated"] is True
+    # The two keys the UI label and the agent depend on must survive intact.
+    assert out["column_count"] == 40
+    assert out["column_names"] == payload["column_names"]
+    # The schema list is kept partially (never dropped wholesale), and the
+    # number of omitted entries is reported.
+    assert isinstance(out.get("schema"), list)
+    assert len(out["schema"]) >= 1
+    if len(out["schema"]) < 40:
+        assert out["schema_omitted"] == 40 - len(out["schema"])
+
+
+def test_large_list_keeps_partial_items_not_preview():
+    big = [{"i": i, "pad": "x" * 200} for i in range(200)]
+    out = truncate_result(big)
+    assert out["truncated"] is True
+    assert "preview" not in out
+    assert len(out["items"]) < 200
+    assert out["omitted"] == 200 - len(out["items"])
+
+
+def test_label_reports_real_count_from_truncated_result():
+    agent = ChatAgentService()
+    truncated = truncate_result(_big_schema_result(40))
+    label = agent._tool_done_message("get_schema", truncated)
+    assert "40 columns" in label
+    assert "(0 columns" not in label
+
+
+@pytest.fixture
+def large_session(session_manager_fixture):
+    cols = [
+        ColumnInfo(
+            name=f"col_{i}",
+            definition=_LONG_DEF,
+            rationale=_LONG_RATIONALE,
+        )
+        for i in range(40)
+    ]
+    session = VisualizationSession(
+        id="chat-truncation-session",
+        type=SessionType.SCHEMATIQ,
+        status=SessionStatus.COMPLETED,
+        metadata=SessionMetadata(source="test"),
+        columns=cols,
+        schema_query="big query",
+    )
+    session_manager_fixture.create_session(session)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_get_schema_survives_truncation_end_to_end(large_session):
+    """The original failure: get_schema on a many-column session reported 0."""
+    executor = ToolExecutor()
+    result = await executor.execute("get_schema", large_session.id, "schematiq", {})
+
+    assert result["column_count"] == 40
+    assert len(result["column_names"]) == 40
+
+    label = ChatAgentService()._tool_done_message("get_schema", result)
+    assert "40 columns" in label
+    assert "(0 columns" not in label


### PR DESCRIPTION
Restores the get_schema truncation fix that did not land in main (only the rationale change merged), plus follow-up hardening.

(1) truncate_result is now structure-preserving: it keeps high-signal keys (column_count, column_names) and partial lists instead of collapsing the whole payload into an opaque preview string. The old behavior silently reported '0 columns' in the UI and fed the model a JSON object cut mid-stream, which made the agent mishandle column edits. (2) get_schema returns a compact per-column payload plus column_count, so a many-column schema stays under the size budget and reaches the agent intact. (3) Result budget raised 4000 -> 8000. (4) edit_column system prompt clarifies rationale is editable and to confirm the target column before editing. (5) Silent except FileNotFoundError in the column rename path now logs a warning.

Verification: py_compile passes all three modules; 47 chat tests pass (existing + new test_chat_result_truncation.py). TODO before merge: full backend test suite.