### PR TITLE
Enlarge Workspace bottombar (tabs, question, progress)

### DIFF
--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -197,11 +197,11 @@
 
 .workspace-bottombar {
   flex: 0 0 auto;
-  height: 40px;
+  height: 52px;
   display: grid;
-  grid-template-columns: minmax(220px, 30vw) minmax(0, 1fr) clamp(96px, 12vw, 160px) 32px;
+  grid-template-columns: minmax(240px, 32vw) minmax(0, 1fr) clamp(120px, 14vw, 190px) 36px;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   border-top: 1px solid hsl(var(--border));
   background: hsl(var(--background));
   padding: 0 12px;
@@ -232,8 +232,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: hsl(var(--muted-foreground));
-  font-size: 12px;
-  line-height: 1;
+  font-size: 14px;
+  line-height: 1.2;
 }
 
 .workspace-topbar-question:focus-visible {
@@ -256,12 +256,12 @@
   align-items: center;
   gap: 8px;
   color: hsl(var(--muted-foreground));
-  font-size: 12px;
+  font-size: 14px;
   white-space: nowrap;
 }
 
 .workspace-topbar-percent {
-  width: 34px;
+  width: 42px;
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
@@ -417,12 +417,12 @@
 }
 
 .workspace-sheet-tab {
-  height: 28px;
+  height: 36px;
   flex: 0 0 auto;
   border: 1px solid transparent;
   border-radius: 4px;
-  padding: 0 12px;
-  font-size: 12px;
+  padding: 0 14px;
+  font-size: 13px;
   color: hsl(var(--muted-foreground));
 }
 

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -3087,7 +3087,7 @@ function Workspace() {
         <div className="workspace-topbar-status" title={bottombarStatus}>
           {status || reextraction ? (
             <>
-              <Progress value={bottombarProgress} className="h-1.5" />
+              <Progress value={bottombarProgress} className="h-2.5" />
               <span className="workspace-topbar-percent">{bottombarProgress}%</span>
               {reextraction && (
                 <Button


### PR DESCRIPTION
The bottombar that holds the sheet tabs, research question and progress indicator was a bit too small to read comfortably. Scales it up while keeping the same layout and proportions: bar height 40px -> 52px, sheet tabs 28px -> 36px with 13px text and wider padding, question text 12px -> 14px, progress percentage 12px -> 14px in a wider column, and the progress bar thickened (h-1.5 -> h-2.5). Pure styling — the grid template columns widen slightly to fit the larger tabs and progress; no behaviour, data or layout-structure changes. Verified: tsc --noEmit clean.