### PR TITLE
feat(routing): Workspace becomes the default route; classic flow moves to /classic

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,7 @@ function AppHeader() {
 
 function App() {
   const location = useLocation();
-  const isWorkspace = location.pathname.startsWith('/workspace');
+  const isWorkspace = location.pathname === '/' || location.pathname.startsWith('/workspace');
 
   return (
     <TooltipProvider>
@@ -47,11 +47,13 @@ function App() {
         {/* Main Content */}
         <main className={isWorkspace ? 'flex-1 min-h-0 overflow-hidden' : 'container py-6 flex-1'}>
           <Routes>
-            <Route path="/" element={<ScheMatiQConfig />} />
+            <Route path="/" element={<Workspace />} />
+            <Route path="/classic" element={<ScheMatiQConfig />} />
             <Route path="/load" element={<Load />} />
-            <Route path="/schematiq" element={<Navigate to="/" replace />} />
+            <Route path="/schematiq" element={<Navigate to="/classic" replace />} />
             <Route path="/visualize/:sessionId" element={<Visualize />} />
-            <Route path="/workspace" element={<Workspace />} />
+            {/* Bare /workspace redirects to the new default; session URLs keep the prefix. */}
+            <Route path="/workspace" element={<Navigate to="/" replace />} />
             <Route path="/workspace/:sessionId" element={<Workspace />} />
           </Routes>
         </main>

--- a/frontend/src/pages/Load.tsx
+++ b/frontend/src/pages/Load.tsx
@@ -114,7 +114,7 @@ const Load = () => {
       {/* Top nav bar — matches ScheMatiQConfig */}
       <div className="flex items-center justify-between mb-8">
         <div className="flex items-center gap-2">
-          <Button variant="ghost" size="icon" onClick={() => navigate('/')} aria-label="Back to Home">
+          <Button variant="ghost" size="icon" onClick={() => navigate('/classic')} aria-label="Back to Home">
             <ArrowLeft className="h-5 w-5" />
           </Button>
         </div>

--- a/frontend/src/pages/Visualize.tsx
+++ b/frontend/src/pages/Visualize.tsx
@@ -1219,7 +1219,7 @@ const Visualize = () => {
         navigate('/schematiq', { replace: true, state: fallbackPayload });
       }
     } else {
-      navigate('/');
+      navigate('/classic');
     }
   }, [session, mode, sessionId, navigate]);
 

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -3770,7 +3770,7 @@ function Workspace() {
               </DropdownMenuItem>
             )}
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => navigate('/')}>
+            <DropdownMenuItem onClick={() => navigate('/classic')}>
               <FileUp className="h-4 w-4" />
               Existing Start Page
             </DropdownMenuItem>


### PR DESCRIPTION
## Motivation
The Workspace is the better experience, so it should be the default landing at `/`. The classic flow stays fully available (not deleted) at a dedicated path.

## Naming
The old flow moves to **`/classic`** — consistent with existing in-app naming (`onOpenClassic`, 'Open classic visualizer', 'Classic Visualizer'). It's a linear multi-page wizard (configure → run → visualize); the Workspace is a single unified spreadsheet-style environment.

## Changes (minimal, non-breaking)
- `/` → `Workspace` (was `ScheMatiQConfig`).
- `/classic` → `ScheMatiQConfig`; `/schematiq` now redirects to `/classic`.
- `/load`, `/visualize/:sessionId` unchanged.
- **Workspace session URLs unchanged**: still `/workspace/:sessionId`. Session creation/import navigations are untouched, so nothing in session handling changes.
- Bare `/workspace` redirects to `/` (old landing links keep working).
- App layout detection becomes `pathname === '/' || startsWith('/workspace')` → Workspace is full-screen; classic pages get the header/footer chrome.
- Internal nav: 'Existing Start Page' and the classic pages' back-home go to `/classic`.

## Why session URLs keep the prefix
Serving sessions at a bare `/:sessionId` would make any unknown single-segment path resolve to a Workspace loading a non-existent session instead of a clean not-found. Keeping `/workspace/:sessionId` avoids that entirely and touches zero session logic.

## Independent of the logo-home fix
This PR does not touch `onHome`. After this change `/` is the Workspace, so the logo lands there regardless; the two PRs compose in any merge order.

## Verify
- Applies clean on main; `npx tsc --noEmit` clean
- Manual QA: `/` shows Workspace New Project dialog · create a project → URL is `/workspace/<id>` and it loads · `/classic` shows the old config · classic run → `/visualize/:id` → back returns to `/classic` · `/load` back button → `/classic` · bare `/workspace` redirects to `/` · header/footer appear only on classic pages, Workspace stays full-screen