### PR TITLE
Emphasize structure tab group over analysis group

### DIFF
--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -465,6 +465,14 @@
   font-weight: 600;
 }
 
+.workspace-sheet-tab-divider {
+  flex: 0 0 auto;
+  width: 1px;
+  height: 20px;
+  margin: 0 8px;
+  background: hsl(var(--border));
+}
+
 .workspace-chat {
   min-width: 0;
   height: 100%;

--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -458,6 +458,11 @@
   color: hsl(var(--muted-foreground));
 }
 
+.workspace-sheet-tab[data-group="structure"] {
+  color: hsl(var(--foreground));
+  font-weight: 500;
+}
+
 .workspace-sheet-tab[data-active="true"] {
   border-color: #188038;
   background: #e6f4ea;

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type MutableRefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { type CSSProperties, type MutableRefObject, Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { HotTable, type HotTableClass } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
@@ -320,13 +320,13 @@ type NewProjectDialogProps = {
   onCreated: (sessionId: string) => void;
 };
 
-const SHEETS: Array<{ id: SheetId; label: string }> = [
-  { id: 'data', label: 'Data' },
-  { id: 'unit', label: 'Observation Unit' },
-  { id: 'schema', label: 'Schema' },
-  { id: 'stats', label: 'Statistics' },
-  { id: 'documents', label: 'Documents' },
-  { id: 'monitor', label: 'Monitor' },
+const SHEETS: Array<{ id: SheetId; label: string; group: 'structure' | 'analysis' }> = [
+  { id: 'data', label: 'Data', group: 'structure' },
+  { id: 'unit', label: 'Observation Unit', group: 'structure' },
+  { id: 'schema', label: 'Schema', group: 'structure' },
+  { id: 'stats', label: 'Statistics', group: 'analysis' },
+  { id: 'documents', label: 'Documents', group: 'analysis' },
+  { id: 'monitor', label: 'Monitor', group: 'analysis' },
 ];
 
 const WORKSPACE_MENUS = [
@@ -3394,15 +3394,19 @@ function Workspace() {
 
       <div className="workspace-bottombar">
         <div className="workspace-bottombar-tabs">
-          {SHEETS.filter((sheet) => sheet.id !== 'monitor' || sessionMode === 'schematiq').map((sheet) => (
-            <button
-              key={sheet.id}
-              className="workspace-sheet-tab"
-              data-active={activeSheet === sheet.id}
-              onClick={() => setActiveSheet(sheet.id)}
-            >
-              {sheet.label}
-            </button>
+          {SHEETS.filter((sheet) => sheet.id !== 'monitor' || sessionMode === 'schematiq').map((sheet, index, sheets) => (
+            <Fragment key={sheet.id}>
+              {index > 0 && sheets[index - 1].group !== sheet.group && (
+                <span className="workspace-sheet-tab-divider" aria-hidden="true" />
+              )}
+              <button
+                className="workspace-sheet-tab"
+                data-active={activeSheet === sheet.id}
+                onClick={() => setActiveSheet(sheet.id)}
+              >
+                {sheet.label}
+              </button>
+            </Fragment>
           ))}
         </div>
 

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -3402,6 +3402,7 @@ function Workspace() {
               <button
                 className="workspace-sheet-tab"
                 data-active={activeSheet === sheet.id}
+                data-group={sheet.group}
                 onClick={() => setActiveSheet(sheet.id)}
               >
                 {sheet.label}


### PR DESCRIPTION
Builds on the tab-group divider (#209). The divider alone read a bit too subtle, so this adds a text-level hierarchy between the two groups: the structure/data views (Data, Observation Unit, Schema) now use the darker foreground color at weight 500 as the primary set, while the analysis views (Statistics, Documents, Monitor) stay in muted-foreground as secondary. Done via a data-group attribute on each tab; the active tab still wins (its green rule comes later with equal specificity), so no regression to the selected state. Avoids introducing a second accent color that would compete with the green active state. Styling/markup only; no behaviour or data changes. Verified: tsc --noEmit clean.