### PR TITLE
Use ScheMatiQ logo as workspace titlebar mark

### DIFF
--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -24,19 +24,18 @@
 .workspace-chrome-titlebar {
   height: 38px;
   display: grid;
-  grid-template-columns: 32px minmax(160px, 320px) minmax(0, 1fr);
+  grid-template-columns: auto minmax(160px, 320px) minmax(0, 1fr);
   align-items: center;
   gap: 8px;
   padding: 6px 10px 2px;
 }
 
 .workspace-file-mark {
-  width: 30px;
   height: 30px;
-  padding: 0;
+  padding: 0 8px 0 4px;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+  gap: 6px;
   border: 0;
   border-radius: 6px;
   background: transparent;
@@ -53,6 +52,18 @@
   height: 26px;
   object-fit: contain;
   display: block;
+}
+
+.workspace-file-mark-name {
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  background: linear-gradient(to right, hsl(var(--primary)), #60a5fa);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
 }
 
 .workspace-file-title {
@@ -1006,7 +1017,11 @@
 
   .workspace-chrome-titlebar {
     height: 58px;
-    grid-template-columns: 32px minmax(120px, 1fr);
+    grid-template-columns: auto minmax(120px, 1fr);
+  }
+
+  .workspace-file-mark-name {
+    display: none;
   }
 
   .workspace-menu-row {

--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -31,14 +31,28 @@
 }
 
 .workspace-file-mark {
-  width: 28px;
-  height: 28px;
+  width: 30px;
+  height: 30px;
+  padding: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 4px;
-  background: #188038;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
   color: #ffffff;
+  cursor: pointer;
+}
+
+.workspace-file-mark:hover {
+  background: rgba(24, 128, 56, 0.1);
+}
+
+.workspace-file-mark-logo {
+  width: 26px;
+  height: 26px;
+  object-fit: contain;
+  display: block;
 }
 
 .workspace-file-title {
@@ -890,7 +904,11 @@
 }
 
 .dark .workspace-file-mark {
-  background: hsl(144 42% 34%);
+  background: transparent;
+}
+
+.dark .workspace-file-mark:hover {
+  background: hsl(145 12% 18%);
 }
 
 .dark .workspace-file-status {

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -2298,6 +2298,7 @@ function SpreadsheetChrome({
   onPrint,
   onExport,
   onSaveProject,
+  onHome,
   onSearch,
   onEstimateCost,
   onShowSheet,
@@ -2319,6 +2320,7 @@ function SpreadsheetChrome({
   onPrint: () => void;
   onExport: () => void;
   onSaveProject: () => void;
+  onHome: () => void;
   onSearch: () => void;
   onEstimateCost: () => void;
   onShowSheet: () => void;
@@ -2363,9 +2365,15 @@ function SpreadsheetChrome({
   return (
     <div className="workspace-chrome" role="toolbar" aria-label="Spreadsheet menu and formatting toolbar">
       <div className="workspace-chrome-titlebar">
-        <div className="workspace-file-mark">
-          <Table2 className="h-4 w-4" />
-        </div>
+        <button
+          type="button"
+          className="workspace-file-mark"
+          onClick={onHome}
+          title="ScheMatiQ home"
+          aria-label="ScheMatiQ home"
+        >
+          <img src="/icon.png" alt="" className="workspace-file-mark-logo" />
+        </button>
         <div className="workspace-file-title">
           <div className="workspace-file-name">{projectTitle}</div>
           <div className="workspace-file-status">{sessionStatus}</div>
@@ -3451,6 +3459,7 @@ function Workspace() {
         onPrint={printWorkspace}
         onExport={exportCurrentProject}
         onSaveProject={saveCurrentProject}
+        onHome={() => navigate('/')}
         onSearch={searchPage}
         onEstimateCost={estimateCurrentCost}
         onShowSheet={() => setChatWidth(0)}

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -2373,6 +2373,7 @@ function SpreadsheetChrome({
           aria-label="ScheMatiQ home"
         >
           <img src="/icon.png" alt="" className="workspace-file-mark-logo" />
+          <span className="workspace-file-mark-name">ScheMatiQ</span>
         </button>
         <div className="workspace-file-title">
           <div className="workspace-file-name">{projectTitle}</div>


### PR DESCRIPTION
The workspace titlebar showed a generic green table glyph as its file mark, while the classic header uses the real ScheMatiQ illustration (icon.png). This replaces that placeholder with the actual logo as a single clickable mark that navigates home, removing the duplicate-square look.