### PR TITLE
Workspace: add more documents to an existing project

### DIFF
--- a/frontend/src/components/DocumentUpload/DocumentUpload.tsx
+++ b/frontend/src/components/DocumentUpload/DocumentUpload.tsx
@@ -44,6 +44,7 @@ interface DocumentUploadProps {
   // Document limit props
   maxDocuments?: number;
   existingDocumentCount?: number;
+  hideHeader?: boolean;
 }
 
 const DocumentUpload: React.FC<DocumentUploadProps> = ({
@@ -57,6 +58,7 @@ const DocumentUpload: React.FC<DocumentUploadProps> = ({
   onCloudDocumentsAdd,
   maxDocuments,
   existingDocumentCount = 0,
+  hideHeader = false,
 }) => {
   // Cloud datasets state
   const [cloudDatasets, setCloudDatasets] = useState<CloudDataset[]>([]);
@@ -175,13 +177,15 @@ const DocumentUpload: React.FC<DocumentUploadProps> = ({
 
   return (
     <div className="space-y-4">
-      <div>
-        <h3 className="text-lg font-semibold mb-2">Upload Documents for Processing</h3>
-        <p className="text-sm text-muted-foreground">
-          Upload text files, PDFs, or documents that will be processed using the extracted schema.
-          Each file will be analyzed to extract data according to the discovered column definitions.
-        </p>
-      </div>
+      {!hideHeader && (
+        <div>
+          <h3 className="text-lg font-semibold mb-2">Upload Documents for Processing</h3>
+          <p className="text-sm text-muted-foreground">
+            Upload text files, PDFs, or documents that will be processed using the extracted schema.
+            Each file will be analyzed to extract data according to the discovered column definitions.
+          </p>
+        </div>
+      )}
 
       {maxDocuments && (
         <Alert className="border-blue-200 bg-blue-50 dark:bg-blue-950/20">

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -15,6 +15,7 @@ import {
   ChevronDown,
   Download,
   FileUp,
+  FileText,
   FolderOpen,
   Cloud,
   HelpCircle,
@@ -2887,6 +2888,7 @@ function Workspace() {
   const [addDocsResult, setAddDocsResult] = useState<DocumentUploadResult | null>(null);
   const [addDocsError, setAddDocsError] = useState<string | null>(null);
   const [addDocsNotice, setAddDocsNotice] = useState<string | null>(null);
+  const [removingAddDoc, setRemovingAddDoc] = useState<string | null>(null);
 
   const deferredDataRef = useRef<PaginatedData | null>(null);
   const cancelChatPendingRef = useRef<(() => Promise<boolean>) | null>(null);
@@ -3632,10 +3634,22 @@ function Workspace() {
     }
   }, [addDocsProcessing, refresh, sessionId, toast]);
 
-  const existingDocNames = useMemo(
-    () => new Set((documents?.documents ?? []).map((d) => d.name.trim().toLowerCase())),
-    [documents],
-  );
+  // Documents already in the project, taken from the session metadata (the same
+  // source the classic flow uses). This is authoritative and covers documents
+  // that exist in the project even when they are not currently available in the
+  // viewer (e.g. after opening a project fresh).
+  const existingUploadedDocs = session?.metadata?.uploaded_documents ?? [];
+  const documentMeta = session?.metadata?.document_metadata;
+
+  const existingDocNames = useMemo(() => {
+    const names = new Set<string>();
+    for (const doc of existingUploadedDocs) {
+      names.add(doc.trim().toLowerCase());
+      const orig = documentMeta?.[doc]?.original_filename;
+      if (orig) names.add(orig.trim().toLowerCase());
+    }
+    return names;
+  }, [existingUploadedDocs, documentMeta]);
 
   // Reject files whose name already exists in the project so an already-extracted
   // source is never uploaded and re-processed. Also de-dupes repeated names within
@@ -3662,6 +3676,21 @@ function Workspace() {
         : null,
     );
   }, [existingDocNames]);
+
+  const handleRemoveAddDoc = useCallback(async (docName: string) => {
+    if (!sessionId || removingAddDoc) return;
+    setRemovingAddDoc(docName);
+    setAddDocsError(null);
+    try {
+      await loadAPI.removeDocument(sessionId, docName);
+      await refresh({ silent: true });
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail;
+      setAddDocsError(typeof detail === 'string' ? detail : err?.message || 'Failed to remove document');
+    } finally {
+      setRemovingAddDoc(null);
+    }
+  }, [refresh, removingAddDoc, sessionId]);
 
   const addDocsPending = (addDocsResult?.uploaded_files?.length ?? 0) > 0;
 
@@ -3986,6 +4015,44 @@ function Workspace() {
                   <p className="text-sm text-muted-foreground mb-3">
                     Upload additional documents and extract them with this project&apos;s existing schema. New rows are appended to the table.
                   </p>
+                  {existingUploadedDocs.length > 0 && (
+                    <div className="space-y-2 mb-3">
+                      <p className="text-sm font-medium">Already in this project ({existingUploadedDocs.length}):</p>
+                      <div className="flex flex-wrap gap-2">
+                        {existingUploadedDocs.map((doc, index) => {
+                          const extraction = documentMeta?.[doc];
+                          const label = extraction?.original_filename || doc;
+                          const statusHint = extraction?.extraction_status;
+                          return (
+                            <div
+                              key={`${doc}-${index}`}
+                              className="flex items-center gap-1 px-3 py-1.5 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-full text-sm"
+                              title={statusHint ? `${label} \u2014 ${statusHint}` : label}
+                            >
+                              <FileText className="h-3.5 w-3.5 shrink-0 text-blue-600 dark:text-blue-400" />
+                              <span className="text-blue-700 dark:text-blue-300 max-w-[200px] truncate">{label}</span>
+                              {statusHint && (
+                                <span className="text-xs text-blue-500/80 dark:text-blue-400/80 truncate max-w-[120px]">({statusHint})</span>
+                              )}
+                              <button
+                                type="button"
+                                onClick={() => handleRemoveAddDoc(doc)}
+                                disabled={removingAddDoc === doc || addDocsProcessing}
+                                className="ml-1 p-0.5 hover:bg-blue-200 dark:hover:bg-blue-800 rounded-full transition-colors disabled:opacity-50"
+                                title={`Remove ${label}`}
+                              >
+                                {removingAddDoc === doc ? (
+                                  <Loader2 className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400 animate-spin" />
+                                ) : (
+                                  <X className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400 hover:text-red-600 dark:hover:text-red-400" />
+                                )}
+                              </button>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
                   {addDocsError && (
                     <Alert variant="destructive" className="mb-3">
                       <AlertDescription className="whitespace-pre-line">{addDocsError}</AlertDescription>

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -15,7 +15,6 @@ import {
   ChevronDown,
   Download,
   FileUp,
-  FileText,
   FolderOpen,
   Cloud,
   HelpCircle,
@@ -2891,7 +2890,6 @@ function Workspace() {
   const [addDocsResult, setAddDocsResult] = useState<DocumentUploadResult | null>(null);
   const [addDocsError, setAddDocsError] = useState<string | null>(null);
   const [addDocsNotice, setAddDocsNotice] = useState<string | null>(null);
-  const [removingAddDoc, setRemovingAddDoc] = useState<string | null>(null);
 
   const deferredDataRef = useRef<PaginatedData | null>(null);
   const cancelChatPendingRef = useRef<(() => Promise<boolean>) | null>(null);
@@ -3709,21 +3707,6 @@ function Workspace() {
     );
   }, [existingDocNames]);
 
-  const handleRemoveAddDoc = useCallback(async (docName: string) => {
-    if (!sessionId || removingAddDoc) return;
-    setRemovingAddDoc(docName);
-    setAddDocsError(null);
-    try {
-      await loadAPI.removeDocument(sessionId, docName);
-      await refresh({ silent: true });
-    } catch (err: any) {
-      const detail = err?.response?.data?.detail;
-      setAddDocsError(typeof detail === 'string' ? detail : err?.message || 'Failed to remove document');
-    } finally {
-      setRemovingAddDoc(null);
-    }
-  }, [refresh, removingAddDoc, sessionId]);
-
   const addDocsPending = (addDocsResult?.uploaded_files?.length ?? 0) > 0;
 
   const startSchemaRediscovery = useCallback(async () => {
@@ -4047,43 +4030,6 @@ function Workspace() {
                   <p className="text-sm text-muted-foreground mb-3">
                     Upload additional documents and extract them with this project&apos;s existing schema. New rows are appended to the table.
                   </p>
-                  {existingDocs.length > 0 && (
-                    <div className="space-y-2 mb-3">
-                      <p className="text-sm font-medium">Already in this project ({existingDocs.length}):</p>
-                      <div className="flex flex-wrap gap-2">
-                        {existingDocs.map((doc, index) => {
-                          const label = doc.label;
-                          const statusHint = doc.status;
-                          return (
-                            <div
-                              key={`${doc.name}-${index}`}
-                              className="flex items-center gap-1 px-3 py-1.5 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-full text-sm"
-                              title={statusHint ? `${label} \u2014 ${statusHint}` : label}
-                            >
-                              <FileText className="h-3.5 w-3.5 shrink-0 text-blue-600 dark:text-blue-400" />
-                              <span className="text-blue-700 dark:text-blue-300 max-w-[200px] truncate">{label}</span>
-                              {statusHint && (
-                                <span className="text-xs text-blue-500/80 dark:text-blue-400/80 truncate max-w-[120px]">({statusHint})</span>
-                              )}
-                              <button
-                                type="button"
-                                onClick={() => handleRemoveAddDoc(doc.name)}
-                                disabled={removingAddDoc === doc.name || addDocsProcessing}
-                                className="ml-1 p-0.5 hover:bg-blue-200 dark:hover:bg-blue-800 rounded-full transition-colors disabled:opacity-50"
-                                title={`Remove ${label}`}
-                              >
-                                {removingAddDoc === doc.name ? (
-                                  <Loader2 className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400 animate-spin" />
-                                ) : (
-                                  <X className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400 hover:text-red-600 dark:hover:text-red-400" />
-                                )}
-                              </button>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  )}
                   {addDocsError && (
                     <Alert variant="destructive" className="mb-3">
                       <AlertDescription className="whitespace-pre-line">{addDocsError}</AlertDescription>

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -2886,6 +2886,7 @@ function Workspace() {
   const [addDocsProcessing, setAddDocsProcessing] = useState(false);
   const [addDocsResult, setAddDocsResult] = useState<DocumentUploadResult | null>(null);
   const [addDocsError, setAddDocsError] = useState<string | null>(null);
+  const [addDocsNotice, setAddDocsNotice] = useState<string | null>(null);
 
   const deferredDataRef = useRef<PaginatedData | null>(null);
   const cancelChatPendingRef = useRef<(() => Promise<boolean>) | null>(null);
@@ -3571,6 +3572,7 @@ function Workspace() {
     if (!sessionId || addDocsFiles.length === 0 || addDocsUploading) return;
     setAddDocsUploading(true);
     setAddDocsError(null);
+    setAddDocsNotice(null);
     try {
       const result = await loadAPI.addDocuments(sessionId, addDocsFiles);
       setAddDocsResult(result);
@@ -3629,6 +3631,37 @@ function Workspace() {
       setAddDocsProcessing(false);
     }
   }, [addDocsProcessing, refresh, sessionId, toast]);
+
+  const existingDocNames = useMemo(
+    () => new Set((documents?.documents ?? []).map((d) => d.name.trim().toLowerCase())),
+    [documents],
+  );
+
+  // Reject files whose name already exists in the project so an already-extracted
+  // source is never uploaded and re-processed. Also de-dupes repeated names within
+  // a single selection. Note: this is a client-side guard by filename; the backend
+  // remains the authoritative source of truth.
+  const handleAddDocsFilesChange = useCallback((incoming: File[]) => {
+    const seen = new Set<string>();
+    const accepted: File[] = [];
+    const skipped: string[] = [];
+    for (const file of incoming) {
+      const key = file.name.trim().toLowerCase();
+      if (existingDocNames.has(key)) {
+        skipped.push(file.name);
+        continue;
+      }
+      if (seen.has(key)) continue;
+      seen.add(key);
+      accepted.push(file);
+    }
+    setAddDocsFiles(accepted);
+    setAddDocsNotice(
+      skipped.length > 0
+        ? `Skipped ${skipped.length} document${skipped.length !== 1 ? 's' : ''} already in this project (already extracted, not re-processed): ${Array.from(new Set(skipped)).join(', ')}`
+        : null,
+    );
+  }, [existingDocNames]);
 
   const addDocsPending = (addDocsResult?.uploaded_files?.length ?? 0) > 0;
 
@@ -3958,8 +3991,21 @@ function Workspace() {
                       <AlertDescription className="whitespace-pre-line">{addDocsError}</AlertDescription>
                     </Alert>
                   )}
+                  {addDocsNotice && (
+                    <Alert className="mb-3">
+                      <AlertDescription className="whitespace-pre-line">{addDocsNotice}</AlertDescription>
+                    </Alert>
+                  )}
+                  {addDocsFiles.length > 0 && (
+                    <div className="mb-3 flex items-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-sm text-foreground">
+                      <Check className="h-4 w-4 shrink-0 text-primary" />
+                      <span>
+                        {addDocsFiles.length} file{addDocsFiles.length !== 1 ? 's' : ''} ready. Review the list below, then click &ldquo;Upload&rdquo; to add {addDocsFiles.length !== 1 ? 'them' : 'it'} to the project.
+                      </span>
+                    </div>
+                  )}
                   <DocumentUpload
-                    onFilesChange={setAddDocsFiles}
+                    onFilesChange={handleAddDocsFilesChange}
                     uploadedFiles={addDocsFiles}
                     loading={addDocsUploading}
                     onUpload={uploadAddDocuments}
@@ -3967,6 +4013,7 @@ function Workspace() {
                     uploadResult={addDocsResult}
                     sessionId={sessionId}
                     existingDocumentCount={documents?.documents?.length ?? 0}
+                    hideHeader
                   />
                   {addDocsPending && (
                     <Button

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -39,6 +39,7 @@ import {
 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
   Dialog,
   DialogContent,
@@ -68,6 +69,7 @@ import StatsDashboard from '@/components/StatsDashboard/StatsDashboard';
 import ScheMatiQMonitor from '@/components/ScheMatiQMonitor/ScheMatiQMonitor';
 import DocumentViewer from '@/components/DocumentViewer/DocumentViewer';
 import DocumentPreview from '@/components/DocumentViewer/DocumentPreview';
+import DocumentUpload from '@/components/DocumentUpload/DocumentUpload';
 import { ViewModeToggle } from '@/components/ViewMode/ViewModeToggle';
 import MissingDocumentsSection from '@/components/SchemaEditor/MissingDocumentsSection';
 import TableFeedbackWidget from '@/components/TableFeedbackWidget/TableFeedbackWidget';
@@ -102,6 +104,7 @@ import {
   CostEstimate,
   DataRow,
   DocumentAvailabilityResponse,
+  DocumentUploadResult,
   PaginatedData,
   SchemaData,
   ReextractionCompletedData,
@@ -357,7 +360,7 @@ const WORKSPACE_MENUS = [
   },
   {
     label: 'Data',
-    items: ['Sort range', 'Create filter', 'Re-extract table', 'Validate schema'],
+    items: ['Sort range', 'Create filter', 'Re-extract table', 'Add documents', 'Validate schema'],
   },
   {
     label: 'Tools',
@@ -2524,6 +2527,7 @@ function SpreadsheetChrome({
   onShowChat,
   onSplitView,
   onRunPendingEdits,
+  onAddDocuments,
   onApplyFormat,
   rerunDisabled,
 }: {
@@ -2547,6 +2551,7 @@ function SpreadsheetChrome({
   onShowChat: () => void;
   onSplitView: () => void;
   onRunPendingEdits: () => void;
+  onAddDocuments: () => void;
   onApplyFormat: (patch: Partial<TableDisplayOptions>) => void;
   rerunDisabled: boolean;
 }) {
@@ -2564,6 +2569,7 @@ function SpreadsheetChrome({
     if (label === 'Show chat full screen') onShowChat();
     if (label === 'Split view') onSplitView();
     if (label === 'Re-extract table') onRunPendingEdits();
+    if (label === 'Add documents') onAddDocuments();
   };
 
   const isDisabled = (label: string) => {
@@ -2581,6 +2587,7 @@ function SpreadsheetChrome({
       'Show chat full screen',
       'Split view',
       'Re-extract table',
+      'Add documents',
     ].includes(label);
   };
 
@@ -2869,6 +2876,16 @@ function Workspace() {
   const [reextractAvailability, setReextractAvailability] = useState<DocumentAvailabilityResponse | null>(null);
   const [reextractAvailabilityLoading, setReextractAvailabilityLoading] = useState(false);
   const [stoppingReextraction, setStoppingReextraction] = useState(false);
+
+  // Add-more-documents (workspace parity with the classic flow): upload extra
+  // source documents and extract them with the existing schema. The backend
+  // endpoints (/load/add-documents, /load/process-documents) are flow-agnostic
+  // and already accept ScheMatiQ sessions, so this is a frontend-only surface.
+  const [addDocsFiles, setAddDocsFiles] = useState<File[]>([]);
+  const [addDocsUploading, setAddDocsUploading] = useState(false);
+  const [addDocsProcessing, setAddDocsProcessing] = useState(false);
+  const [addDocsResult, setAddDocsResult] = useState<DocumentUploadResult | null>(null);
+  const [addDocsError, setAddDocsError] = useState<string | null>(null);
 
   const deferredDataRef = useRef<PaginatedData | null>(null);
   const cancelChatPendingRef = useRef<(() => Promise<boolean>) | null>(null);
@@ -3549,6 +3566,72 @@ function Workspace() {
     if (!reextraction) setStoppingReextraction(false);
   }, [reextraction]);
 
+  // Step 1: upload extra documents into the session's pending queue.
+  const uploadAddDocuments = useCallback(async () => {
+    if (!sessionId || addDocsFiles.length === 0 || addDocsUploading) return;
+    setAddDocsUploading(true);
+    setAddDocsError(null);
+    try {
+      const result = await loadAPI.addDocuments(sessionId, addDocsFiles);
+      setAddDocsResult(result);
+      setAddDocsFiles([]);
+      await refresh({ silent: true });
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail;
+      const message =
+        detail && typeof detail === 'object' && Array.isArray(detail.errors)
+          ? detail.errors.join('\n')
+          : typeof detail === 'string'
+            ? detail
+            : err?.message || 'Failed to upload documents';
+      setAddDocsError(message);
+    } finally {
+      setAddDocsUploading(false);
+    }
+  }, [addDocsFiles, addDocsUploading, refresh, sessionId]);
+
+  // Step 2: extract the queued documents with the existing schema. The LLM
+  // config is resolved exactly like re-extraction; the backend additionally
+  // falls back to the session's stored value_extraction_backend when none is
+  // passed. New rows stream into the table via the existing WebSocket handler.
+  const processAddDocuments = useCallback(async () => {
+    if (!sessionId || addDocsProcessing) return;
+    setAddDocsProcessing(true);
+    setAddDocsError(null);
+    try {
+      const cfg = await configAPI.getConfig().catch(() => ({ allow_llm_config: true }));
+      const configured = await getConfiguredProviders();
+      const available = getAvailableProviders(configured);
+      const provider: LLMProviderKey = !cfg.allow_llm_config
+        ? 'gemini'
+        : (available[0] ?? 'gemini');
+      const model = getDefaultModelForProvider(provider);
+      const apiKey = await getApiKeyForProvider(provider);
+      const llmConfig: Record<string, unknown> = { provider, model, temperature: 0 };
+      if (apiKey) llmConfig.api_key = apiKey;
+
+      await loadAPI.processDocuments(sessionId, llmConfig);
+      setAddDocsResult(null);
+      setActiveSheet('data');
+      toast({
+        title: 'Processing new documents',
+        description: 'New rows will appear in the table as they are extracted.',
+        duration: 4000,
+      });
+      await refresh({ silent: true });
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail;
+      const message = err?.response?.status === 503
+        ? (detail || 'The server is busy. Please try again in a few minutes.')
+        : (typeof detail === 'string' ? detail : err?.message || 'Failed to start processing');
+      setAddDocsError(message);
+    } finally {
+      setAddDocsProcessing(false);
+    }
+  }, [addDocsProcessing, refresh, sessionId, toast]);
+
+  const addDocsPending = (addDocsResult?.uploaded_files?.length ?? 0) > 0;
+
   const startSchemaRediscovery = useCallback(async () => {
     if (!sessionId || rerunStarting) return;
 
@@ -3794,6 +3877,7 @@ function Workspace() {
         onShowChat={() => setChatWidth(window.innerWidth)}
         onSplitView={() => setChatWidth(380)}
         onRunPendingEdits={runPendingEdits}
+        onAddDocuments={() => setActiveSheet('documents')}
         onApplyFormat={applyTableFormat}
         rerunDisabled={!sessionId || !pendingRerunKind || rerunStarting}
       />
@@ -3856,8 +3940,48 @@ function Workspace() {
               )}
             </div>
           ) : activeSheet === 'documents' ? (
-            <div style={{ height: '100%', minHeight: 0, overflow: 'hidden' }}>
-              <DocumentViewer sessionId={sessionId} refreshKey={data.total_count} />
+            <div style={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+              <div style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+                <DocumentViewer sessionId={sessionId} refreshKey={data.total_count} />
+              </div>
+              {sessionId && (
+                <div
+                  className="border-t border-border"
+                  style={{ flexShrink: 0, maxHeight: '48%', overflowY: 'auto', padding: '16px' }}
+                >
+                  <h3 className="text-base font-semibold mb-1">Add more documents</h3>
+                  <p className="text-sm text-muted-foreground mb-3">
+                    Upload additional documents and extract them with this project&apos;s existing schema. New rows are appended to the table.
+                  </p>
+                  {addDocsError && (
+                    <Alert variant="destructive" className="mb-3">
+                      <AlertDescription className="whitespace-pre-line">{addDocsError}</AlertDescription>
+                    </Alert>
+                  )}
+                  <DocumentUpload
+                    onFilesChange={setAddDocsFiles}
+                    uploadedFiles={addDocsFiles}
+                    loading={addDocsUploading}
+                    onUpload={uploadAddDocuments}
+                    canUpload={Boolean(sessionId) && !addDocsProcessing}
+                    uploadResult={addDocsResult}
+                    sessionId={sessionId}
+                    existingDocumentCount={documents?.documents?.length ?? 0}
+                  />
+                  {addDocsPending && (
+                    <Button
+                      type="button"
+                      className="w-full mt-3"
+                      onClick={processAddDocuments}
+                      disabled={addDocsProcessing}
+                    >
+                      {addDocsProcessing
+                        ? 'Starting extraction\u2026'
+                        : `Process ${addDocsResult?.uploaded_files?.length ?? 0} new document(s)`}
+                    </Button>
+                  )}
+                </div>
+              )}
             </div>
           ) : activeSheet !== 'monitor' ? (
             activeSheet === 'data' && showSourcePanel ? (

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -2805,6 +2805,9 @@ function SpreadsheetChrome({
   );
 }
 
+const normalizeDocName = (s: string) => s.trim().toLowerCase();
+const stripDocExt = (s: string) => s.replace(/\.[^.\\/]+$/, '');
+
 function Workspace() {
   const { sessionId } = useParams();
   const navigate = useNavigate();
@@ -3634,34 +3637,63 @@ function Workspace() {
     }
   }, [addDocsProcessing, refresh, sessionId, toast]);
 
-  // Documents already in the project, taken from the session metadata (the same
-  // source the classic flow uses). This is authoritative and covers documents
-  // that exist in the project even when they are not currently available in the
-  // viewer (e.g. after opening a project fresh).
-  const existingUploadedDocs = session?.metadata?.uploaded_documents ?? [];
-  const documentMeta = session?.metadata?.document_metadata;
+  // Everything already in this project. Two sources, unioned:
+  //  - documents.documents: documents that already have extracted rows. This is
+  //    authoritative for a loaded/saved project, where the source files may no
+  //    longer be "available" for preview but the document is still in the table.
+  //  - session.metadata.uploaded_documents: documents uploaded this session that
+  //    may not have been processed into rows yet.
+  const existingDocs = useMemo(() => {
+    const map = new Map<string, { name: string; label: string; status?: string }>();
+    for (const d of documents?.documents ?? []) {
+      const key = normalizeDocName(d.name);
+      if (!map.has(key)) {
+        map.set(key, {
+          name: d.name,
+          label: d.name,
+          status: d.rowCount ? `${d.rowCount} row${d.rowCount === 1 ? '' : 's'}` : undefined,
+        });
+      }
+    }
+    const meta = session?.metadata?.document_metadata;
+    for (const doc of session?.metadata?.uploaded_documents ?? []) {
+      const label = meta?.[doc]?.original_filename || doc;
+      const key = normalizeDocName(label);
+      const status = meta?.[doc]?.extraction_status;
+      const existing = map.get(key);
+      if (existing) {
+        if (status && !existing.status) existing.status = status;
+      } else {
+        map.set(key, { name: doc, label, status });
+      }
+    }
+    return Array.from(map.values());
+  }, [documents, session]);
 
   const existingDocNames = useMemo(() => {
     const names = new Set<string>();
-    for (const doc of existingUploadedDocs) {
-      names.add(doc.trim().toLowerCase());
-      const orig = documentMeta?.[doc]?.original_filename;
-      if (orig) names.add(orig.trim().toLowerCase());
+    for (const d of existingDocs) {
+      names.add(normalizeDocName(d.label));
+      names.add(normalizeDocName(d.name));
+      names.add(normalizeDocName(stripDocExt(d.label)));
+      names.add(normalizeDocName(stripDocExt(d.name)));
     }
     return names;
-  }, [existingUploadedDocs, documentMeta]);
+  }, [existingDocs]);
 
   // Reject files whose name already exists in the project so an already-extracted
-  // source is never uploaded and re-processed. Also de-dupes repeated names within
-  // a single selection. Note: this is a client-side guard by filename; the backend
-  // remains the authoritative source of truth.
+  // source is never uploaded and re-processed. Matches on the full name and on the
+  // extension-stripped base name (a loaded project may store the document without
+  // its original extension). Also de-dupes repeated names within a selection.
+  // Client-side guard; the backend remains the source of truth.
   const handleAddDocsFilesChange = useCallback((incoming: File[]) => {
     const seen = new Set<string>();
     const accepted: File[] = [];
     const skipped: string[] = [];
     for (const file of incoming) {
-      const key = file.name.trim().toLowerCase();
-      if (existingDocNames.has(key)) {
+      const key = normalizeDocName(file.name);
+      const baseKey = normalizeDocName(stripDocExt(file.name));
+      if (existingDocNames.has(key) || existingDocNames.has(baseKey)) {
         skipped.push(file.name);
         continue;
       }
@@ -4015,17 +4047,16 @@ function Workspace() {
                   <p className="text-sm text-muted-foreground mb-3">
                     Upload additional documents and extract them with this project&apos;s existing schema. New rows are appended to the table.
                   </p>
-                  {existingUploadedDocs.length > 0 && (
+                  {existingDocs.length > 0 && (
                     <div className="space-y-2 mb-3">
-                      <p className="text-sm font-medium">Already in this project ({existingUploadedDocs.length}):</p>
+                      <p className="text-sm font-medium">Already in this project ({existingDocs.length}):</p>
                       <div className="flex flex-wrap gap-2">
-                        {existingUploadedDocs.map((doc, index) => {
-                          const extraction = documentMeta?.[doc];
-                          const label = extraction?.original_filename || doc;
-                          const statusHint = extraction?.extraction_status;
+                        {existingDocs.map((doc, index) => {
+                          const label = doc.label;
+                          const statusHint = doc.status;
                           return (
                             <div
-                              key={`${doc}-${index}`}
+                              key={`${doc.name}-${index}`}
                               className="flex items-center gap-1 px-3 py-1.5 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-full text-sm"
                               title={statusHint ? `${label} \u2014 ${statusHint}` : label}
                             >
@@ -4036,12 +4067,12 @@ function Workspace() {
                               )}
                               <button
                                 type="button"
-                                onClick={() => handleRemoveAddDoc(doc)}
-                                disabled={removingAddDoc === doc || addDocsProcessing}
+                                onClick={() => handleRemoveAddDoc(doc.name)}
+                                disabled={removingAddDoc === doc.name || addDocsProcessing}
                                 className="ml-1 p-0.5 hover:bg-blue-200 dark:hover:bg-blue-800 rounded-full transition-colors disabled:opacity-50"
                                 title={`Remove ${label}`}
                               >
-                                {removingAddDoc === doc ? (
+                                {removingAddDoc === doc.name ? (
                                   <Loader2 className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400 animate-spin" />
                                 ) : (
                                   <X className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400 hover:text-red-600 dark:hover:text-red-400" />


### PR DESCRIPTION
Brings the classic flow's 'Add More Documents' capability to the Workspace flow. The Documents tab now hosts an uploader below the document viewer: upload extra source files, then process them with the project's existing schema. New rows stream into the table via the existing WebSocket handler. Reuses the shared DocumentUpload component and mirrors re-extraction's LLM-config/API-key resolution; the backend /load/add-documents and /load/process-documents endpoints are already flow-agnostic and accept ScheMatiQ sessions, so this is a frontend-only change. Also adds a 'Add documents' entry to the Data menu. No backend changes; re-extraction and project creation are untouched.