### PR TITLE
Replace native title with instant CSS tooltips on Schema header icons.

### DIFF
--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -563,9 +563,20 @@
   border-color: #b7d4c1;
   color: #0f5132;
   font-weight: 700;
+  overflow: visible;
+}
+
+.workspace-hot .handsontable .ht_clone_top thead th {
+  overflow: visible;
+}
+
+.workspace-hot .handsontable .htCore thead th .relative,
+.workspace-hot .handsontable .ht_clone_top thead th .relative {
+  overflow: visible;
 }
 
 .workspace-hot .handsontable .colHeader .workspace-col-header-info {
+  position: relative;
   display: inline-flex;
   vertical-align: middle;
   margin-left: 4px;
@@ -577,6 +588,39 @@
 .workspace-hot .handsontable .colHeader .workspace-col-header-info svg {
   width: 14px;
   height: 14px;
+}
+
+.workspace-hot .handsontable .colHeader .workspace-col-header-info::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: calc(100% + 6px);
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 200;
+  width: max-content;
+  max-width: 20rem;
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  white-space: normal;
+  text-align: left;
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 100ms ease, visibility 100ms ease;
+  transition-delay: 0ms;
+}
+
+.workspace-hot .handsontable .colHeader .workspace-col-header-info:hover::after,
+.workspace-hot .handsontable .colHeader .workspace-col-header-info:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
 }
 
 .workspace-hot .handsontable .htCore tbody th {

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -159,7 +159,7 @@ function formatSheetColHeader(column: SheetColumn): string {
   const label = escapeHtmlText(column.label);
   if (!column.headerTooltip) return label;
   const escaped = escapeHtmlAttribute(column.headerTooltip);
-  return `${label}<span class="workspace-col-header-info" title="${escaped}" aria-label="${escaped}">${SCHEMA_COLUMN_HEADER_INFO_ICON}</span>`;
+  return `${label}<span class="workspace-col-header-info" data-tooltip="${escaped}" aria-label="${escaped}" tabindex="0" role="img">${SCHEMA_COLUMN_HEADER_INFO_ICON}</span>`;
 }
 
 type WorkspaceMessage = {


### PR DESCRIPTION
Native title tooltips have an uncontrollable delay; use data-tooltip and CSS for fast hover help.