### PR TITLE
Shorten Monitor tab label and bold the bottombar question

### DIFF
--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -233,6 +233,7 @@
   white-space: nowrap;
   color: hsl(var(--muted-foreground));
   font-size: 14px;
+  font-weight: 600;
   line-height: 1.2;
 }
 

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -317,7 +317,7 @@ const SHEETS: Array<{ id: SheetId; label: string }> = [
   { id: 'unit', label: 'Observation Unit' },
   { id: 'schema', label: 'Schema' },
   { id: 'stats', label: 'Statistics' },
-  { id: 'monitor', label: 'ScheMatiQ Monitor' },
+  { id: 'monitor', label: 'Monitor' },
 ];
 
 const WORKSPACE_MENUS = [


### PR DESCRIPTION
Two small bottombar tweaks. Renames the 'ScheMatiQ Monitor' sheet tab to just 'Monitor' — the ScheMatiQ prefix is redundant inside the app, and the longer label was getting slightly clipped in its active (bold) state. Also makes the research question in the bottombar always font-weight 600 so it stands out more. Styling and label only; no behaviour or data changes. The classic Visualizer page keeps its own label and is intentionally untouched. Verified: tsc --noEmit clean.