### PR TITLE
Bold the structure tabs in the bottombar

### DIFF
--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -460,14 +460,14 @@
 
 .workspace-sheet-tab[data-group="structure"] {
   color: hsl(var(--foreground));
-  font-weight: 500;
+  font-weight: 700;
 }
 
 .workspace-sheet-tab[data-active="true"] {
   border-color: #188038;
   background: #e6f4ea;
   color: #137333;
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .workspace-sheet-tab-divider {


### PR DESCRIPTION
Makes the three structure tabs (Data, Observation Unit, Schema) clearly bold to set them apart from the analysis tabs, replacing the earlier too-subtle weight 500 with 700. The active tab weight is bumped to 700 as well so the active structure tab (e.g. Data) stays consistent with its bold siblings instead of looking lighter. Analysis tabs keep their normal weight. CSS-only; no markup, behaviour, or data changes. Verified: git apply --check clean on a fresh clone.