### PR TITLE
fix(workspace): render the /tools list as a Markdown bullet list

### DIFF
--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -1902,7 +1902,9 @@ function formatToolsList(tools: ChatToolInfo[]): string {
     .map((tool) => {
       const badge = tool.cost_class === 'expensive' ? ' [cost]' : '';
       const status = tool.available ? '' : ' (planned)';
-      return `• ${tool.name}${badge}${status}: ${tool.description}`;
+      // Markdown list item; the name is inline code so underscores in tool
+      // names (e.g. edit_observation_unit) are not parsed as emphasis.
+      return `- \`${tool.name}\`${badge}${status}: ${tool.description}`;
     })
     .join('\n');
 }


### PR DESCRIPTION
The chat now renders assistant replies as Markdown (PR #220), which collapsed the `/tools` output into one paragraph because it used a literal bullet char with single-newline joins.
- Switch `formatToolsList` to real Markdown list items (`- ...`).
- Wrap each tool name in inline code so underscores (e.g. `edit_observation_unit`) are not parsed as emphasis.

Verified: tsc --noEmit clean.