### PR TITLE
Fix cloud dataset dropdown hidden behind dialog

### DIFF
--- a/frontend/src/components/CloudDatasetPicker/CloudDatasetPicker.tsx
+++ b/frontend/src/components/CloudDatasetPicker/CloudDatasetPicker.tsx
@@ -70,7 +70,7 @@ export function CloudDatasetPicker({
             <ChevronDown className="ml-2 h-4 w-4 flex-shrink-0" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-full min-w-[300px] max-h-[300px] overflow-y-auto">
+        <DropdownMenuContent className="z-[140] w-full min-w-[300px] max-h-[300px] overflow-y-auto">
           <DropdownMenuLabel>Select Datasets</DropdownMenuLabel>
           {datasets.length === 0 ? (
             <div className="px-2 py-1.5 text-sm text-muted-foreground">No datasets available</div>


### PR DESCRIPTION
The dataset picker's dropdown rendered at z-50, below the dialog overlay/content (z-130), so it opened behind the dialog and appeared unclickable. Raises the dropdown content to z-[140]. Works in both the page (classic) and dialog (workspace) contexts.