### PR TITLE
Stop the last sheet tab from being clipped

### DIFF
--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -199,7 +199,7 @@
   flex: 0 0 auto;
   height: 52px;
   display: grid;
-  grid-template-columns: minmax(240px, 32vw) minmax(0, 1fr) clamp(120px, 14vw, 190px) 36px;
+  grid-template-columns: minmax(0, max-content) minmax(0, 1fr) clamp(120px, 14vw, 190px) 36px;
   align-items: center;
   gap: 14px;
   border-top: 1px solid hsl(var(--border));


### PR DESCRIPTION
After bolding the structure tabs, the tab row outgrew the bottombar's fixed tabs column (minmax(240px, 32vw)) and the last tab (Monitor) was being cut off by the column's overflow boundary. Changes that column to minmax(0, max-content) so it sizes to the tabs' natural width and shows all of them in full, with the research-question column (1fr, already ellipsized) absorbing the remaining space. On very narrow viewports the column can still shrink to 0 and the existing overflow-x: auto on the tab row takes over as a fallback. No tab sizing changes. CSS-only; verified git apply --check clean on a fresh clone.