### PR TITLE
Show readable source and row/column counts instead of raw mode/status

### DIFF
--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -3315,9 +3315,31 @@ function Workspace() {
   const progressPercent = Math.round((status?.progress || 0) * 100);
   const topbarQuestion = schema?.query || config?.query || '';
   const projectTitle = topbarQuestion || (sessionId ? `ScheMatiQ ${sessionId.slice(0, 8)}` : 'Untitled workspace');
-  const chromeStatus = sessionId
-    ? `${sessionMode} / ${loading ? 'loading' : status?.status || 'loading'}`
-    : 'No project open';
+  const chromeStatus = useMemo(() => {
+    if (!sessionId) return 'No project open';
+    if (loading) return 'Loading…';
+
+    const rawStatus = status?.status || '';
+    const isDone = rawStatus === 'completed' || rawStatus === 'schema_extracted' || rawStatus === 'stopped';
+    const isFailed = rawStatus === 'error' || rawStatus === 'failed';
+
+    if (isFailed) return 'Extraction failed';
+
+    // Still working: surface a live, human label instead of the raw status key.
+    if (!isDone) {
+      return sessionMode === 'load' ? 'Importing…' : 'Extracting…';
+    }
+
+    // Done: replace the status word (which just repeats what the visible table
+    // already shows) with useful context — where the data came from + its size.
+    const source = sessionMode === 'load' ? 'Imported file' : 'Extracted from documents';
+    const rowCount = data.total_count;
+    const colCount = status?.columns_discovered ?? schema?.schema.length ?? 0;
+    const parts = [source];
+    if (rowCount > 0) parts.push(`${rowCount} ${rowCount === 1 ? 'row' : 'rows'}`);
+    if (colCount > 0) parts.push(`${colCount} ${colCount === 1 ? 'column' : 'columns'}`);
+    return parts.join(' · ');
+  }, [sessionId, loading, status, sessionMode, data.total_count, schema]);
   const isSheetHidden = chatWidth >= window.innerWidth - 80;
   const isChatHidden = chatWidth <= 24;
   const bodyGridColumns = isSheetHidden


### PR DESCRIPTION
The title-bar subline showed the internal sessionMode and status key (e.g. 'schematiq / completed'), which is jargon to end users and, once a table is visible, merely repeats what the screen already shows. It now shows a live label while working ('Extracting…' / 'Importing…') and, when done, the data source plus its size ('Extracted from documents · 24 rows · 8 columns'). Failures read 'Extraction failed'. The raw mode/status value is preserved in the Stgh pr create --base main --head fix/worksled.