### PR TITLE
Separate structure and analysis tabs in the bottombar

### DIFF
--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -465,6 +465,14 @@
   font-weight: 600;
 }
 
+.workspace-sheet-tab-divider {
+  flex: 0 0 auto;
+  width: 1px;
+  height: 20px;
+  margin: 0 8px;
+  background: hsl(var(--border));
+}
+
 .workspace-chat {
   min-width: 0;
   height: 100%;

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type MutableRefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { type CSSProperties, type MutableRefObject, Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { HotTable, type HotTableClass } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
@@ -320,13 +320,13 @@ type NewProjectDialogProps = {
   onCreated: (sessionId: string) => void;
 };
 
-const SHEETS: Array<{ id: SheetId; label: string }> = [
-  { id: 'data', label: 'Data' },
-  { id: 'unit', label: 'Observation Unit' },
-  { id: 'schema', label: 'Schema' },
-  { id: 'stats', label: 'Statistics' },
-  { id: 'documents', label: 'Documents' },
-  { id: 'monitor', label: 'Monitor' },
+const SHEETS: Array<{ id: SheetId; label: string; group: 'structure' | 'analysis' }> = [
+  { id: 'data', label: 'Data', group: 'structure' },
+  { id: 'unit', label: 'Observation Unit', group: 'structure' },
+  { id: 'schema', label: 'Schema', group: 'structure' },
+  { id: 'stats', label: 'Statistics', group: 'analysis' },
+  { id: 'documents', label: 'Documents', group: 'analysis' },
+  { id: 'monitor', label: 'Monitor', group: 'analysis' },
 ];
 
 const WORKSPACE_MENUS = [
@@ -3394,15 +3394,19 @@ function Workspace() {
 
       <div className="workspace-bottombar">
         <div className="workspace-bottombar-tabs">
-          {SHEETS.filter((sheet) => sheet.id !== 'monitor' || sessionMode === 'schematiq').map((sheet) => (
-            <button
-              key={sheet.id}
-              className="workspace-sheet-tab"
-              data-active={activeSheet === sheet.id}
-              onClick={() => setActiveSheet(sheet.id)}
-            >
-              {sheet.label}
-            </button>
+          {SHEETS.filter((sheet) => sheet.id !== 'monitor' || sessionMode === 'schematiq').map((sheet, index, sheets) => (
+            <Fragment key={sheet.id}>
+              {index > 0 && sheets[index - 1].group !== sheet.group && (
+                <span className="workspace-sheet-tab-divider" aria-hidden="true" />
+              )}
+              <button
+                className="workspace-sheet-tab"
+                data-active={activeSheet === sheet.id}
+                onClick={() => setActiveSheet(sheet.id)}
+              >
+                {sheet.label}
+              </button>
+            </Fragment>
           ))}
         </div>
 


### PR DESCRIPTION
The bottombar tabs mix two conceptually different groups: the structure/data views (Data, Observation Unit, Schema) and the analysis views (Statistics, Documents, Monitor). This adds a thin vertical divider between the two groups so the distinction reads at a glance, while keeping the bar clean and professional. Implemented by tagging each sheet with a group ('structure' | 'analysis') and rendering a divider wherever the group changes, so it stays correct if tabs are added, reordered, or hidden (e.g. Monitor outside schematiq mode). Chose a divider over coloring half the tabs, which would compete with the green active state. Styling/markup only; no behaviour or data changes. Verified: tsc --noEmit and eslint clean.