### PR TITLE
feat(workspace): re-attach source documents for imported projects (view-only)

### DIFF
--- a/backend/app/api/routes/units.py
+++ b/backend/app/api/routes/units.py
@@ -3,9 +3,9 @@
 import io
 import mimetypes
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, File, HTTPException, Query, UploadFile
 from fastapi.responses import StreamingResponse
 
 from app.models.unit import (
@@ -19,7 +19,8 @@ from app.models.unit import (
 from app.models.session import PaginatedData, DataRow, FilterSortRequest
 from app.services.unit_view_service import unit_view_service
 from app.services import session_manager, pubmed_enrichment_service
-from app.services.data_utils import candidate_data_dirs
+from app.services.data_utils import candidate_data_dirs, get_data_dir
+from app.services.file_parser import is_system_file
 from app.storage import get_storage
 
 router = APIRouter()
@@ -228,6 +229,67 @@ async def get_document_content(
         )
 
     return StreamingResponse(io.BytesIO(content), media_type=media_type, headers=headers)
+
+
+# Per-file ceiling, mirroring the add-documents upload guard.
+_MAX_ATTACH_FILE_BYTES = 25 * 1024 * 1024
+
+
+@router.post(
+    "/source-documents/{session_id}",
+    summary="Attach source documents for inline viewing",
+    description=(
+        "Store the original bytes of uploaded source documents so the document "
+        "viewer can render them. Unlike /load/add-documents this is view-only: it "
+        "does NOT change session status or queue the files for processing, so an "
+        "imported project stays 'completed'. Files are matched to existing rows by "
+        "name/stem at serve time, so re-uploading the project's original filenames "
+        "is enough to make previews resolve."
+    ),
+)
+async def attach_source_documents(
+    session_id: str,
+    files: List[UploadFile] = File(...),
+):
+    """Persist uploaded originals under the session's pending_documents/ dir.
+
+    The viewer's ``get_document_content`` already searches documents/ and
+    pending_documents/ (with stem matching) across every candidate data dir, so
+    writing the originals here is sufficient for inline preview. We deliberately
+    avoid preprocessing (no PDF->text conversion) so the original file renders
+    natively, and we never touch session.status or uploaded_documents.
+
+    Note: this writes to the local filesystem, which is durable in dev and for a
+    single-instance backend. Durable storage of re-attached files on the Supabase
+    backend is handled by the project-bundle (zip) work.
+    """
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    pending_dir = get_data_dir() / session_id / "pending_documents"
+    pending_dir.mkdir(parents=True, exist_ok=True)
+
+    attached: list[str] = []
+    skipped: list[dict] = []
+    for upload in files:
+        name = Path(upload.filename or "").name
+        if not name or is_system_file(name):
+            continue
+        content = await upload.read()
+        if len(content) > _MAX_ATTACH_FILE_BYTES:
+            skipped.append({"name": name, "reason": "exceeds 25MB limit"})
+            continue
+        try:
+            (pending_dir / name).write_bytes(content)
+            attached.append(name)
+        except Exception as e:  # pragma: no cover - defensive
+            skipped.append({"name": name, "reason": str(e)})
+
+    if not attached and skipped:
+        raise HTTPException(status_code=400, detail={"skipped": skipped})
+
+    return {"status": "success", "attached": attached, "skipped": skipped}
 
 
 @router.post(

--- a/frontend/src/components/DocumentViewer/DocumentPreview.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentPreview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { FileText, ExternalLink, Download, FileX } from 'lucide-react';
+import { FileText, ExternalLink, Download, FileX, Upload } from 'lucide-react';
 
 import { unitsAPI } from '../../services/api';
 
@@ -25,6 +25,16 @@ interface DocumentPreviewProps {
   documentName: string | null;
   /** Message shown when no document is selected. */
   emptyHint?: string;
+  /**
+   * Bump this to force a fresh availability probe and iframe reload — e.g. after
+   * the user uploads previously-missing source files for an imported project.
+   */
+  reloadToken?: number;
+  /**
+   * When provided, the "not available" state offers a button that invokes this
+   * (typically opens a file picker to re-attach the original source documents).
+   */
+  onRequestUpload?: () => void;
 }
 
 /**
@@ -33,15 +43,24 @@ interface DocumentPreviewProps {
  * fallback for formats the browser cannot render.
  *
  * Before rendering, the content URL is probed with a HEAD request: if the
- * document cannot be served (e.g. an older project whose files are no longer
- * stored, where the endpoint returns an error), a friendly "not available"
- * message is shown instead of letting the iframe render the raw error body.
+ * document cannot be served (e.g. an imported project whose files were never
+ * re-attached, where the endpoint returns an error), a friendly "not available"
+ * message is shown instead of letting the iframe render the raw error body. The
+ * message can offer an upload action so the user can supply the original files.
  */
-const DocumentPreview: React.FC<DocumentPreviewProps> = ({ sessionId, documentName, emptyHint }) => {
-  const contentUrl = useMemo(
-    () => (sessionId && documentName ? unitsAPI.getDocumentContentUrl(sessionId, documentName) : null),
-    [sessionId, documentName],
-  );
+const DocumentPreview: React.FC<DocumentPreviewProps> = ({
+  sessionId,
+  documentName,
+  emptyHint,
+  reloadToken,
+  onRequestUpload,
+}) => {
+  const contentUrl = useMemo(() => {
+    if (!sessionId || !documentName) return null;
+    const base = unitsAPI.getDocumentContentUrl(sessionId, documentName);
+    // Cache-bust so a freshly uploaded file isn't masked by a cached 404/response.
+    return reloadToken ? `${base}&_t=${reloadToken}` : base;
+  }, [sessionId, documentName, reloadToken]);
 
   const [availability, setAvailability] = useState<Availability>('idle');
 
@@ -90,8 +109,18 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({ sessionId, documentNa
           <FileX className="h-8 w-8 opacity-40" />
           <span>This document isn&apos;t available to preview.</span>
           <span className="text-xs">
-            It may be from an older project whose source files are no longer stored.
+            Imported projects don&apos;t include the original files. Upload them to enable preview.
           </span>
+          {onRequestUpload && (
+            <button
+              type="button"
+              onClick={onRequestUpload}
+              className="mt-1 inline-flex items-center gap-1 px-3 py-1.5 rounded-md border border-border hover:bg-muted/50 transition-colors text-foreground"
+            >
+              <Upload className="h-4 w-4" />
+              Upload source documents
+            </button>
+          )}
         </div>
       );
     }

--- a/frontend/src/components/DocumentViewer/DocumentViewer.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentViewer.tsx
@@ -1,9 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import { FileText } from 'lucide-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { FileText, Upload, Loader2 } from 'lucide-react';
 
 import { unitsAPI } from '../../services/api';
 import { DocumentSummary } from '../../types/unit';
 import DocumentPreview from './DocumentPreview';
+
+/** Extensions accepted by the source-document re-attach picker (mirrors the backend allow-list). */
+const ACCEPTED_UPLOAD_EXTENSIONS = '.txt,.md,.pdf,.doc,.docx,.rtf,.json';
 
 interface DocumentViewerProps {
   sessionId: string | null | undefined;
@@ -11,16 +14,37 @@ interface DocumentViewerProps {
   refreshKey?: number;
 }
 
+const extractErrorMessage = (err: any): string => {
+  const detail = err?.response?.data?.detail;
+  if (typeof detail === 'string') return detail;
+  if (detail && Array.isArray(detail.errors) && detail.errors.length > 0) {
+    return detail.errors.join(' ');
+  }
+  return 'Could not upload documents. Please try again.';
+};
+
 /**
  * Browse a session's uploaded source documents: a list on the left and an
  * inline preview on the right (see DocumentPreview). "Open full" opens the
  * document in a new browser tab.
+ *
+ * Imported projects carry the schema and data but not the original files, so the
+ * preview reports documents as unavailable. The header (and the preview's empty
+ * state) offer an upload action that re-attaches the original source files via
+ * the existing add-documents endpoint, after which previews resolve.
  */
 const DocumentViewer: React.FC<DocumentViewerProps> = ({ sessionId, refreshKey }) => {
   const [documents, setDocuments] = useState<DocumentSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
+
+  // Bumped after a successful upload to force the list to refetch and the
+  // preview to re-probe / reload the now-available file.
+  const [reloadToken, setReloadToken] = useState(0);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     if (!sessionId) {
@@ -47,7 +71,34 @@ const DocumentViewer: React.FC<DocumentViewerProps> = ({ sessionId, refreshKey }
     return () => {
       cancelled = true;
     };
-  }, [sessionId, refreshKey]);
+  }, [sessionId, refreshKey, reloadToken]);
+
+  const openFilePicker = useCallback(() => {
+    setUploadError(null);
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFilesSelected = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(e.target.files || []);
+      // Reset so selecting the same files again re-triggers onChange.
+      e.target.value = '';
+      if (!sessionId || files.length === 0) return;
+
+      setUploading(true);
+      setUploadError(null);
+      try {
+        await unitsAPI.attachSourceDocuments(sessionId, files);
+        // Refetch the list and re-probe the preview against the newly stored files.
+        setReloadToken((t) => t + 1);
+      } catch (err: any) {
+        setUploadError(extractErrorMessage(err));
+      } finally {
+        setUploading(false);
+      }
+    },
+    [sessionId],
+  );
 
   if (!sessionId) {
     return (
@@ -59,12 +110,36 @@ const DocumentViewer: React.FC<DocumentViewerProps> = ({ sessionId, refreshKey }
 
   return (
     <div className="h-full flex min-h-0">
+      {/* Hidden picker shared by the header button and the preview's empty state. */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept={ACCEPTED_UPLOAD_EXTENSIONS}
+        onChange={handleFilesSelected}
+        className="hidden"
+      />
+
       {/* Document list */}
       <div className="w-56 flex-shrink-0 border-r border-border overflow-y-auto">
-        <div className="px-3 py-2 text-xs text-muted-foreground border-b border-border">
-          {loading ? 'Loading\u2026' : `${documents.length} document${documents.length === 1 ? '' : 's'}`}
+        <div className="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground border-b border-border">
+          <span className="truncate">
+            {loading ? 'Loading\u2026' : `${documents.length} document${documents.length === 1 ? '' : 's'}`}
+          </span>
+          <span className="flex-1" />
+          <button
+            type="button"
+            onClick={openFilePicker}
+            disabled={uploading}
+            title="Upload the original source documents for this project"
+            className="inline-flex items-center gap-1 px-1.5 py-1 rounded-md border border-border hover:bg-muted/50 transition-colors text-foreground disabled:opacity-50"
+          >
+            {uploading ? <Loader2 className="h-3 w-3 animate-spin" /> : <Upload className="h-3 w-3" />}
+            <span>Upload</span>
+          </button>
         </div>
         {error && <div className="px-3 py-2 text-xs text-destructive">{error}</div>}
+        {uploadError && <div className="px-3 py-2 text-xs text-destructive">{uploadError}</div>}
         {documents.map((doc) => {
           const active = doc.name === selected;
           return (
@@ -98,7 +173,12 @@ const DocumentViewer: React.FC<DocumentViewerProps> = ({ sessionId, refreshKey }
       </div>
 
       {/* Preview pane */}
-      <DocumentPreview sessionId={sessionId} documentName={selected} />
+      <DocumentPreview
+        sessionId={sessionId}
+        documentName={selected}
+        reloadToken={reloadToken}
+        onRequestUpload={openFilePicker}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type MutableRefObject, Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { type CSSProperties, type ChangeEvent, type MutableRefObject, Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -2614,6 +2614,11 @@ function Workspace() {
   const [formatVersion, setFormatVersion] = useState(0);
   const [sheetSelection, setSheetSelection] = useState<SheetSelection>(null);
   const [showSourcePanel, setShowSourcePanel] = useState(false);
+  // View-only re-attach of source files for the data-sheet source panel. Bumping
+  // the token re-probes the preview so a freshly uploaded file resolves.
+  const [sourceDocReloadToken, setSourceDocReloadToken] = useState(0);
+  const [attachingSourceDocs, setAttachingSourceDocs] = useState(false);
+  const sourceDocInputRef = useRef<HTMLInputElement | null>(null);
   const [chatWidth, setChatWidth] = useState(() => {
     const saved = Number(localStorage.getItem('workspace.chatWidth'));
     return Number.isFinite(saved) ? saved : 380;
@@ -3456,6 +3461,28 @@ function Workspace() {
     return raw ? String(raw).trim() : null;
   }, [activeSheet, sheetSelection, alignedDocData, alignedUnitData, dataView]);
 
+  const handleAttachSourceDocs = useCallback(
+    async (e: ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(e.target.files || []);
+      e.target.value = '';
+      if (!sessionId || files.length === 0) return;
+      setAttachingSourceDocs(true);
+      try {
+        await unitsAPI.attachSourceDocuments(sessionId, files);
+        setSourceDocReloadToken((t) => t + 1);
+      } catch (err) {
+        toast({
+          title: 'Upload failed',
+          description: 'Could not attach the source documents. Please try again.',
+          variant: 'destructive',
+        });
+      } finally {
+        setAttachingSourceDocs(false);
+      }
+    },
+    [sessionId, toast],
+  );
+
   const dataGridNode = (
     <div className="workspace-grid-wrap">
       <SpreadsheetSurface
@@ -3577,10 +3604,20 @@ function Workspace() {
             activeSheet === 'data' && showSourcePanel ? (
               <div className="workspace-data-split">
                 <div className="workspace-source-panel">
+                  <input
+                    ref={sourceDocInputRef}
+                    type="file"
+                    multiple
+                    accept=".txt,.md,.pdf,.doc,.docx,.rtf,.json"
+                    onChange={handleAttachSourceDocs}
+                    className="hidden"
+                  />
                   <DocumentPreview
                     sessionId={sessionId}
                     documentName={selectedSourceDoc}
                     emptyHint="Select a row to see its source document."
+                    reloadToken={sourceDocReloadToken}
+                    onRequestUpload={attachingSourceDocs ? undefined : () => sourceDocInputRef.current?.click()}
                   />
                 </div>
                 {dataGridNode}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -919,6 +919,26 @@ export const unitsAPI = {
     `${API_BASE}/units/document-content/${encodeURIComponent(sessionId)}?name=${encodeURIComponent(name)}`,
 
   /**
+   * Re-attach original source files to a session so the document viewer can
+   * render them. View-only: does not change session status or queue the files
+   * for processing (unlike loadAPI.addDocuments). Used to restore previews for
+   * imported projects, which carry schema + data but not the original files.
+   */
+  attachSourceDocuments: async (
+    sessionId: string,
+    files: File[],
+  ): Promise<{ status: string; attached: string[]; skipped: { name: string; reason: string }[] }> => {
+    const formData = new FormData();
+    files.forEach((file) => formData.append('files', file));
+    const response = await api.post(
+      `/units/source-documents/${encodeURIComponent(sessionId)}`,
+      formData,
+      { headers: { 'Content-Type': 'multipart/form-data' } },
+    );
+    return response.data;
+  },
+
+  /**
    * Get list of source documents with row counts.
    */
   getDocuments: async (sessionId: string): Promise<DocumentListResponse> => {


### PR DESCRIPTION
Imported projects carry schema + data but not the original files, so the document viewer reported every document as unavailable. 

- Add a view-only endpoint (POST /units/source-documents/{session_id}) that stores the original bytes under pending_documents/ without touching session.status or the processing queue.
- Add an upload affordance in both the Documents tab and the data-sheet source panel. 
- The existing stem-matching serve path then resolves the previews.