### PR TITLE
Fix New Project dialog overflow when breakdown expands

### DIFF
--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -682,7 +682,7 @@ function NewProjectDialog({ open, onOpenChange, onCreated }: NewProjectDialogPro
   return (
     <>
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>New Project</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
Caps the New Project dialog at 90vh with internal scroll, so expanding the cost breakdown no longer pushes the action buttons and close control out of reach.