### PR TITLE
chore(workspace): hide tool-suggestion picker and drop dead pinned-tool state

### DIFF
--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -65,7 +65,7 @@ class ChatAgentService:
         chat_id: Optional[str] = None,
         pinned_tool: Optional[str] = None,
     ) -> dict[str, Any]:
-        state = self._get_or_create_session(session_id, session_mode, chat_id, pinned_tool)
+        state = self._get_or_create_session(session_id, session_mode, chat_id)
         outbound_messages: list[dict[str, Any]] = []
         if state.pending:
             abort_messages, new_pending = await self._abort_pending(
@@ -82,7 +82,7 @@ class ChatAgentService:
                 }
         user_text = message
         if pinned_tool:
-            user_text = f"[User pinned tool: {pinned_tool}]\n{message}"
+            user_text = f"[User suggested tool: {pinned_tool}]\n{message}"
 
         try:
             result = await self._run_loop(state, user_text, outbound_messages)
@@ -107,7 +107,7 @@ class ChatAgentService:
             if self._is_stale_chat_error(exc) and chat_id:
                 logger.warning("Stale chat session %s, starting fresh: %s", chat_id, exc)
                 chat_session_store.delete(chat_id)
-                state = self._get_or_create_session(session_id, session_mode, None, pinned_tool)
+                state = self._get_or_create_session(session_id, session_mode, None)
                 result = await self._run_loop(state, user_text, outbound_messages)
                 return {
                     "chat_id": state.chat_id,
@@ -231,12 +231,10 @@ class ChatAgentService:
         session_id: str,
         session_mode: str,
         chat_id: Optional[str],
-        pinned_tool: Optional[str],
     ) -> ChatSessionState:
         if chat_id:
             existing = chat_session_store.get(chat_id)
             if existing and existing.workspace_session_id == session_id:
-                existing.pinned_tool = pinned_tool
                 return existing
 
         client, chat = self._create_gemini_chat(session_id, session_mode)
@@ -245,7 +243,6 @@ class ChatAgentService:
             chat=chat,
             workspace_session_id=session_id,
             session_mode=session_mode,
-            pinned_tool=pinned_tool,
         )
         new_id = chat_session_store.create(state)
         state.chat_id = new_id

--- a/backend/app/services/chat/session_store.py
+++ b/backend/app/services/chat/session_store.py
@@ -22,7 +22,6 @@ class ChatSessionState:
     session_mode: str
     chat_id: Optional[str] = None
     pending: Optional[PendingToolCall] = None
-    pinned_tool: Optional[str] = None
 
 
 class ChatSessionStore:

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -1929,6 +1929,12 @@ function ChatMessageBody({ message }: { message: WorkspaceMessage }) {
   );
 }
 
+// Tool-suggestion control. Lets the user nudge the assistant toward a specific
+// tool; it is sent to the backend as a soft hint (prepended to the message), not
+// an enforced tool_choice, so the assistant may still pick a different tool.
+// Hidden for now — flip to `true` to re-expose the picker.
+const SHOW_TOOL_SUGGESTION: boolean = false;
+
 function ChatPanel({
   sessionId,
   sessionMode,
@@ -2179,14 +2185,14 @@ function ChatPanel({
         </div>
       </div>
 
-      {availableTools.length > 0 && (
+      {SHOW_TOOL_SUGGESTION && availableTools.length > 0 && (
         <div className="workspace-chat-tools px-3 pb-2">
           <select
             className="w-full rounded-md border bg-background px-2 py-1 text-xs"
             value={pinnedTool || ''}
             onChange={(event) => setPinnedTool(event.target.value || null)}
           >
-            <option value="">Pin a tool (optional)</option>
+            <option value="">Suggest a tool (optional)</option>
             {availableTools.map((tool) => (
               <option key={tool.name} value={tool.name}>
                 {tool.name}


### PR DESCRIPTION
Hides the chat tool-suggestion picker for now while keeping the implementation in the tree.
- Rename label 'Pin a tool' -> 'Suggest a tool'; backend prefix '[User pinned tool]' -> '[User suggested tool]' (it is a soft prompt hint, not an enforced tool_choice).
- Remove dead `pinned_tool` field from `ChatSessionState` (assigned, never read) and drop the now-unused param from `_get_or_create_session`.
- Add `SHOW_TOOL_SUGGESTION` flag (false) gating the picker.

Re-enabling is a one-line flip in a follow-up PR. Verified: tsc --noEmit clean, backend py_compile clean.