### PR TITLE
feat(workspace): browse and preview source documents in a Documents tab

### DIFF
--- a/backend/app/api/routes/units.py
+++ b/backend/app/api/routes/units.py
@@ -1,7 +1,12 @@
 """API routes for observation unit view and merge operations."""
 
-from typing import Optional
+import io
+import mimetypes
+from pathlib import Path
+from typing import Optional, Tuple
+
 from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import StreamingResponse
 
 from app.models.unit import (
     UnitListResponse,
@@ -14,6 +19,8 @@ from app.models.unit import (
 from app.models.session import PaginatedData, DataRow, FilterSortRequest
 from app.services.unit_view_service import unit_view_service
 from app.services import session_manager, pubmed_enrichment_service
+from app.services.data_utils import candidate_data_dirs
+from app.storage import get_storage
 
 router = APIRouter()
 
@@ -96,6 +103,131 @@ async def list_source_documents(session_id: str):
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error listing documents: {str(e)}")
+
+
+# Extensions served with an explicit, browser-renderable content type so the
+# document viewer can show them inline in an <iframe>. Anything else falls back
+# to a generic type and is offered as a download by the frontend.
+_INLINE_MEDIA_TYPES = {
+    ".pdf": "application/pdf",
+    ".html": "text/html",
+    ".htm": "text/html",
+    ".txt": "text/plain",
+    ".md": "text/markdown",
+    ".csv": "text/csv",
+    ".json": "application/json",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".svg": "image/svg+xml",
+}
+
+# Media types whose content can carry executable markup (scripts, embeds). When
+# we serve these inline we add a sandboxing CSP so user-uploaded files cannot
+# run script in the application origin.
+_SANDBOXED_MEDIA_TYPES = {"text/html", "image/svg+xml"}
+
+
+def _media_type_for(name: str) -> str:
+    ext = Path(name).suffix.lower()
+    if ext in _INLINE_MEDIA_TYPES:
+        return _INLINE_MEDIA_TYPES[ext]
+    guessed, _ = mimetypes.guess_type(name)
+    return guessed or "application/octet-stream"
+
+
+def _find_local_document(session_id: str, name: str) -> Optional[Path]:
+    """Locate an uploaded source document on the local filesystem.
+
+    Searches documents/ and pending_documents/ across every known data dir
+    (CWD, backend, dev.sh instances). Matches the exact filename first, then
+    falls back to stem matching since the recorded source_document name may
+    omit the extension.
+    """
+    target_stem = Path(name).stem.lower()
+    target_name = name.lower()
+    for base in candidate_data_dirs():
+        for sub in ("documents", "pending_documents"):
+            doc_dir = base / session_id / sub
+            if not doc_dir.is_dir():
+                continue
+            exact = doc_dir / name
+            if exact.is_file():
+                return exact
+            for f in doc_dir.iterdir():
+                if not f.is_file() or f.name.startswith("."):
+                    continue
+                if f.name.lower() == target_name or f.stem.lower() == target_stem:
+                    return f
+    return None
+
+
+async def _load_document_bytes(session, session_id: str, name: str) -> Tuple[Optional[bytes], Optional[str]]:
+    """Return (bytes, media_type) for a source document, or (None, None).
+
+    Tries the local filesystem first (dev / freshly uploaded), then Supabase
+    storage's ``datasets`` bucket under the session's cloud dataset. Richer
+    per-document cloud-folder resolution lives in reextraction_service if this
+    fallback ever proves insufficient.
+    """
+    local = _find_local_document(session_id, name)
+    if local is not None:
+        return local.read_bytes(), _media_type_for(local.name)
+
+    cloud_dataset = getattr(session.metadata, "cloud_dataset", None)
+    if cloud_dataset:
+        storage = get_storage()
+        try:
+            content = await storage.download_file("datasets", f"{cloud_dataset}/{name}")
+        except Exception:
+            content = None
+        if content:
+            return content, _media_type_for(name)
+
+    return None, None
+
+
+@router.get(
+    "/document-content/{session_id}",
+    summary="Serve a source document inline",
+    description="Stream the raw bytes of an uploaded source document for inline viewing",
+)
+async def get_document_content(
+    session_id: str,
+    name: str = Query(..., description="Source document filename"),
+):
+    """Serve an uploaded source document's raw bytes for the document viewer.
+
+    The ``name`` is validated against the session's known source documents to
+    prevent path traversal; only files that actually appear in the session are
+    served. HTML/SVG is served with a sandboxing CSP so user-uploaded markup
+    cannot execute scripts in the app origin.
+    """
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    # Allowlist: only serve names that are real source documents for this session.
+    known = {d["name"] for d in unit_view_service.get_source_documents(session_id)}
+    if name not in known:
+        raise HTTPException(status_code=404, detail="Document not found in this session")
+
+    content, media_type = await _load_document_bytes(session, session_id, name)
+    if content is None:
+        raise HTTPException(status_code=404, detail="Document file is not available")
+
+    headers = {
+        "Content-Disposition": f'inline; filename="{Path(name).name}"',
+        "Cache-Control": "private, max-age=60",
+    }
+    if media_type in _SANDBOXED_MEDIA_TYPES:
+        headers["Content-Security-Policy"] = (
+            "sandbox; default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'"
+        )
+
+    return StreamingResponse(io.BytesIO(content), media_type=media_type, headers=headers)
 
 
 @router.post(

--- a/frontend/src/components/DocumentViewer/DocumentPreview.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentPreview.tsx
@@ -1,0 +1,98 @@
+import React, { useMemo } from 'react';
+import { FileText, ExternalLink, Download } from 'lucide-react';
+
+import { unitsAPI } from '../../services/api';
+
+/** Extensions the browser can render inline in an <iframe>. */
+const INLINE_EXTENSIONS = new Set([
+  'pdf', 'html', 'htm', 'txt', 'md', 'csv', 'json',
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg',
+]);
+
+/** Inline content that can carry executable markup, so the iframe is sandboxed. */
+const SANDBOX_EXTENSIONS = new Set(['html', 'htm', 'svg']);
+
+const extensionOf = (name: string): string => {
+  const dot = name.lastIndexOf('.');
+  return dot >= 0 ? name.slice(dot + 1).toLowerCase() : '';
+};
+
+interface DocumentPreviewProps {
+  sessionId: string | null | undefined;
+  /** Source-document name (raw value, as returned by the documents endpoint). */
+  documentName: string | null;
+  /** Message shown when no document is selected. */
+  emptyHint?: string;
+}
+
+/**
+ * Renders a single source document inline (native browser rendering for
+ * PDF/HTML/images/text) with an "Open full" link to a new tab, and a download
+ * fallback for formats the browser cannot render. The browser uses the HTTP
+ * Content-Type to decide how to render, so a name without an extension is still
+ * attempted inline.
+ */
+const DocumentPreview: React.FC<DocumentPreviewProps> = ({ sessionId, documentName, emptyHint }) => {
+  const contentUrl = useMemo(
+    () => (sessionId && documentName ? unitsAPI.getDocumentContentUrl(sessionId, documentName) : null),
+    [sessionId, documentName],
+  );
+
+  const ext = documentName ? extensionOf(documentName) : '';
+  const canRenderInline = ext === '' || INLINE_EXTENSIONS.has(ext);
+  const needsSandbox = SANDBOX_EXTENSIONS.has(ext);
+
+  return (
+    <div className="flex-1 min-w-0 h-full flex flex-col">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border text-xs">
+        <span className="truncate text-muted-foreground" title={documentName || ''}>
+          {documentName || 'No document selected'}
+        </span>
+        <span className="flex-1" />
+        {contentUrl && (
+          <a
+            href={contentUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-border hover:bg-muted/50 transition-colors text-foreground"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            Open full
+          </a>
+        )}
+      </div>
+
+      <div className="flex-1 min-h-0 bg-muted/20">
+        {!contentUrl ? (
+          <div className="h-full flex items-center justify-center text-sm text-muted-foreground text-center px-4">
+            {emptyHint || 'Select a document to preview it.'}
+          </div>
+        ) : canRenderInline ? (
+          <iframe
+            key={contentUrl}
+            src={contentUrl}
+            title={documentName || 'Document preview'}
+            className="w-full h-full border-0"
+            {...(needsSandbox ? { sandbox: '' } : {})}
+          />
+        ) : (
+          <div className="h-full flex flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
+            <FileText className="h-8 w-8 opacity-40" />
+            <span>Preview isn&apos;t available for .{ext} files.</span>
+            <a
+              href={contentUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md border border-border hover:bg-muted/50 transition-colors text-foreground"
+            >
+              <Download className="h-4 w-4" />
+              Open / download
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DocumentPreview;

--- a/frontend/src/components/DocumentViewer/DocumentViewer.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentViewer.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { FileText, ExternalLink, Download } from 'lucide-react';
+
+import { unitsAPI } from '../../services/api';
+import { DocumentSummary } from '../../types/unit';
+
+/** Extensions the browser can render inline in an <iframe>. */
+const INLINE_EXTENSIONS = new Set([
+  'pdf', 'html', 'htm', 'txt', 'md', 'csv', 'json',
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg',
+]);
+
+/** Inline content that can carry executable markup, so the iframe is sandboxed. */
+const SANDBOX_EXTENSIONS = new Set(['html', 'htm', 'svg']);
+
+const extensionOf = (name: string): string => {
+  const dot = name.lastIndexOf('.');
+  return dot >= 0 ? name.slice(dot + 1).toLowerCase() : '';
+};
+
+interface DocumentViewerProps {
+  sessionId: string | null;
+}
+
+/**
+ * Browse a session's uploaded source documents: a list on the left, an inline
+ * preview on the right (native browser rendering for PDF/HTML/images/text), and
+ * an "Open full" link that opens the document in a new browser tab.
+ */
+const DocumentViewer: React.FC<DocumentViewerProps> = ({ sessionId }) => {
+  const [documents, setDocuments] = useState<DocumentSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setDocuments([]);
+      setSelected(null);
+      return undefined;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    unitsAPI
+      .getDocuments(sessionId)
+      .then((res) => {
+        if (cancelled) return;
+        setDocuments(res.documents);
+        setSelected((prev) => prev ?? res.documents[0]?.name ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Could not load the document list.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  const contentUrl = useMemo(
+    () => (sessionId && selected ? unitsAPI.getDocumentContentUrl(sessionId, selected) : null),
+    [sessionId, selected],
+  );
+
+  const selectedExt = selected ? extensionOf(selected) : '';
+  const canRenderInline = INLINE_EXTENSIONS.has(selectedExt);
+  const needsSandbox = SANDBOX_EXTENSIONS.has(selectedExt);
+
+  if (!sessionId) {
+    return (
+      <div className="h-full flex items-center justify-center text-sm text-muted-foreground">
+        Open a project to view its documents.
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex min-h-0">
+      {/* Document list */}
+      <div className="w-56 flex-shrink-0 border-r border-border overflow-y-auto">
+        <div className="px-3 py-2 text-xs text-muted-foreground border-b border-border">
+          {loading ? 'Loading\u2026' : `${documents.length} document${documents.length === 1 ? '' : 's'}`}
+        </div>
+        {error && <div className="px-3 py-2 text-xs text-destructive">{error}</div>}
+        {documents.map((doc) => {
+          const active = doc.name === selected;
+          return (
+            <button
+              key={doc.name}
+              type="button"
+              onClick={() => setSelected(doc.name)}
+              className={`w-full text-left flex items-center gap-2 px-3 py-2 border-l-2 transition-colors ${
+                active ? 'border-primary bg-primary/10' : 'border-transparent hover:bg-muted/50'
+              }`}
+            >
+              <FileText
+                className={`h-4 w-4 flex-shrink-0 ${active ? 'text-primary' : 'text-muted-foreground'}`}
+              />
+              <span className="min-w-0">
+                <span className="block text-xs font-medium truncate" title={doc.name}>
+                  {doc.name}
+                </span>
+                <span className="block text-[11px] text-muted-foreground">
+                  {doc.rowCount} row{doc.rowCount === 1 ? '' : 's'}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+        {!loading && documents.length === 0 && !error && (
+          <div className="px-3 py-6 text-xs text-muted-foreground text-center">
+            No documents in this project yet.
+          </div>
+        )}
+      </div>
+
+      {/* Preview pane */}
+      <div className="flex-1 min-w-0 flex flex-col">
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-border text-xs">
+          <span className="truncate text-muted-foreground" title={selected || ''}>
+            {selected || 'No document selected'}
+          </span>
+          <span className="flex-1" />
+          {contentUrl && (
+            <a
+              href={contentUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-border hover:bg-muted/50 transition-colors text-foreground"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              Open full
+            </a>
+          )}
+        </div>
+
+        <div className="flex-1 min-h-0 bg-muted/20">
+          {!contentUrl ? (
+            <div className="h-full flex items-center justify-center text-sm text-muted-foreground">
+              Select a document to preview it.
+            </div>
+          ) : canRenderInline ? (
+            <iframe
+              key={contentUrl}
+              src={contentUrl}
+              title={selected || 'Document preview'}
+              className="w-full h-full border-0"
+              {...(needsSandbox ? { sandbox: '' } : {})}
+            />
+          ) : (
+            <div className="h-full flex flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
+              <FileText className="h-8 w-8 opacity-40" />
+              <span>Preview isn&apos;t available for .{selectedExt} files.</span>
+              <a
+                href={contentUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md border border-border hover:bg-muted/50 transition-colors text-foreground"
+              >
+                <Download className="h-4 w-4" />
+                Open / download
+              </a>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DocumentViewer;

--- a/frontend/src/components/DocumentViewer/DocumentViewer.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentViewer.tsx
@@ -7,6 +7,8 @@ import DocumentPreview from './DocumentPreview';
 
 interface DocumentViewerProps {
   sessionId: string | null | undefined;
+  /** Changes when the underlying data updates, so the list refetches as documents arrive. */
+  refreshKey?: number;
 }
 
 /**
@@ -14,7 +16,7 @@ interface DocumentViewerProps {
  * inline preview on the right (see DocumentPreview). "Open full" opens the
  * document in a new browser tab.
  */
-const DocumentViewer: React.FC<DocumentViewerProps> = ({ sessionId }) => {
+const DocumentViewer: React.FC<DocumentViewerProps> = ({ sessionId, refreshKey }) => {
   const [documents, setDocuments] = useState<DocumentSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -45,7 +47,7 @@ const DocumentViewer: React.FC<DocumentViewerProps> = ({ sessionId }) => {
     return () => {
       cancelled = true;
     };
-  }, [sessionId]);
+  }, [sessionId, refreshKey]);
 
   if (!sessionId) {
     return (

--- a/frontend/src/components/DocumentViewer/DocumentViewer.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentViewer.tsx
@@ -1,31 +1,18 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { FileText, ExternalLink, Download } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import { FileText } from 'lucide-react';
 
 import { unitsAPI } from '../../services/api';
 import { DocumentSummary } from '../../types/unit';
-
-/** Extensions the browser can render inline in an <iframe>. */
-const INLINE_EXTENSIONS = new Set([
-  'pdf', 'html', 'htm', 'txt', 'md', 'csv', 'json',
-  'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg',
-]);
-
-/** Inline content that can carry executable markup, so the iframe is sandboxed. */
-const SANDBOX_EXTENSIONS = new Set(['html', 'htm', 'svg']);
-
-const extensionOf = (name: string): string => {
-  const dot = name.lastIndexOf('.');
-  return dot >= 0 ? name.slice(dot + 1).toLowerCase() : '';
-};
+import DocumentPreview from './DocumentPreview';
 
 interface DocumentViewerProps {
-  sessionId: string | null;
+  sessionId: string | null | undefined;
 }
 
 /**
- * Browse a session's uploaded source documents: a list on the left, an inline
- * preview on the right (native browser rendering for PDF/HTML/images/text), and
- * an "Open full" link that opens the document in a new browser tab.
+ * Browse a session's uploaded source documents: a list on the left and an
+ * inline preview on the right (see DocumentPreview). "Open full" opens the
+ * document in a new browser tab.
  */
 const DocumentViewer: React.FC<DocumentViewerProps> = ({ sessionId }) => {
   const [documents, setDocuments] = useState<DocumentSummary[]>([]);
@@ -59,15 +46,6 @@ const DocumentViewer: React.FC<DocumentViewerProps> = ({ sessionId }) => {
       cancelled = true;
     };
   }, [sessionId]);
-
-  const contentUrl = useMemo(
-    () => (sessionId && selected ? unitsAPI.getDocumentContentUrl(sessionId, selected) : null),
-    [sessionId, selected],
-  );
-
-  const selectedExt = selected ? extensionOf(selected) : '';
-  const canRenderInline = INLINE_EXTENSIONS.has(selectedExt);
-  const needsSandbox = SANDBOX_EXTENSIONS.has(selectedExt);
 
   if (!sessionId) {
     return (
@@ -118,55 +96,7 @@ const DocumentViewer: React.FC<DocumentViewerProps> = ({ sessionId }) => {
       </div>
 
       {/* Preview pane */}
-      <div className="flex-1 min-w-0 flex flex-col">
-        <div className="flex items-center gap-2 px-3 py-2 border-b border-border text-xs">
-          <span className="truncate text-muted-foreground" title={selected || ''}>
-            {selected || 'No document selected'}
-          </span>
-          <span className="flex-1" />
-          {contentUrl && (
-            <a
-              href={contentUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-border hover:bg-muted/50 transition-colors text-foreground"
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-              Open full
-            </a>
-          )}
-        </div>
-
-        <div className="flex-1 min-h-0 bg-muted/20">
-          {!contentUrl ? (
-            <div className="h-full flex items-center justify-center text-sm text-muted-foreground">
-              Select a document to preview it.
-            </div>
-          ) : canRenderInline ? (
-            <iframe
-              key={contentUrl}
-              src={contentUrl}
-              title={selected || 'Document preview'}
-              className="w-full h-full border-0"
-              {...(needsSandbox ? { sandbox: '' } : {})}
-            />
-          ) : (
-            <div className="h-full flex flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
-              <FileText className="h-8 w-8 opacity-40" />
-              <span>Preview isn&apos;t available for .{selectedExt} files.</span>
-              <a
-                href={contentUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md border border-border hover:bg-muted/50 transition-colors text-foreground"
-              >
-                <Download className="h-4 w-4" />
-                Open / download
-              </a>
-            </div>
-          )}
-        </div>
-      </div>
+      <DocumentPreview sessionId={sessionId} documentName={selected} />
     </div>
   );
 };

--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -273,6 +273,26 @@
   text-overflow: ellipsis;
 }
 
+/* Data sheet split: optional source-document panel on the left of the grid. */
+.workspace-data-split {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+}
+
+.workspace-source-panel {
+  flex: 0 0 clamp(260px, 32%, 520px);
+  min-width: 0;
+  display: flex;
+  border-right: 1px solid hsl(var(--border));
+  overflow: hidden;
+}
+
+.workspace-data-split .workspace-grid-wrap {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .workspace-followup-banner {
   flex: 0 0 auto;
   display: flex;

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -2917,11 +2917,22 @@ function Workspace() {
   const selectedSourceDoc = useMemo<string | null>(() => {
     if (activeSheet !== 'data' || !sheetSelection || sheetSelection.sheet !== 'data') return null;
     const rows = (dataView === 'by_unit' ? alignedUnitData : data).rows || [];
-    const hot = hotTableRef.current?.hotInstance;
+    if (rows.length === 0) return null;
     const visualRow = sheetSelection.fromRow;
-    const physical = hot ? hot.toPhysicalRow(visualRow) : visualRow;
+    if (visualRow == null || visualRow < 0) return null;
+
+    // Map the visually selected row to its data row, accounting for column
+    // sorting. toPhysicalRow can return null/-1 for out-of-range rows, so guard
+    // and fall back to the visual index, then bound-check before reading.
+    const hot = hotTableRef.current?.hotInstance;
+    let physical = visualRow;
+    if (hot && typeof hot.toPhysicalRow === 'function') {
+      const mapped = hot.toPhysicalRow(visualRow);
+      if (mapped != null && mapped >= 0) physical = mapped;
+    }
     const row = rows[physical] ?? rows[visualRow];
     if (!row) return null;
+
     const raw =
       row._source_document ||
       row._parent_document ||
@@ -3009,18 +3020,19 @@ function Workspace() {
                 viewMode={dataView === 'by_unit' ? 'by_unit' : 'standard'}
                 onViewModeChange={(mode) => setDataView(mode === 'by_unit' ? 'by_unit' : 'by_document')}
               />
-              <span style={{ flex: 1 }} />
+              <span style={{ width: 1, alignSelf: 'stretch', background: '#e2e8e2', margin: '2px 4px' }} />
               <Button
                 size="sm"
-                variant={showSourcePanel ? 'secondary' : 'ghost'}
+                variant={showSourcePanel ? 'secondary' : 'outline'}
                 onClick={() => setShowSourcePanel((v) => !v)}
-                className="gap-1"
+                className="gap-1.5"
                 aria-pressed={showSourcePanel}
-                title="Show the source document for the selected row"
+                title="Show the source document for the selected row, side by side with the data"
               >
                 <PanelLeft className="h-4 w-4" />
-                Source
+                {showSourcePanel ? 'Hide source' : 'Show source document'}
               </Button>
+              <span style={{ flex: 1 }} />
             </div>
           )}
           {activeSheet === 'stats' ? (
@@ -3040,7 +3052,7 @@ function Workspace() {
             </div>
           ) : activeSheet === 'documents' ? (
             <div style={{ height: '100%', minHeight: 0, overflow: 'hidden' }}>
-              <DocumentViewer sessionId={sessionId} />
+              <DocumentViewer sessionId={sessionId} refreshKey={data.total_count} />
             </div>
           ) : activeSheet !== 'monitor' ? (
             activeSheet === 'data' && showSourcePanel ? (

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -58,6 +58,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { extractDisplayValue } from '@/components/DataTable/utils/valueUtils';
 import StatsDashboard from '@/components/StatsDashboard/StatsDashboard';
 import ScheMatiQMonitor from '@/components/ScheMatiQMonitor/ScheMatiQMonitor';
+import DocumentViewer from '@/components/DocumentViewer/DocumentViewer';
 import { ViewModeToggle } from '@/components/ViewMode/ViewModeToggle';
 import MissingDocumentsSection from '@/components/SchemaEditor/MissingDocumentsSection';
 import {
@@ -113,7 +114,7 @@ const documentDisplayName = (value?: string | null): string => {
   return (parts[parts.length - 1] || String(value)).trim();
 };
 
-type SheetId = 'data' | 'unit' | 'schema' | 'stats' | 'monitor';
+type SheetId = 'data' | 'unit' | 'schema' | 'stats' | 'monitor' | 'documents';
 type WorkspaceSessionMode = 'schematiq' | 'load';
 type PendingRerunKind = 'schema' | 'unit';
 
@@ -312,6 +313,7 @@ const SHEETS: Array<{ id: SheetId; label: string }> = [
   { id: 'unit', label: 'Observation Unit' },
   { id: 'schema', label: 'Schema' },
   { id: 'stats', label: 'Statistics' },
+  { id: 'documents', label: 'Documents' },
   { id: 'monitor', label: 'ScheMatiQ Monitor' },
 ];
 
@@ -2975,6 +2977,10 @@ function Workspace() {
                   Statistics will appear once processing completes.
                 </div>
               )}
+            </div>
+          ) : activeSheet === 'documents' ? (
+            <div style={{ height: '100%', minHeight: 0, overflow: 'hidden' }}>
+              <DocumentViewer sessionId={sessionId} />
             </div>
           ) : activeSheet !== 'monitor' ? (
             <div className="workspace-grid-wrap">

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -29,6 +29,7 @@ import {
   Underline,
   X,
   MoreVertical,
+  PanelLeft,
 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -59,6 +60,7 @@ import { extractDisplayValue } from '@/components/DataTable/utils/valueUtils';
 import StatsDashboard from '@/components/StatsDashboard/StatsDashboard';
 import ScheMatiQMonitor from '@/components/ScheMatiQMonitor/ScheMatiQMonitor';
 import DocumentViewer from '@/components/DocumentViewer/DocumentViewer';
+import DocumentPreview from '@/components/DocumentViewer/DocumentPreview';
 import { ViewModeToggle } from '@/components/ViewMode/ViewModeToggle';
 import MissingDocumentsSection from '@/components/SchemaEditor/MissingDocumentsSection';
 import {
@@ -2188,6 +2190,7 @@ function Workspace() {
   });
   const [formatVersion, setFormatVersion] = useState(0);
   const [sheetSelection, setSheetSelection] = useState<SheetSelection>(null);
+  const [showSourcePanel, setShowSourcePanel] = useState(false);
   const [chatWidth, setChatWidth] = useState(() => {
     const saved = Number(localStorage.getItem('workspace.chatWidth'));
     return Number.isFinite(saved) ? saved : 380;
@@ -2908,6 +2911,51 @@ function Workspace() {
     window.addEventListener('pointerup', handleUp);
   }, []);
 
+  // Source document of the currently selected data row, used by the optional
+  // source panel on the Data sheet. Uses the raw _source_document value so it
+  // matches the document names the content endpoint allowlists.
+  const selectedSourceDoc = useMemo<string | null>(() => {
+    if (activeSheet !== 'data' || !sheetSelection || sheetSelection.sheet !== 'data') return null;
+    const rows = (dataView === 'by_unit' ? alignedUnitData : data).rows || [];
+    const hot = hotTableRef.current?.hotInstance;
+    const visualRow = sheetSelection.fromRow;
+    const physical = hot ? hot.toPhysicalRow(visualRow) : visualRow;
+    const row = rows[physical] ?? rows[visualRow];
+    if (!row) return null;
+    const raw =
+      row._source_document ||
+      row._parent_document ||
+      (Array.isArray(row.papers) ? row.papers[0] : undefined);
+    return raw ? String(raw).trim() : null;
+  }, [activeSheet, sheetSelection, data, alignedUnitData, dataView]);
+
+  const dataGridNode = (
+    <div className="workspace-grid-wrap">
+      <SpreadsheetSurface
+        activeSheet={activeSheet}
+        data={activeSheet === 'data' && dataView === 'by_unit' ? alignedUnitData : data}
+        schema={schema}
+        displayOptions={tableDisplay}
+        cellFormats={cellFormats}
+        formatVersion={formatVersion}
+        hotTableRef={hotTableRef}
+        onSelectionChange={updateSheetSelection}
+        onRefresh={refreshSilent}
+        onEditFollowUp={notifyEditFollowUp}
+        onEditEnd={flushDeferredData}
+        layoutRevision={gridLayoutRevision}
+      />
+      {(loading || importingProject) && sessionId && (
+        <div className="workspace-loading-overlay" role="status" aria-live="polite">
+          <div className="workspace-loading-card">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            <span>Loading project…</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
   return (
     <div className="workspace-root h-full w-full">
       <SpreadsheetChrome
@@ -2961,6 +3009,18 @@ function Workspace() {
                 viewMode={dataView === 'by_unit' ? 'by_unit' : 'standard'}
                 onViewModeChange={(mode) => setDataView(mode === 'by_unit' ? 'by_unit' : 'by_document')}
               />
+              <span style={{ flex: 1 }} />
+              <Button
+                size="sm"
+                variant={showSourcePanel ? 'secondary' : 'ghost'}
+                onClick={() => setShowSourcePanel((v) => !v)}
+                className="gap-1"
+                aria-pressed={showSourcePanel}
+                title="Show the source document for the selected row"
+              >
+                <PanelLeft className="h-4 w-4" />
+                Source
+              </Button>
             </div>
           )}
           {activeSheet === 'stats' ? (
@@ -2983,30 +3043,18 @@ function Workspace() {
               <DocumentViewer sessionId={sessionId} />
             </div>
           ) : activeSheet !== 'monitor' ? (
-            <div className="workspace-grid-wrap">
-              <SpreadsheetSurface
-                activeSheet={activeSheet}
-                data={activeSheet === 'data' && dataView === 'by_unit' ? alignedUnitData : data}
-                schema={schema}
-                displayOptions={tableDisplay}
-                cellFormats={cellFormats}
-                formatVersion={formatVersion}
-                hotTableRef={hotTableRef}
-                onSelectionChange={updateSheetSelection}
-                onRefresh={refreshSilent}
-                onEditFollowUp={notifyEditFollowUp}
-                onEditEnd={flushDeferredData}
-                layoutRevision={gridLayoutRevision}
-              />
-              {(loading || importingProject) && sessionId && (
-                <div className="workspace-loading-overlay" role="status" aria-live="polite">
-                  <div className="workspace-loading-card">
-                    <Loader2 className="h-5 w-5 animate-spin" />
-                    <span>Loading project…</span>
-                  </div>
+            activeSheet === 'data' && showSourcePanel ? (
+              <div className="workspace-data-split">
+                <div className="workspace-source-panel">
+                  <DocumentPreview
+                    sessionId={sessionId}
+                    documentName={selectedSourceDoc}
+                    emptyHint="Select a row to see its source document."
+                  />
                 </div>
-              )}
-            </div>
+                {dataGridNode}
+              </div>
+            ) : dataGridNode
           ) : null}
 
           {/*

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -912,6 +912,13 @@ export const unitsAPI = {
   },
 
   /**
+   * Build the URL that serves a source document's raw bytes for inline viewing.
+   * Works both as an <iframe> src and as an anchor href (open in a new tab).
+   */
+  getDocumentContentUrl: (sessionId: string, name: string): string =>
+    `${API_BASE}/units/document-content/${encodeURIComponent(sessionId)}?name=${encodeURIComponent(name)}`,
+
+  /**
    * Get list of source documents with row counts.
    */
   getDocuments: async (sessionId: string): Promise<DocumentListResponse> => {


### PR DESCRIPTION
Adds a Documents tab to the workspace so users can browse the source documents they uploaded and preview each one inline, with an Open full link that opens the document in a new browser tab.

Backend
- New GET /units/document-content/{session_id}?name=<file> streams a source document inline. Locates the file on the local filesystem first (documents/ and pending_documents/ across all known data dirs), then falls back to Supabase storage's datasets bucket under the session's cloud_dataset.
- The name is allowlisted against the session's real source documents (get_source_documents) to prevent path traversal; only files that belong to the session are served.
- HTML and SVG are served with a sandboxing Content-Security-Policy so user-uploaded markup cannot run scripts in the app origin.

Frontend
- unitsAPI.getDocumentContentUrl builds the inline URL (used as both iframe src and the Open full href).
- New DocumentViewer component: document list on the left, inline iframe preview on the right (native browser rendering for PDF/HTML/images/text), Open full opens a new tab, and a download fallback for non-renderable types. HTML/SVG previews are rendered in a sandboxed iframe.
- New Documents tab in the workspace bottombar, shown in both session modes.

Phase 1 only: relies on the browser's native viewer (which already provides per-page navigation and thumbnails for PDFs). Per-page custom thumbnails via pdf.js are deferred to a possible phase 2.