### PR TITLE
Fix Workspace data grid rendering at half width on initial load

### DIFF
--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -794,6 +794,17 @@ function SpreadsheetSurface({
   const { sessionId } = useParams();
   const { toast } = useToast();
   const gridContainerRef = useRef<HTMLDivElement | null>(null);
+  // Track the grid container as state (not just a ref) so the measurement
+  // effect below re-runs the moment the real element mounts. On the
+  // project-creation flow the surface first renders a placeholder (no session,
+  // no ref) and only attaches the measured element once a session arrives;
+  // a plain ref would not re-trigger the effect, leaving the grid stuck at its
+  // 320px fallback width until a tab switch forces a remount.
+  const [gridContainerEl, setGridContainerEl] = useState<HTMLDivElement | null>(null);
+  const setGridContainerRef = useCallback((node: HTMLDivElement | null) => {
+    gridContainerRef.current = node;
+    setGridContainerEl(node);
+  }, []);
   const lastGridSizeRef = useRef({ width: 0, height: 0 });
   const [gridSize, setGridSize] = useState({ width: 0, height: 0 });
 
@@ -832,7 +843,7 @@ function SpreadsheetSurface({
   }, [applyGridSize, hotTableRef]);
 
   useLayoutEffect(() => {
-    const element = gridContainerRef.current;
+    const element = gridContainerEl;
     if (!element) return undefined;
 
     lastGridSizeRef.current = { width: 0, height: 0 };
@@ -864,7 +875,7 @@ function SpreadsheetSurface({
       observer?.disconnect();
       window.removeEventListener('resize', measureGrid);
     };
-  }, [activeSheet, layoutRevision, measureGrid]);
+  }, [activeSheet, layoutRevision, measureGrid, gridContainerEl]);
 
   useEffect(() => {
     syncHotTableDimensions();
@@ -1357,7 +1368,7 @@ function SpreadsheetSurface({
 
   return (
     <div
-      ref={gridContainerRef}
+      ref={setGridContainerRef}
       className="workspace-grid-surface h-full w-full min-h-0 min-w-0"
       style={{
         '--workspace-table-font': displayOptions.fontFamily === 'Mono'


### PR DESCRIPTION
On the project-creation flow the Workspace data grid first rendered at its 320px fallback width and only expanded to full width after switching tabs and back. SpreadsheetSurface measures its container to size the HotTable, but the measurement useLayoutEffect depended only on [activeSheet, layoutRevision, measureGrid] and read the container via a plain ref. When the surface first mounts without a session it renders a placeholder with no ref attached, so the effect bails early; once a session arrives the real element attaches but none of those deps change, so the effect never re-runs and gridSize stays {0,0} (HotTable falls back to width 320). A tab switch remounts the component, which is why it corrected itself. Fix: attach the grid container via a callback ref that also stores it in state, and add that state to the effect deps, so the full measurement pipeline (double-rAF + 120ms retry + ResizeObserver) re-runs the moment the real element mounts. Covers the creation flow, async data arrival, and direct navigation. Measurement/timing only; no data, row, or editing changes. Verified: tsc --noEmit clean, eslint clean (incl. react-hooks/exhaustive-deps).