### PR TITLE
Share advanced settings UI across classic config and workspace flows

### DIFF
--- a/frontend/src/components/AdvancedSettings/AdvancedSettingsFields.tsx
+++ b/frontend/src/components/AdvancedSettings/AdvancedSettingsFields.tsx
@@ -1,0 +1,539 @@
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { InfoTooltip } from '@/components/InfoTooltip/InfoTooltip';
+import { ModelSelector } from '@/components/ModelSelector';
+import InitialSchemaEditor from '@/components/InitialSchemaEditor/InitialSchemaEditor';
+import {
+  DEFAULT_DOCUMENT_RANDOMIZATION_SEED,
+  DEFAULT_DOCUMENTS_BATCH_SIZE,
+  DEFAULT_MAX_KEYS_SCHEMA,
+  DEFAULT_SCHEMA_MODEL,
+  DEFAULT_RELEASE_EXTRACTION_MODEL,
+  LLM_PROVIDER_NAMES,
+  getDefaultModelForProvider,
+  type LLMProviderKey,
+} from '@/constants';
+import type { InitialSchemaColumn } from '@/types';
+
+/**
+ * Normalized model for the advanced extraction settings, shared by the classic
+ * config screen and the Workspace new-project dialog. Each screen adapts this
+ * model to/from its own config representation; this component only renders the
+ * fields and reports changes through onChange.
+ */
+export interface AdvancedSettingsValue {
+  skipValueExtraction: boolean;
+  maxKeysSchema: number;
+  documentsBatchSize: number;
+  // Developer-mode schema params
+  seed: number;
+  convergenceThreshold: number | null;
+  // Observation unit
+  observationUnitMode: 'auto' | 'name_only' | 'full';
+  observationUnitName: string;
+  observationUnitDefinition: string;
+  reviewObservationUnit: boolean;
+  // LLM configuration (shown when allowLlmConfig)
+  schemaProvider: string;
+  schemaModel: string;
+  schemaTemperature: number;
+  valueProvider: string;
+  valueModel: string;
+  valueTemperature: number;
+  // Retriever (developer mode)
+  retrieverModelName: string;
+  retrieverPassageChars: number;
+  retrieverOverlap: number;
+  retrieverK: number;
+  retrieverDynamicK: number;
+  // Developer mode: bypass the document limit on upload
+  bypassLimit: boolean;
+  // Pre-defined columns
+  initialSchemaPath?: string;
+  initialSchemaData?: InitialSchemaColumn[] | null;
+}
+
+/** Backend retriever defaults (mirror backend RetrieverConfig pydantic model). */
+export const RETRIEVER_DEFAULTS = {
+  model_name: 'all-MiniLM-L6-v2',
+  passage_chars: 512,
+  overlap: 64,
+  k: 15,
+  dynamic_k_threshold: 0.65,
+} as const;
+
+export const DEFAULT_ADVANCED_SETTINGS: AdvancedSettingsValue = {
+  skipValueExtraction: false,
+  maxKeysSchema: DEFAULT_MAX_KEYS_SCHEMA,
+  documentsBatchSize: DEFAULT_DOCUMENTS_BATCH_SIZE,
+  seed: DEFAULT_DOCUMENT_RANDOMIZATION_SEED,
+  convergenceThreshold: null,
+  observationUnitMode: 'auto',
+  observationUnitName: '',
+  observationUnitDefinition: '',
+  reviewObservationUnit: false,
+  schemaProvider: 'gemini',
+  schemaModel: DEFAULT_SCHEMA_MODEL,
+  schemaTemperature: 0,
+  valueProvider: 'gemini',
+  valueModel: DEFAULT_RELEASE_EXTRACTION_MODEL,
+  valueTemperature: 0,
+  retrieverModelName: RETRIEVER_DEFAULTS.model_name,
+  retrieverPassageChars: RETRIEVER_DEFAULTS.passage_chars,
+  retrieverOverlap: RETRIEVER_DEFAULTS.overlap,
+  retrieverK: RETRIEVER_DEFAULTS.k,
+  retrieverDynamicK: RETRIEVER_DEFAULTS.dynamic_k_threshold,
+  bypassLimit: false,
+  initialSchemaPath: undefined,
+  initialSchemaData: null,
+};
+
+/** True when any retriever field differs from the backend defaults. */
+export function retrieverIsCustomized(value: AdvancedSettingsValue): boolean {
+  return (
+    value.retrieverModelName !== RETRIEVER_DEFAULTS.model_name ||
+    value.retrieverPassageChars !== RETRIEVER_DEFAULTS.passage_chars ||
+    value.retrieverOverlap !== RETRIEVER_DEFAULTS.overlap ||
+    value.retrieverK !== RETRIEVER_DEFAULTS.k ||
+    value.retrieverDynamicK !== RETRIEVER_DEFAULTS.dynamic_k_threshold
+  );
+}
+
+/** Builds the initial_observation_unit payload from the model, if any. */
+export function observationUnitFromValue(
+  value: AdvancedSettingsValue,
+): { name: string; definition?: string } | undefined {
+  const name = value.observationUnitName.trim();
+  if (value.observationUnitMode === 'name_only' && name) {
+    return { name };
+  }
+  if (value.observationUnitMode === 'full' && name) {
+    return { name, definition: value.observationUnitDefinition.trim() || undefined };
+  }
+  return undefined;
+}
+
+interface AdvancedSettingsFieldsProps {
+  value: AdvancedSettingsValue;
+  onChange: (patch: Partial<AdvancedSettingsValue>) => void;
+  developerMode: boolean;
+  allowLlmConfig: boolean;
+  providers: LLMProviderKey[];
+  maxDocuments?: number;
+  className?: string;
+}
+
+export function AdvancedSettingsFields({
+  value,
+  onChange,
+  developerMode,
+  allowLlmConfig,
+  providers,
+  maxDocuments,
+  className,
+}: AdvancedSettingsFieldsProps) {
+  const [editingSchemaLlm, setEditingSchemaLlm] = useState(false);
+  const [editingValueLlm, setEditingValueLlm] = useState(false);
+
+  return (
+    <div className={className ?? 'space-y-4'}>
+      {/* Schema-only mode */}
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="adv-skip-value"
+          checked={value.skipValueExtraction}
+          onCheckedChange={(checked) => onChange({ skipValueExtraction: checked === true })}
+        />
+        <Label htmlFor="adv-skip-value" className="text-sm cursor-pointer inline-flex items-center gap-1.5">
+          Discover columns only (skip data extraction)
+          <InfoTooltip text="Discover only the table schema without extracting data values. Faster and lower cost." />
+        </Label>
+      </div>
+
+      {/* Schema parameters */}
+      <div className="space-y-3">
+        <Label className="text-sm font-medium">Schema Parameters</Label>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1">
+            <Label htmlFor="adv-max-keys" className="text-xs text-muted-foreground inline-flex items-center gap-1">
+              Max Columns
+              <InfoTooltip text="Maximum number of columns in your table." />
+            </Label>
+            <Input
+              id="adv-max-keys"
+              type="number"
+              min={1}
+              max={500}
+              value={value.maxKeysSchema}
+              onChange={(e) => onChange({ maxKeysSchema: parseInt(e.target.value, 10) || DEFAULT_MAX_KEYS_SCHEMA })}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="adv-batch-size" className="text-xs text-muted-foreground inline-flex items-center gap-1">
+              Batch Size
+              <InfoTooltip text="Documents per schema refinement batch." />
+            </Label>
+            <Input
+              id="adv-batch-size"
+              type="number"
+              min={1}
+              max={20}
+              value={value.documentsBatchSize}
+              onChange={(e) => onChange({ documentsBatchSize: parseInt(e.target.value, 10) || DEFAULT_DOCUMENTS_BATCH_SIZE })}
+            />
+          </div>
+          {developerMode && (
+            <>
+              <div className="space-y-1">
+                <Label htmlFor="adv-seed" className="text-xs text-muted-foreground">Seed</Label>
+                <Input
+                  id="adv-seed"
+                  type="number"
+                  value={value.seed}
+                  onChange={(e) => onChange({ seed: parseInt(e.target.value, 10) || 0 })}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="adv-convergence" className="text-xs text-muted-foreground inline-flex items-center gap-1">
+                  Convergence Threshold
+                  <InfoTooltip text="Number of consecutive batches without schema change needed to stop discovery." />
+                </Label>
+                <Input
+                  id="adv-convergence"
+                  type="number"
+                  min={1}
+                  max={20}
+                  placeholder="default"
+                  value={value.convergenceThreshold ?? ''}
+                  onChange={(e) => {
+                    const raw = e.target.value.trim();
+                    onChange({ convergenceThreshold: raw === '' ? null : (parseInt(raw, 10) || null) });
+                  }}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      <hr />
+
+      {/* Pre-define columns */}
+      <Collapsible>
+        <CollapsibleTrigger className="group flex items-center gap-2 text-sm font-medium hover:text-foreground transition-colors">
+          <ChevronDown className="h-4 w-4 transition-transform duration-200 group-data-[state=open]:rotate-180" />
+          <span>Pre-define columns</span>
+          <span className="text-xs font-normal text-muted-foreground">(optional)</span>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="mt-3">
+          <p className="text-xs text-muted-foreground mb-3">
+            Add columns you want to appear in the final table. Only the column name is
+            required; definition and rationale are optional and will be filled by the
+            AI during discovery if left blank.
+          </p>
+          <InitialSchemaEditor
+            onSchemaChange={(path, data) => onChange({ initialSchemaPath: path, initialSchemaData: data })}
+          />
+        </CollapsibleContent>
+      </Collapsible>
+
+      <hr />
+
+      {/* Observation unit */}
+      <div className="space-y-3">
+        <Label className="text-sm font-medium inline-flex items-center gap-1.5">
+          Observation Unit
+          <InfoTooltip text="What each row in your table represents (e.g., 'a research paper' or 'a patient'). Usually auto-detected, but you can customize it if needed." />
+        </Label>
+        <RadioGroup
+          value={value.observationUnitMode === 'auto' ? 'auto' : 'specify'}
+          onValueChange={(mode) => {
+            if (mode === 'auto') {
+              onChange({ observationUnitMode: 'auto', observationUnitName: '', observationUnitDefinition: '' });
+            } else {
+              onChange({ observationUnitMode: 'name_only', reviewObservationUnit: false });
+            }
+          }}
+          className="space-y-3"
+        >
+          <div className="flex items-start space-x-3">
+            <RadioGroupItem value="auto" id="adv-obs-auto" className="mt-1" />
+            <div className="space-y-1">
+              <Label htmlFor="adv-obs-auto" className="font-medium cursor-pointer">Auto-detect (recommended)</Label>
+              <p className="text-sm text-muted-foreground">
+                The system will automatically determine the observation unit from your query and documents.
+              </p>
+              {value.observationUnitMode === 'auto' && (
+                <div className="flex items-center gap-2 mt-1.5">
+                  <Checkbox
+                    id="adv-review-obs"
+                    checked={value.reviewObservationUnit}
+                    onCheckedChange={(checked) => onChange({ reviewObservationUnit: checked === true })}
+                  />
+                  <Label htmlFor="adv-review-obs" className="text-sm cursor-pointer inline-flex items-center gap-1.5">
+                    Review before schema generation
+                    <InfoTooltip text="Pause after the observation unit is discovered so you can review and edit it before schema generation begins." />
+                  </Label>
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="flex items-start space-x-3">
+            <RadioGroupItem value="specify" id="adv-obs-specify" className="mt-1" />
+            <div className="space-y-1 flex-1">
+              <Label htmlFor="adv-obs-specify" className="font-medium cursor-pointer">I'll specify</Label>
+              <p className="text-sm text-muted-foreground">
+                Provide a unit name; optionally add a definition for full control.
+              </p>
+              {value.observationUnitMode !== 'auto' && (
+                <div className="space-y-2 mt-2">
+                  <Input
+                    placeholder="e.g., Research Paper, Model-Benchmark Evaluation"
+                    value={value.observationUnitName}
+                    onChange={(e) => onChange({ observationUnitName: e.target.value })}
+                  />
+                  <Collapsible>
+                    <CollapsibleTrigger className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
+                      <ChevronDown className="h-3.5 w-3.5" />
+                      <span>Add definition</span>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="mt-2">
+                      <Input
+                        placeholder="e.g., Each row represents a single research paper"
+                        value={value.observationUnitDefinition}
+                        onChange={(e) => onChange({
+                          observationUnitDefinition: e.target.value,
+                          observationUnitMode: e.target.value.trim() ? 'full' : 'name_only',
+                        })}
+                      />
+                    </CollapsibleContent>
+                  </Collapsible>
+                </div>
+              )}
+            </div>
+          </div>
+        </RadioGroup>
+      </div>
+
+      {/* LLM configuration */}
+      {allowLlmConfig && (
+        <>
+          <hr />
+          {/* Schema creation LLM */}
+          <div className="space-y-3">
+            {editingSchemaLlm ? (
+              <>
+                <div className="flex items-center justify-between">
+                  <Label className="text-sm font-medium">Schema Creation LLM</Label>
+                  <Button variant="ghost" size="sm" onClick={() => setEditingSchemaLlm(false)}>Done</Button>
+                </div>
+                <div className="space-y-2">
+                  <div className="space-y-1">
+                    <Label className="text-xs">Provider</Label>
+                    <Select
+                      value={value.schemaProvider}
+                      onValueChange={(provider) => onChange({ schemaProvider: provider, schemaModel: getDefaultModelForProvider(provider as LLMProviderKey) })}
+                    >
+                      <SelectTrigger><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        {providers.map((provider) => (
+                          <SelectItem key={provider} value={provider}>{LLM_PROVIDER_NAMES[provider]}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Model</Label>
+                    <ModelSelector
+                      provider={value.schemaProvider as LLMProviderKey}
+                      value={value.schemaModel}
+                      onChange={(modelId) => onChange({ schemaModel: modelId })}
+                      showDetails
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Temperature</Label>
+                    <Input
+                      type="number"
+                      min={0}
+                      max={2}
+                      step={0.1}
+                      value={value.schemaTemperature}
+                      onChange={(e) => onChange({ schemaTemperature: parseFloat(e.target.value) || 0 })}
+                    />
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className="flex items-center justify-between">
+                <div className="text-sm">
+                  <span className="font-medium">Schema LLM:</span>{' '}
+                  <span className="text-muted-foreground">
+                    {LLM_PROVIDER_NAMES[value.schemaProvider as LLMProviderKey]} / {value.schemaModel}
+                    {value.schemaTemperature !== 0 && ` (temp: ${value.schemaTemperature})`}
+                  </span>
+                </div>
+                <Button variant="ghost" size="sm" onClick={() => setEditingSchemaLlm(true)}>Edit</Button>
+              </div>
+            )}
+          </div>
+
+          <hr />
+
+          {/* Value extraction LLM */}
+          <div className="space-y-3">
+            {editingValueLlm ? (
+              <>
+                <div className="flex items-center justify-between">
+                  <Label className="text-sm font-medium">Value Extraction LLM</Label>
+                  <Button variant="ghost" size="sm" onClick={() => setEditingValueLlm(false)}>Done</Button>
+                </div>
+                <div className="space-y-2">
+                  <div className="space-y-1">
+                    <Label className="text-xs">Provider</Label>
+                    <Select
+                      value={value.valueProvider}
+                      onValueChange={(provider) => onChange({ valueProvider: provider, valueModel: getDefaultModelForProvider(provider as LLMProviderKey) })}
+                    >
+                      <SelectTrigger><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        {providers.map((provider) => (
+                          <SelectItem key={provider} value={provider}>{LLM_PROVIDER_NAMES[provider]}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Model</Label>
+                    <ModelSelector
+                      provider={value.valueProvider as LLMProviderKey}
+                      value={value.valueModel}
+                      onChange={(modelId) => onChange({ valueModel: modelId })}
+                      showDetails
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Temperature</Label>
+                    <Input
+                      type="number"
+                      min={0}
+                      max={2}
+                      step={0.1}
+                      value={value.valueTemperature}
+                      onChange={(e) => onChange({ valueTemperature: parseFloat(e.target.value) || 0 })}
+                    />
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className="flex items-center justify-between">
+                <div className="text-sm">
+                  <span className="font-medium">Value LLM:</span>{' '}
+                  <span className="text-muted-foreground">
+                    {LLM_PROVIDER_NAMES[value.valueProvider as LLMProviderKey]} / {value.valueModel}
+                    {value.valueTemperature !== 0 && ` (temp: ${value.valueTemperature})`}
+                  </span>
+                </div>
+                <Button variant="ghost" size="sm" onClick={() => setEditingValueLlm(true)}>Edit</Button>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Retriever (developer mode) */}
+      {developerMode && (
+        <>
+          <hr />
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Retriever</Label>
+            <div className="space-y-2">
+              <div className="space-y-1">
+                <Label className="text-xs">Model Name</Label>
+                <Input
+                  value={value.retrieverModelName}
+                  onChange={(e) => onChange({ retrieverModelName: e.target.value })}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <div className="space-y-1">
+                  <Label className="text-xs">Passage Chars</Label>
+                  <Input
+                    type="number"
+                    min={128}
+                    max={2048}
+                    value={value.retrieverPassageChars}
+                    onChange={(e) => onChange({ retrieverPassageChars: parseInt(e.target.value, 10) || RETRIEVER_DEFAULTS.passage_chars })}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">Overlap</Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={256}
+                    value={value.retrieverOverlap}
+                    onChange={(e) => onChange({ retrieverOverlap: parseInt(e.target.value, 10) || 0 })}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">K</Label>
+                  <Input
+                    type="number"
+                    min={1}
+                    max={50}
+                    value={value.retrieverK}
+                    onChange={(e) => onChange({ retrieverK: parseInt(e.target.value, 10) || 1 })}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">Dynamic K</Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={1}
+                    step={0.05}
+                    value={value.retrieverDynamicK}
+                    onChange={(e) => onChange({ retrieverDynamicK: parseFloat(e.target.value) || 0 })}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Bypass document limit (developer mode) */}
+      {developerMode && (
+        <>
+          <hr />
+          <div className="flex items-center justify-between p-3 border rounded-lg bg-amber-50 border-amber-200 dark:bg-amber-950/20 dark:border-amber-800">
+            <div>
+              <Label className="text-sm font-medium">Bypass Document Limit</Label>
+              <p className="text-xs text-muted-foreground">
+                Disable the {maxDocuments ? `${maxDocuments}-document ` : 'document '}limit for testing.
+              </p>
+            </div>
+            <Switch checked={value.bypassLimit} onCheckedChange={(checked) => onChange({ bypassLimit: checked })} />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default AdvancedSettingsFields;

--- a/frontend/src/pages/ScheMatiQConfig.tsx
+++ b/frontend/src/pages/ScheMatiQConfig.tsx
@@ -12,28 +12,17 @@ import {
 import {
   getDefaultModelForProvider,
   getAvailableProviders,
-  LLM_PROVIDER_NAMES,
   LLMProviderKey,
   DEFAULT_SCHEMA_MODEL,
   DEFAULT_RELEASE_EXTRACTION_MODEL,
 } from '@/constants/llmModels';
-import { ModelSelector } from '@/components/ModelSelector';
 
 import { WelcomeDialog } from '@/components/WelcomeDialog/WelcomeDialog';
 import { ConsentDialog, getSavedConsent } from '@/components/ConsentDialog/ConsentDialog';
-import { InfoTooltip } from '@/components/InfoTooltip/InfoTooltip';
 
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -43,11 +32,13 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Switch } from '@/components/ui/switch';
-import { Checkbox } from '@/components/ui/checkbox';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-import InitialSchemaEditor from '@/components/InitialSchemaEditor/InitialSchemaEditor';
+import {
+  AdvancedSettingsFields,
+  RETRIEVER_DEFAULTS,
+  type AdvancedSettingsValue,
+} from '@/components/AdvancedSettings/AdvancedSettingsFields';
 import {
   Sheet,
   SheetContent,
@@ -100,10 +91,6 @@ const ScheMatiQConfigPage = () => {
 
   // Settings sheet state
   const [settingsOpen, setSettingsOpen] = useState(false);
-
-  // LLM editing states (dev mode smart defaults display)
-  const [editingSchemaLlm, setEditingSchemaLlm] = useState(false);
-  const [editingValueLlm, setEditingValueLlm] = useState(false);
 
   // Cost estimate expand state
   const [costExpanded, setCostExpanded] = useState(false);
@@ -402,8 +389,6 @@ const ScheMatiQConfigPage = () => {
     setObservationUnitDefinition('');
     setCostEstimate(null);
     setSettingsOpen(false);
-    setEditingSchemaLlm(false);
-    setEditingValueLlm(false);
     setCostExpanded(false);
     setError(null);
   };
@@ -475,6 +460,64 @@ const ScheMatiQConfigPage = () => {
         [field]: value,
       },
     }));
+  };
+
+  // Adapter: map this screen's config + local state into the shared
+  // AdvancedSettingsFields model, and route the model's changes back to the
+  // existing setters/handlers so submit, restore, and cost-estimate logic
+  // stay unchanged.
+  const advancedValue: AdvancedSettingsValue = useMemo(() => ({
+    skipValueExtraction: config.skip_value_extraction ?? false,
+    maxKeysSchema: config.max_keys_schema,
+    documentsBatchSize: config.documents_batch_size,
+    seed: config.document_randomization_seed,
+    convergenceThreshold: config.convergence_threshold ?? null,
+    observationUnitMode,
+    observationUnitName,
+    observationUnitDefinition,
+    reviewObservationUnit: config.review_observation_unit ?? false,
+    schemaProvider: config.schema_creation_backend.provider,
+    schemaModel: config.schema_creation_backend.model,
+    schemaTemperature: config.schema_creation_backend.temperature,
+    valueProvider: config.value_extraction_backend.provider,
+    valueModel: config.value_extraction_backend.model,
+    valueTemperature: config.value_extraction_backend.temperature,
+    retrieverModelName: config.retriever?.model_name ?? RETRIEVER_DEFAULTS.model_name,
+    retrieverPassageChars: config.retriever?.passage_chars ?? RETRIEVER_DEFAULTS.passage_chars,
+    retrieverOverlap: config.retriever?.overlap ?? RETRIEVER_DEFAULTS.overlap,
+    retrieverK: config.retriever?.k ?? RETRIEVER_DEFAULTS.k,
+    retrieverDynamicK: config.retriever?.dynamic_k_threshold ?? RETRIEVER_DEFAULTS.dynamic_k_threshold,
+    bypassLimit: limitBypassEnabled,
+    initialSchemaPath,
+    initialSchemaData,
+  }), [config, observationUnitMode, observationUnitName, observationUnitDefinition, limitBypassEnabled, initialSchemaPath, initialSchemaData]);
+
+  const applyAdvancedSettings = (patch: Partial<AdvancedSettingsValue>) => {
+    if (patch.skipValueExtraction !== undefined) handleConfigChange('skip_value_extraction', patch.skipValueExtraction);
+    if (patch.maxKeysSchema !== undefined) handleConfigChange('max_keys_schema', patch.maxKeysSchema);
+    if (patch.documentsBatchSize !== undefined) handleConfigChange('documents_batch_size', patch.documentsBatchSize);
+    if (patch.seed !== undefined) handleConfigChange('document_randomization_seed', patch.seed);
+    if ('convergenceThreshold' in patch) handleConfigChange('convergence_threshold', patch.convergenceThreshold ?? undefined);
+    if (patch.reviewObservationUnit !== undefined) handleConfigChange('review_observation_unit', patch.reviewObservationUnit);
+    if (patch.observationUnitMode !== undefined) setObservationUnitMode(patch.observationUnitMode);
+    if (patch.observationUnitName !== undefined) setObservationUnitName(patch.observationUnitName);
+    if (patch.observationUnitDefinition !== undefined) setObservationUnitDefinition(patch.observationUnitDefinition);
+    if (patch.schemaProvider !== undefined) handleSchemaBackendChange('provider', patch.schemaProvider);
+    if (patch.schemaModel !== undefined) handleSchemaBackendChange('model', patch.schemaModel);
+    if (patch.schemaTemperature !== undefined) handleSchemaBackendChange('temperature', patch.schemaTemperature);
+    if (patch.valueProvider !== undefined) handleValueBackendChange('provider', patch.valueProvider);
+    if (patch.valueModel !== undefined) handleValueBackendChange('model', patch.valueModel);
+    if (patch.valueTemperature !== undefined) handleValueBackendChange('temperature', patch.valueTemperature);
+    if (patch.retrieverModelName !== undefined) handleRetrieverChange('model_name', patch.retrieverModelName);
+    if (patch.retrieverPassageChars !== undefined) handleRetrieverChange('passage_chars', patch.retrieverPassageChars);
+    if (patch.retrieverOverlap !== undefined) handleRetrieverChange('overlap', patch.retrieverOverlap);
+    if (patch.retrieverK !== undefined) handleRetrieverChange('k', patch.retrieverK);
+    if (patch.retrieverDynamicK !== undefined) handleRetrieverChange('dynamic_k_threshold', patch.retrieverDynamicK);
+    if (patch.bypassLimit !== undefined) setLimitBypassEnabled(patch.bypassLimit);
+    if ('initialSchemaPath' in patch || 'initialSchemaData' in patch) {
+      setInitialSchemaPath(patch.initialSchemaPath);
+      setInitialSchemaData(patch.initialSchemaData ?? undefined);
+    }
   };
 
   // InitialSchema state kept for navigation-state restoration; UI hidden for simplicity
@@ -1141,413 +1184,14 @@ const ScheMatiQConfigPage = () => {
             <SheetDescription>Fine-tune how the schema is discovered and data is extracted.</SheetDescription>
           </SheetHeader>
           <div className="space-y-4">
-                {/* Schema Only Mode Checkbox */}
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="schema-only"
-                    checked={config.skip_value_extraction || false}
-                    onCheckedChange={(checked) => handleConfigChange('skip_value_extraction', checked)}
-                  />
-                  <Label htmlFor="schema-only" className="text-sm cursor-pointer inline-flex items-center gap-1.5">
-                    Discover columns only (skip data extraction)
-                    <InfoTooltip text="Discover only the table schema without extracting data values. Faster and lower cost." />
-                  </Label>
-                </div>
-
-                {/* Schema Parameters */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium">Schema Parameters</Label>
-                  <div className="grid grid-cols-2 gap-3">
-                    <div className="space-y-1">
-                      <Label htmlFor="max_keys" className="text-xs text-muted-foreground inline-flex items-center gap-1">
-                        Max Columns
-                        <InfoTooltip text="Maximum number of columns in your table." />
-                      </Label>
-                      <Input
-                        id="max_keys"
-                        type="number"
-                        value={config.max_keys_schema}
-                        onChange={(e) => handleConfigChange('max_keys_schema', parseInt(e.target.value))}
-                        min={1}
-                        max={500}
-                      />
-                    </div>
-                    <div className="space-y-1">
-                      <Label htmlFor="batch_size" className="text-xs text-muted-foreground inline-flex items-center gap-1">
-                        Batch Size
-                        <InfoTooltip text="Documents per schema refinement batch." />
-                      </Label>
-                      <Input
-                        id="batch_size"
-                        type="number"
-                        value={config.documents_batch_size}
-                        onChange={(e) => handleConfigChange('documents_batch_size', parseInt(e.target.value))}
-                        min={1}
-                        max={20}
-                      />
-                    </div>
-                    {developerMode && (
-                      <>
-                        <div className="space-y-1">
-                          <Label htmlFor="seed" className="text-xs text-muted-foreground">Seed</Label>
-                          <Input
-                            id="seed"
-                            type="number"
-                            value={config.document_randomization_seed}
-                            onChange={(e) => handleConfigChange('document_randomization_seed', parseInt(e.target.value))}
-                          />
-                        </div>
-                        <div className="space-y-1">
-                          <Label htmlFor="convergence_threshold" className="text-xs text-muted-foreground inline-flex items-center gap-1">
-                            Convergence Threshold
-                            <InfoTooltip text="Number of consecutive batches without schema change needed to stop discovery." />
-                          </Label>
-                          <Input
-                            id="convergence_threshold"
-                            type="number"
-                            value={config.convergence_threshold ?? 5}
-                            onChange={(e) => handleConfigChange('convergence_threshold', parseInt(e.target.value))}
-                            min={1}
-                            max={20}
-                          />
-                        </div>
-                      </>
-                    )}
-                  </div>
-                </div>
-
-                <hr />
-
-                {/* Pre-define columns (collapsed by default) */}
-                <Collapsible>
-                  <CollapsibleTrigger className="group flex items-center gap-2 text-sm font-medium hover:text-foreground transition-colors">
-                    <ChevronDown className="h-4 w-4 transition-transform duration-200 group-data-[state=open]:rotate-180" />
-                    <span>Pre-define columns</span>
-                    <span className="text-xs font-normal text-muted-foreground">(optional)</span>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent className="mt-3">
-                    <p className="text-xs text-muted-foreground mb-3">
-                      Add columns you want to appear in the final table. Only the column name is
-                      required — definition and rationale are optional and will be filled by the
-                      AI during discovery if left blank.
-                    </p>
-                    <InitialSchemaEditor
-                      onSchemaChange={(path, data) => {
-                        setInitialSchemaPath(path);
-                        setInitialSchemaData(data);
-                      }}
-                    />
-                  </CollapsibleContent>
-                </Collapsible>
-
-                <hr />
-
-                {/* Observation Unit */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium inline-flex items-center gap-1.5">
-                    Observation Unit
-                    <InfoTooltip text="What each row in your table represents (e.g., 'a research paper' or 'a patient'). Usually auto-detected, but you can customize it if needed." />
-                  </Label>
-                  <RadioGroup
-                    value={observationUnitMode === 'auto' ? 'auto' : 'specify'}
-                    onValueChange={(value) => {
-                      if (value === 'auto') {
-                        setObservationUnitMode('auto');
-                        setObservationUnitName('');
-                        setObservationUnitDefinition('');
-                      } else {
-                        setObservationUnitMode('name_only');
-                        // Clear review flag when user specifies manually
-                        handleConfigChange('review_observation_unit', false);
-                      }
-                    }}
-                    className="space-y-3"
-                  >
-                    <div className="flex items-start space-x-3">
-                      <RadioGroupItem value="auto" id="obs-auto" className="mt-1" />
-                      <div className="space-y-1">
-                        <Label htmlFor="obs-auto" className="font-medium cursor-pointer">
-                          Auto-detect (recommended)
-                        </Label>
-                        <p className="text-sm text-muted-foreground">
-                          The system will automatically determine the observation unit from your query and documents.
-                        </p>
-                        {observationUnitMode === 'auto' && (
-                          <div className="flex items-center gap-2 mt-1.5">
-                            <Checkbox
-                              id="review-obs-unit"
-                              checked={config.review_observation_unit || false}
-                              onCheckedChange={(checked) => handleConfigChange('review_observation_unit', checked)}
-                            />
-                            <Label htmlFor="review-obs-unit" className="text-sm cursor-pointer inline-flex items-center gap-1.5">
-                              Review before schema generation
-                              <InfoTooltip text="Pause after the observation unit is discovered so you can review and edit it before schema generation begins." />
-                            </Label>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                    <div className="flex items-start space-x-3">
-                      <RadioGroupItem value="specify" id="obs-specify" className="mt-1" />
-                      <div className="space-y-1 flex-1">
-                        <Label htmlFor="obs-specify" className="font-medium cursor-pointer">
-                          I'll specify
-                        </Label>
-                        <p className="text-sm text-muted-foreground">
-                          Provide a unit name; optionally add a definition for full control.
-                        </p>
-                        {observationUnitMode !== 'auto' && (
-                          <div className="space-y-2 mt-2">
-                            <Input
-                              placeholder="e.g., Research Paper, Model-Benchmark Evaluation"
-                              value={observationUnitName}
-                              onChange={(e) => setObservationUnitName(e.target.value)}
-                            />
-                            <Collapsible>
-                              <CollapsibleTrigger className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
-                                <ChevronDown className="h-3.5 w-3.5" />
-                                <span>Add definition</span>
-                              </CollapsibleTrigger>
-                              <CollapsibleContent className="mt-2">
-                                <Input
-                                  placeholder="e.g., Each row represents a single research paper"
-                                  value={observationUnitDefinition}
-                                  onChange={(e) => {
-                                    setObservationUnitDefinition(e.target.value);
-                                    if (e.target.value.trim()) {
-                                      setObservationUnitMode('full');
-                                    }
-                                  }}
-                                />
-                              </CollapsibleContent>
-                            </Collapsible>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </RadioGroup>
-                </div>
-
-                {/* Developer Mode: LLM Configuration */}
-                {allowLlmConfig && (
-                  <>
-                    <hr />
-
-                    {/* Schema Creation LLM */}
-                    <div className="space-y-3">
-                      {editingSchemaLlm ? (
-                        <>
-                          <div className="flex items-center justify-between">
-                            <Label className="text-sm font-medium">Schema Creation LLM</Label>
-                            <Button variant="ghost" size="sm" onClick={() => setEditingSchemaLlm(false)}>
-                              Done
-                            </Button>
-                          </div>
-                          <div className="space-y-2">
-                            <div className="space-y-1">
-                              <Label className="text-xs">Provider</Label>
-                              <Select
-                                value={config.schema_creation_backend.provider}
-                                onValueChange={(value) => handleSchemaBackendChange('provider', value)}
-                              >
-                                <SelectTrigger>
-                                  <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  {configuredProviders.map((provider) => (
-                                    <SelectItem key={provider} value={provider}>
-                                      {LLM_PROVIDER_NAMES[provider as LLMProviderKey]}
-                                    </SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
-                            </div>
-                            <div className="space-y-1">
-                              <Label className="text-xs">Model</Label>
-                              <ModelSelector
-                                provider={config.schema_creation_backend.provider as LLMProviderKey}
-                                value={config.schema_creation_backend.model}
-                                onChange={(modelId) => handleSchemaBackendChange('model', modelId)}
-                                showDetails={true}
-                              />
-                            </div>
-                            <div className="space-y-1">
-                              <Label className="text-xs">Temperature</Label>
-                              <Input
-                                type="number"
-                                value={config.schema_creation_backend.temperature}
-                                onChange={(e) => handleSchemaBackendChange('temperature', parseFloat(e.target.value))}
-                                min={0}
-                                max={2}
-                                step={0.1}
-                              />
-                            </div>
-                          </div>
-                        </>
-                      ) : (
-                        <div className="flex items-center justify-between">
-                          <div className="text-sm">
-                            <span className="font-medium">Schema LLM:</span>{' '}
-                            <span className="text-muted-foreground">
-                              {LLM_PROVIDER_NAMES[config.schema_creation_backend.provider as LLMProviderKey]} / {config.schema_creation_backend.model}
-                              {config.schema_creation_backend.temperature !== 0 && ` (temp: ${config.schema_creation_backend.temperature})`}
-                            </span>
-                          </div>
-                          <Button variant="ghost" size="sm" onClick={() => setEditingSchemaLlm(true)}>
-                            Edit
-                          </Button>
-                        </div>
-                      )}
-                    </div>
-
-                    <hr />
-
-                    {/* Value Extraction LLM */}
-                    <div className="space-y-3">
-                      {editingValueLlm ? (
-                        <>
-                          <div className="flex items-center justify-between">
-                            <Label className="text-sm font-medium">Value Extraction LLM</Label>
-                            <Button variant="ghost" size="sm" onClick={() => setEditingValueLlm(false)}>
-                              Done
-                            </Button>
-                          </div>
-                          <div className="space-y-2">
-                            <div className="space-y-1">
-                              <Label className="text-xs">Provider</Label>
-                              <Select
-                                value={config.value_extraction_backend.provider}
-                                onValueChange={(value) => handleValueBackendChange('provider', value)}
-                              >
-                                <SelectTrigger>
-                                  <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  {configuredProviders.map((provider) => (
-                                    <SelectItem key={provider} value={provider}>
-                                      {LLM_PROVIDER_NAMES[provider as LLMProviderKey]}
-                                    </SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
-                            </div>
-                            <div className="space-y-1">
-                              <Label className="text-xs">Model</Label>
-                              <ModelSelector
-                                provider={config.value_extraction_backend.provider as LLMProviderKey}
-                                value={config.value_extraction_backend.model}
-                                onChange={(modelId) => handleValueBackendChange('model', modelId)}
-                                showDetails={true}
-                              />
-                            </div>
-                            <div className="space-y-1">
-                              <Label className="text-xs">Temperature</Label>
-                              <Input
-                                type="number"
-                                value={config.value_extraction_backend.temperature}
-                                onChange={(e) => handleValueBackendChange('temperature', parseFloat(e.target.value))}
-                                min={0}
-                                max={2}
-                                step={0.1}
-                              />
-                            </div>
-                          </div>
-                        </>
-                      ) : (
-                        <div className="flex items-center justify-between">
-                          <div className="text-sm">
-                            <span className="font-medium">Value LLM:</span>{' '}
-                            <span className="text-muted-foreground">
-                              {LLM_PROVIDER_NAMES[config.value_extraction_backend.provider as LLMProviderKey]} / {config.value_extraction_backend.model}
-                              {config.value_extraction_backend.temperature !== 0 && ` (temp: ${config.value_extraction_backend.temperature})`}
-                            </span>
-                          </div>
-                          <Button variant="ghost" size="sm" onClick={() => setEditingValueLlm(true)}>
-                            Edit
-                          </Button>
-                        </div>
-                      )}
-                    </div>
-                  </>
-                )}
-
-                {/* Developer Mode: Retriever Settings */}
-                {developerMode && (
-                  <>
-                    <hr />
-                    <div className="space-y-2">
-                      <Label className="text-sm font-medium">Retriever</Label>
-                      <div className="space-y-2">
-                        <div className="space-y-1">
-                          <Label className="text-xs">Model Name</Label>
-                          <Input
-                            value={config.retriever?.model_name || ''}
-                            onChange={(e) => handleRetrieverChange('model_name', e.target.value)}
-                          />
-                        </div>
-                        <div className="grid grid-cols-2 gap-2">
-                          <div className="space-y-1">
-                            <Label className="text-xs">Passage Chars</Label>
-                            <Input
-                              type="number"
-                              value={config.retriever?.passage_chars || 512}
-                              onChange={(e) => handleRetrieverChange('passage_chars', parseInt(e.target.value))}
-                              min={128}
-                              max={2048}
-                            />
-                          </div>
-                          <div className="space-y-1">
-                            <Label className="text-xs">Overlap</Label>
-                            <Input
-                              type="number"
-                              value={config.retriever?.overlap || 64}
-                              onChange={(e) => handleRetrieverChange('overlap', parseInt(e.target.value))}
-                              min={0}
-                              max={256}
-                            />
-                          </div>
-                          <div className="space-y-1">
-                            <Label className="text-xs">K</Label>
-                            <Input
-                              type="number"
-                              value={config.retriever?.k || 15}
-                              onChange={(e) => handleRetrieverChange('k', parseInt(e.target.value))}
-                              min={1}
-                              max={50}
-                            />
-                          </div>
-                          <div className="space-y-1">
-                            <Label className="text-xs">Dynamic K</Label>
-                            <Input
-                              type="number"
-                              value={config.retriever?.dynamic_k_threshold || 0.65}
-                              onChange={(e) => handleRetrieverChange('dynamic_k_threshold', parseFloat(e.target.value))}
-                              min={0}
-                              max={1}
-                              step={0.05}
-                            />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </>
-                )}
-
-                {/* Developer Mode: Bypass Document Limit */}
-                {developerMode && (
-                  <>
-                    <hr />
-                    <div className="flex items-center justify-between p-3 border rounded-lg bg-amber-50 border-amber-200 dark:bg-amber-950/20 dark:border-amber-800">
-                      <div>
-                        <Label className="text-sm font-medium">Bypass Document Limit</Label>
-                        <p className="text-xs text-muted-foreground">
-                          Disable the {maxDocuments}-document limit for testing.
-                        </p>
-                      </div>
-                      <Switch checked={limitBypassEnabled} onCheckedChange={setLimitBypassEnabled} />
-                    </div>
-                  </>
-                )}
+                <AdvancedSettingsFields
+                  value={advancedValue}
+                  onChange={applyAdvancedSettings}
+                  developerMode={developerMode}
+                  allowLlmConfig={allowLlmConfig}
+                  providers={configuredProviders as LLMProviderKey[]}
+                  maxDocuments={maxDocuments}
+                />
           </div>
 
               {/* Cost Estimate - Developer mode only */}

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -52,6 +52,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
 import { Textarea } from '@/components/ui/textarea';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useToast } from '@/components/ui/use-toast';
@@ -67,9 +68,13 @@ import {
 } from '@/components/DataTable/utils/excerptUtils';
 import ContentModal from '@/components/ContentModal/ContentModal';
 import {
-  DEFAULT_DOCUMENT_RANDOMIZATION_SEED,
-  DEFAULT_DOCUMENTS_BATCH_SIZE,
-  DEFAULT_MAX_KEYS_SCHEMA,
+  AdvancedSettingsFields,
+  DEFAULT_ADVANCED_SETTINGS,
+  observationUnitFromValue,
+  retrieverIsCustomized,
+  type AdvancedSettingsValue,
+} from '@/components/AdvancedSettings/AdvancedSettingsFields';
+import {
   getAvailableProviders,
   getDefaultModelForProvider,
   WS_DISCONNECTED_REFRESH_INTERVAL,
@@ -351,8 +356,6 @@ const WORKSPACE_MENUS = [
 ];
 
 const DEFAULT_PROVIDER = 'gemini';
-const DEFAULT_SCHEMA_MODEL = 'gemini-2.5-flash';
-const DEFAULT_VALUE_MODEL = 'gemini-3.1-flash-lite-preview';
 const EDITABLE_OBSERVATION_UNIT_FIELDS = new Set(['name', 'definition', 'example_names']);
 const TABLE_FONT_OPTIONS: TableFontFamily[] = ['Inter', 'Arial', 'Georgia', 'Mono'];
 const TABLE_FONT_SIZE_OPTIONS = [10, 11, 12, 13, 14, 16, 18];
@@ -402,29 +405,58 @@ function parseAllowedValues(value: unknown): string[] | undefined {
     .filter(Boolean);
 }
 
-function buildConfig(query: string, apiKey: string): ScheMatiQConfig {
-  const backend = {
-    provider: DEFAULT_PROVIDER,
-    model: DEFAULT_SCHEMA_MODEL,
-    temperature: 0,
-    api_key: apiKey || undefined,
-  };
+const WORKSPACE_DEFAULT_ADVANCED: AdvancedSettingsValue = {
+  ...DEFAULT_ADVANCED_SETTINGS,
+  schemaProvider: DEFAULT_PROVIDER,
+  valueProvider: DEFAULT_PROVIDER,
+};
 
-  return {
+function buildConfig(query: string, apiKey: string, advanced: AdvancedSettingsValue = WORKSPACE_DEFAULT_ADVANCED): ScheMatiQConfig {
+  const config: ScheMatiQConfig = {
     query,
     docs_path: null,
     upload_pending: true,
-    max_keys_schema: DEFAULT_MAX_KEYS_SCHEMA,
-    documents_batch_size: DEFAULT_DOCUMENTS_BATCH_SIZE,
-    schema_creation_backend: backend,
+    max_keys_schema: advanced.maxKeysSchema,
+    documents_batch_size: advanced.documentsBatchSize,
+    schema_creation_backend: {
+      provider: advanced.schemaProvider,
+      model: advanced.schemaModel,
+      temperature: advanced.schemaTemperature,
+      api_key: apiKey || undefined,
+    },
     value_extraction_backend: {
-      ...backend,
-      model: DEFAULT_VALUE_MODEL,
+      provider: advanced.valueProvider,
+      model: advanced.valueModel,
+      temperature: advanced.valueTemperature,
+      api_key: apiKey || undefined,
     },
     output_path: 'outputs/workspace_output.json',
-    document_randomization_seed: DEFAULT_DOCUMENT_RANDOMIZATION_SEED,
-    skip_value_extraction: false,
+    document_randomization_seed: advanced.seed,
+    skip_value_extraction: advanced.skipValueExtraction,
+    initial_observation_unit: observationUnitFromValue(advanced),
+    review_observation_unit: advanced.observationUnitMode === 'auto' ? advanced.reviewObservationUnit : undefined,
+    initial_schema: advanced.initialSchemaData ?? undefined,
+    initial_schema_path: !advanced.initialSchemaData ? advanced.initialSchemaPath : undefined,
   };
+
+  if (advanced.convergenceThreshold != null) {
+    config.convergence_threshold = advanced.convergenceThreshold;
+  }
+
+  if (retrieverIsCustomized(advanced)) {
+    config.retriever = {
+      type: 'embedding',
+      model_name: advanced.retrieverModelName,
+      passage_chars: advanced.retrieverPassageChars,
+      overlap: advanced.retrieverOverlap,
+      k: advanced.retrieverK,
+      enable_dynamic_k: true,
+      dynamic_k_threshold: advanced.retrieverDynamicK,
+      dynamic_k_minimum: 3,
+    };
+  }
+
+  return config;
 }
 
 function schemaFromLoadSession(session: VisualizationSession | null): SchemaData | null {
@@ -473,11 +505,34 @@ function NewProjectDialog({ open, onOpenChange, onCreated }: NewProjectDialogPro
   const [creating, setCreating] = useState(false);
   const [startConfirmed, setStartConfirmed] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [advanced, setAdvanced] = useState<AdvancedSettingsValue>(WORKSPACE_DEFAULT_ADVANCED);
+  const [developerMode, setDeveloperMode] = useState(false);
+  const [allowLlmConfig, setAllowLlmConfig] = useState(false);
+  const [maxDocuments, setMaxDocuments] = useState<number | undefined>(undefined);
+  const [providers, setProviders] = useState<LLMProviderKey[]>([DEFAULT_PROVIDER as LLMProviderKey]);
+
+  const updateAdvanced = useCallback((patch: Partial<AdvancedSettingsValue>) => {
+    setAdvanced((prev) => ({ ...prev, ...patch }));
+    setEstimate(null);
+    setStartConfirmed(false);
+  }, []);
 
   useEffect(() => {
-    configAPI.getConfig()
-      .then((config) => setServerHasKeys(Boolean(config.server_has_api_keys)))
-      .catch(() => setServerHasKeys(false));
+    let cancelled = false;
+    (async () => {
+      const config = await configAPI.getConfig().catch(() => null);
+      const configured = await getConfiguredProviders().catch(() => []);
+      if (cancelled) return;
+      const available = getAvailableProviders(configured) as LLMProviderKey[];
+      setServerHasKeys(Boolean(config?.server_has_api_keys));
+      setDeveloperMode(Boolean(config?.developer_mode));
+      setAllowLlmConfig(Boolean(config?.allow_llm_config));
+      setMaxDocuments(typeof config?.max_documents === 'number' ? config.max_documents : undefined);
+      setProviders(available.length > 0 ? available : [DEFAULT_PROVIDER as LLMProviderKey]);
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -498,7 +553,7 @@ function NewProjectDialog({ open, onOpenChange, onCreated }: NewProjectDialogPro
     setError(null);
     setEstimating(true);
     try {
-      const config = buildConfig(query.trim(), apiKey.trim());
+      const config = buildConfig(query.trim(), apiKey.trim(), advanced);
       const result = await schematiqAPI.estimateCostPreview(
         config,
         files.map((file) => ({ name: file.webkitRelativePath || file.name, size: file.size }))
@@ -513,7 +568,7 @@ function NewProjectDialog({ open, onOpenChange, onCreated }: NewProjectDialogPro
     } finally {
       setEstimating(false);
     }
-  }, [apiKey, files, query]);
+  }, [apiKey, files, query, advanced]);
 
   const startProject = useCallback(async () => {
     if (!query.trim() || files.length === 0) {
@@ -533,9 +588,9 @@ function NewProjectDialog({ open, onOpenChange, onCreated }: NewProjectDialogPro
     setCreating(true);
     setError(null);
     try {
-      const config = buildConfig(query.trim(), apiKey.trim());
+      const config = buildConfig(query.trim(), apiKey.trim(), advanced);
       const result = await schematiqAPI.configure(config);
-      await loadAPI.addDocuments(result.session_id, files);
+      await loadAPI.addDocuments(result.session_id, files, advanced.bypassLimit);
       await schematiqAPI.run(result.session_id);
       toast({
         title: 'Project started',
@@ -549,7 +604,7 @@ function NewProjectDialog({ open, onOpenChange, onCreated }: NewProjectDialogPro
     } finally {
       setCreating(false);
     }
-  }, [apiKey, estimate, estimateProject, files, navigate, onCreated, onOpenChange, query, serverHasKeys, startConfirmed, toast]);
+  }, [apiKey, estimate, estimateProject, files, navigate, onCreated, onOpenChange, query, serverHasKeys, startConfirmed, toast, advanced]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -617,6 +672,24 @@ function NewProjectDialog({ open, onOpenChange, onCreated }: NewProjectDialogPro
               placeholder={serverHasKeys ? 'Optional: server keys are configured' : 'Required unless server keys are configured'}
             />
           </div>
+
+          <Collapsible>
+            <CollapsibleTrigger className="group flex items-center gap-2 text-sm font-medium hover:text-foreground transition-colors">
+              <ChevronDown className="h-4 w-4 transition-transform duration-200 group-data-[state=open]:rotate-180" />
+              <span>Advanced settings</span>
+              <span className="text-xs font-normal text-muted-foreground">(optional)</span>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="mt-3">
+              <AdvancedSettingsFields
+                value={advanced}
+                onChange={updateAdvanced}
+                developerMode={developerMode}
+                allowLlmConfig={allowLlmConfig}
+                providers={providers}
+                maxDocuments={maxDocuments}
+              />
+            </CollapsibleContent>
+          </Collapsible>
 
           {estimate && (
             <div className="rounded-md border bg-muted/30 p-3 text-sm">


### PR DESCRIPTION
Extracts the classic config screen's Advanced Settings into a single presentational component (AdvancedSettingsFields) used by both the classic flow and the Workspace new-project dialog. The workspace flow now has full parity (pre-define columns, LLM config, dev settings), and both flows share the same default models (gemini-3.5-flash for schema, gemini-3.1-flash-lite for value). Each flow keeps its own submit/restore logic; only the fields UI and value model are shared.