### PR TITLE
Group sheet tabs into segmented pills

### DIFF
--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -211,10 +211,20 @@
   min-width: 0;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 10px;
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: none;
+}
+
+.workspace-sheet-tab-group {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  border-radius: 8px;
+  background: hsl(var(--muted));
 }
 
 .workspace-bottombar-tabs::-webkit-scrollbar {
@@ -458,24 +468,11 @@
   color: hsl(var(--muted-foreground));
 }
 
-.workspace-sheet-tab[data-group="structure"] {
-  color: hsl(var(--foreground));
-  font-weight: 500;
-}
-
 .workspace-sheet-tab[data-active="true"] {
   border-color: #188038;
   background: #e6f4ea;
   color: #137333;
   font-weight: 600;
-}
-
-.workspace-sheet-tab-divider {
-  flex: 0 0 auto;
-  width: 1px;
-  height: 20px;
-  margin: 0 8px;
-  background: hsl(var(--border));
 }
 
 .workspace-chat {

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type MutableRefObject, Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { type CSSProperties, type MutableRefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { HotTable, type HotTableClass } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
@@ -3580,21 +3580,26 @@ function Workspace() {
 
       <div className="workspace-bottombar">
         <div className="workspace-bottombar-tabs">
-          {SHEETS.filter((sheet) => sheet.id !== 'monitor' || sessionMode === 'schematiq').map((sheet, index, sheets) => (
-            <Fragment key={sheet.id}>
-              {index > 0 && sheets[index - 1].group !== sheet.group && (
-                <span className="workspace-sheet-tab-divider" aria-hidden="true" />
-              )}
-              <button
-                className="workspace-sheet-tab"
-                data-active={activeSheet === sheet.id}
-                data-group={sheet.group}
-                onClick={() => setActiveSheet(sheet.id)}
-              >
-                {sheet.label}
-              </button>
-            </Fragment>
-          ))}
+          {(['structure', 'analysis'] as const).map((group) => {
+            const groupSheets = SHEETS.filter(
+              (sheet) => sheet.group === group && (sheet.id !== 'monitor' || sessionMode === 'schematiq'),
+            );
+            if (groupSheets.length === 0) return null;
+            return (
+              <div key={group} className="workspace-sheet-tab-group">
+                {groupSheets.map((sheet) => (
+                  <button
+                    key={sheet.id}
+                    className="workspace-sheet-tab"
+                    data-active={activeSheet === sheet.id}
+                    onClick={() => setActiveSheet(sheet.id)}
+                  >
+                    {sheet.label}
+                  </button>
+                ))}
+              </div>
+            );
+          })}
         </div>
 
         <Tooltip>


### PR DESCRIPTION
The earlier thin divider and primary/secondary text shade read too subtly to communicate the two tab groups. This replaces both with a segmented-control layout: the structure views (Data, Observation Unit, Schema) and the analysis views (Statistics, Documents, Monitor) each sit in their own subtle muted-background pill, separated by a clear gap. The active tab keeps its green fill and now reads as a selected segment inside its pill. Tabs are rendered by partitioning SHEETS on the existing group field, so empty groups (e.g. Monitor hidden outside schematiq mode) collapse cleanly. Removes the now-superseded divider span, the data-group text-color rule, and the unused Fragment import. Styling/markup only; no behaviour or data changes. Verified: tsc --noEmit and eslint clean.