### PR TITLE
fix(workspace): keep toasts from covering the bottombar progress

### DIFF
--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[150] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "app-toast-viewport fixed top-0 z-[150] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
       className
     )}
     {...props}

--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -273,6 +273,17 @@
   text-overflow: ellipsis;
 }
 
+/* Lift the global toast viewport above the 52px workspace bottombar so
+   transient toasts (e.g. "Project started") never cover the live progress bar.
+   Scoped to the Workspace route via the body attribute, and only on the sm+
+   breakpoint where the viewport is bottom-anchored (it is top-anchored on
+   mobile). The viewport's own padding adds the visual gap above the bar. */
+@media (min-width: 640px) {
+  body[data-workspace-active="true"] .app-toast-viewport {
+    bottom: 52px;
+  }
+}
+
 .workspace-followup-banner {
   flex: 0 0 auto;
   display: flex;

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -2303,6 +2303,16 @@ function Workspace() {
     setSessionMode(requestedMode);
   }, [requestedMode, sessionId]);
 
+  // Mark the body while the Workspace is mounted so global toasts can be lifted
+  // above the fixed bottombar (see Workspace.css). Scoped to this route only so
+  // toast positioning elsewhere in the app is unaffected.
+  useEffect(() => {
+    document.body.setAttribute('data-workspace-active', 'true');
+    return () => {
+      document.body.removeAttribute('data-workspace-active');
+    };
+  }, []);
+
   useEffect(() => {
     setPendingRerunKind(null);
     setPendingSchemaColumns([]);


### PR DESCRIPTION
Transient toasts (e.g. "Project started") were popping up at the bottom-right corner directly over the workspace bottombar's live progress bar and percentage, hiding the status.

This lifts the global toast viewport above the 52px bottombar, scoped to the Workspace route only (via a `data-workspace-active` body attribute) and only on the sm+ breakpoint where the viewport is bottom-anchored. Toast behavior on every other page and on mobile is unchanged.

Changes:
- toast.tsx: add a stable `app-toast-viewport` class to the viewport for scoped CSS targeting
- Workspace.tsx: set/remove the body attribute on mount/unmount
- Workspace.css: media-query rule lifting the viewport by 52px on the workspace