### PR TITLE
fix(workspace): header logo returns to workspace start, not classic flow

### DIFF
--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -3530,7 +3530,7 @@ function Workspace() {
         onPrint={printWorkspace}
         onExport={exportCurrentProject}
         onSaveProject={saveCurrentProject}
-        onHome={() => navigate('/')}
+        onHome={() => navigate('/workspace')}
         onSearch={searchPage}
         onEstimateCost={estimateCurrentCost}
         onShowSheet={() => setChatWidth(0)}


### PR DESCRIPTION
## Problem
The clickable ScheMatiQ logo in the workspace top bar sent users to the classic flow (`/`, ScheMatiQConfig) instead of resetting the workspace.

## Solution
Wire the logo's `onHome` to `navigate('/workspace')`. The `/workspace` route re-renders `Workspace` with no `sessionId`, and the existing effects reopen the New Project dialog and reset session-scoped state (`data`, `schema`, `status`, `session`, `dataView`) — i.e. the new flow's initial state.

The intentional 'Existing Start Page' menu item (`navigate('/')`) is left unchanged.

## Verify
- Applies clean on main; `npx tsc --noEmit` clean
- Manual: open a workspace session → click the logo → lands on the New Project dialog at /workspace