### PR TITLE
feat(workspace): portable project bundle with source documents (.zip)

### DIFF
--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -1529,6 +1529,31 @@ async def export_complete_data(session_id: str, format: str = "json"):
                 headers={"Content-Disposition": f"attachment; filename={filename}"}
             )
             
+        elif format.lower() == "bundle":
+            # Self-contained project bundle: the round-trippable project.json plus
+            # the original source files, so a re-imported project can preview them.
+            import zipfile
+            from app.services.document_files import gather_source_documents
+
+            documents = await gather_source_documents(session, session_id)
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zip_file:
+                zip_file.writestr(
+                    "project.json",
+                    json.dumps(export_data, indent=2, ensure_ascii=False, default=str),
+                )
+                for name, content in documents:
+                    safe = Path(name).name
+                    if safe:
+                        zip_file.writestr(f"documents/{safe}", content)
+
+            filename = f"{session_id[:8]}_bundle.zip"
+            return StreamingResponse(
+                io.BytesIO(buf.getvalue()),
+                media_type="application/zip",
+                headers={"Content-Disposition": f"attachment; filename={filename}"},
+            )
+
         elif format.lower() == "zip":
             # ZIP package with separate files
             import zipfile

--- a/backend/app/api/routes/schematiq.py
+++ b/backend/app/api/routes/schematiq.py
@@ -855,6 +855,32 @@ async def export_complete_schematiq_data(
                 headers={"Content-Disposition": f"attachment; filename={filename}"}
             )
             
+        elif format.lower() == "bundle":
+            # Self-contained project bundle: the round-trippable project.json plus
+            # the original source files, so a re-imported project can preview them.
+            import zipfile
+            from app.services.document_files import gather_source_documents
+
+            documents = await gather_source_documents(session, session_id)
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zip_file:
+                zip_file.writestr(
+                    "project.json",
+                    json.dumps(export_data, indent=2, ensure_ascii=False, default=str),
+                )
+                for name, content in documents:
+                    safe = Path(name).name
+                    if safe:
+                        zip_file.writestr(f"documents/{safe}", content)
+
+            timestamp = user_time.strftime("%Y-%m-%d_%H-%M-%S")
+            filename = f"ScheMatiQ_{timestamp}_bundle.zip"
+            return StreamingResponse(
+                io.BytesIO(buf.getvalue()),
+                media_type="application/zip",
+                headers={"Content-Disposition": f"attachment; filename={filename}"},
+            )
+
         elif format.lower() == "zip":
             # ZIP package with separate files
             import zipfile

--- a/backend/app/services/document_files.py
+++ b/backend/app/services/document_files.py
@@ -1,0 +1,87 @@
+"""Resolve and read the ORIGINAL bytes of a session's source documents.
+
+Used to assemble the portable project bundle (export ``format=bundle``). Mirrors
+the document viewer's resolution order so anything previewable is also
+bundle-able: local ``documents/`` and ``pending_documents/`` across the candidate
+data dirs first, then the Supabase ``datasets`` bucket under the session's
+``cloud_dataset``. Returns originals (no PDF->text conversion) so re-imported
+bundles preview natively.
+
+NOTE: ``_find_local_document`` duplicates the helper of the same name in
+``app.api.routes.units``; a future refactor can fold both onto this module.
+"""
+
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from app.services.data_utils import candidate_data_dirs
+from app.services.unit_view_service import unit_view_service
+from app.storage import get_storage
+
+
+def _find_local_document(session_id: str, name: str) -> Optional[Path]:
+    """Locate an uploaded source document on the local filesystem.
+
+    Searches documents/ and pending_documents/ across every known data dir.
+    Matches the exact filename first, then falls back to stem matching since the
+    recorded source_document name may omit the extension.
+    """
+    target_stem = Path(name).stem.lower()
+    target_name = name.lower()
+    for base in candidate_data_dirs():
+        for sub in ("documents", "pending_documents"):
+            doc_dir = base / session_id / sub
+            if not doc_dir.is_dir():
+                continue
+            exact = doc_dir / name
+            if exact.is_file():
+                return exact
+            for f in doc_dir.iterdir():
+                if not f.is_file() or f.name.startswith("."):
+                    continue
+                if f.name.lower() == target_name or f.stem.lower() == target_stem:
+                    return f
+    return None
+
+
+async def gather_source_documents(session, session_id: str) -> List[Tuple[str, bytes]]:
+    """Return ``(filename, original_bytes)`` for each source document in a session.
+
+    Order mirrors the viewer: local files first, then the session's cloud dataset
+    in Supabase storage. Documents that cannot be located are silently skipped
+    (the bundle still imports; those previews simply stay unavailable).
+    """
+    try:
+        names = [d["name"] for d in unit_view_service.get_source_documents(session_id)]
+    except Exception:
+        names = []
+
+    out: List[Tuple[str, bytes]] = []
+    seen: set = set()
+    cloud_dataset = getattr(session.metadata, "cloud_dataset", None)
+    storage = None
+
+    for name in names:
+        if not name or name in seen:
+            continue
+        seen.add(name)
+
+        local = _find_local_document(session_id, name)
+        if local is not None:
+            try:
+                out.append((local.name, local.read_bytes()))
+                continue
+            except Exception:
+                pass
+
+        if cloud_dataset:
+            if storage is None:
+                storage = get_storage()
+            try:
+                content = await storage.download_file("datasets", f"{cloud_dataset}/{name}")
+            except Exception:
+                content = None
+            if content:
+                out.append((name, content))
+
+    return out

--- a/backend/app/services/file_parser.py
+++ b/backend/app/services/file_parser.py
@@ -114,8 +114,10 @@ class FileParser:
             detected_format = "csv"
         elif filename.endswith('.json') or filename.endswith('.jsonl'):
             detected_format = "json"
+        elif filename.endswith('.zip'):
+            detected_format = "zip"
         else:
-            errors.append("Unsupported file format. Please upload CSV or JSON files.")
+            errors.append("Unsupported file format. Please upload CSV, JSON, or a project bundle (.zip).")
         
         # Try to read and validate content
         try:
@@ -179,7 +181,23 @@ class FileParser:
                                 sample_data = [{k: v for k, v in data.items() if k is not None}]
                 except json.JSONDecodeError as e:
                     errors.append(f"Invalid JSON format: {str(e)}")
-                    
+
+            elif detected_format == "zip":
+                # Project bundle: must be a valid zip containing project.json.
+                import io as _io
+                import zipfile
+                content = await file.read()
+                await file.seek(0)
+                if not zipfile.is_zipfile(_io.BytesIO(content)):
+                    errors.append("Invalid project bundle: not a valid .zip file.")
+                else:
+                    with zipfile.ZipFile(_io.BytesIO(content)) as zf:
+                        names = zf.namelist()
+                        if not any(n == "project.json" or n.endswith("/project.json") for n in names):
+                            errors.append("Project bundle is missing project.json.")
+                        else:
+                            warnings.append("Detected ScheMatiQ project bundle (.zip)")
+
         except Exception as e:
             errors.append(f"Error reading file: {str(e)}")
         
@@ -293,7 +311,13 @@ class FileParser:
         return result
 
     async def save_uploaded_file(self, session_id: str, file: UploadFile):
-        """Save uploaded file to data directory."""
+        """Save uploaded file to data directory.
+
+        For a project bundle (.zip) the archive is unpacked: project.json is
+        written at the session root (so parse_file picks it up like a normal JSON
+        import) and bundled source files are restored under pending_documents/ so
+        the document viewer can render them. The raw zip is removed afterwards.
+        """
         session_dir = self.data_dir / session_id
         session_dir.mkdir(exist_ok=True)
         
@@ -301,8 +325,43 @@ class FileParser:
         async with aiofiles.open(file_path, 'wb') as f:
             content = await file.read()
             await f.write(content)
-        
+
+        if file_path.suffix.lower() == '.zip':
+            return self._extract_project_bundle(file_path, session_dir)
+
         return file_path
+
+    def _extract_project_bundle(self, zip_path: Path, session_dir: Path) -> Path:
+        """Unpack a project bundle into the session dir; return the project.json path.
+
+        Only the basename of each bundled document is used (zip-slip safe), and
+        documents land in pending_documents/ where the viewer's resolver looks.
+        """
+        import zipfile
+
+        pending_dir = session_dir / "pending_documents"
+        pending_dir.mkdir(parents=True, exist_ok=True)
+        project_json_path = session_dir / "project.json"
+
+        with zipfile.ZipFile(zip_path) as zf:
+            for info in zf.infolist():
+                if info.is_dir():
+                    continue
+                name = info.filename
+                base = Path(name).name
+                if name == "project.json" or name.endswith("/project.json"):
+                    with zf.open(info) as src:
+                        project_json_path.write_bytes(src.read())
+                elif (name.startswith("documents/") or "/documents/" in name) and base:
+                    with zf.open(info) as src:
+                        (pending_dir / base).write_bytes(src.read())
+
+        zip_path.unlink(missing_ok=True)
+
+        if not project_json_path.exists():
+            raise ValueError("Project bundle is missing project.json")
+
+        return project_json_path
     
     async def parse_file(self, session_id: str, mapping: Optional[ColumnMappingRequest] = None) -> Dict[str, Any]:
         """Parse file and extract data."""

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -335,7 +335,7 @@ const SHEETS: Array<{ id: SheetId; label: string; group: 'structure' | 'analysis
 const WORKSPACE_MENUS = [
   {
     label: 'File',
-    items: ['New project', 'Import project', 'Open classic visualizer', 'Download table (.csv)', 'Save project (.schematiq.json)'],
+    items: ['New project', 'Import project', 'Open classic visualizer', 'Download table (.csv)', 'Save project (.schematiq.json)', 'Save project with documents (.zip)'],
   },
   {
     label: 'Edit',
@@ -2332,6 +2332,7 @@ function SpreadsheetChrome({
   onPrint,
   onExport,
   onSaveProject,
+  onSaveProjectWithDocs,
   onHome,
   onSearch,
   onEstimateCost,
@@ -2354,6 +2355,7 @@ function SpreadsheetChrome({
   onPrint: () => void;
   onExport: () => void;
   onSaveProject: () => void;
+  onSaveProjectWithDocs: () => void;
   onHome: () => void;
   onSearch: () => void;
   onEstimateCost: () => void;
@@ -2370,6 +2372,7 @@ function SpreadsheetChrome({
     if (label === 'Open classic visualizer') onOpenClassic();
     if (label === 'Download table (.csv)') onExport();
     if (label === 'Save project (.schematiq.json)') onSaveProject();
+    if (label === 'Save project with documents (.zip)') onSaveProjectWithDocs();
     if (label === 'Project details') onProjectDetails();
     if (label === 'Refresh project') onRefresh();
     if (label === 'Estimate cost') onEstimateCost();
@@ -2386,6 +2389,7 @@ function SpreadsheetChrome({
       'Open classic visualizer',
       'Download table (.csv)',
       'Save project (.schematiq.json)',
+      'Save project with documents (.zip)',
       'Project details',
       'Refresh project',
       'Estimate cost',
@@ -2460,6 +2464,13 @@ function SpreadsheetChrome({
               <div>
                 <div>Save Project (.schematiq.json)</div>
                 <div className="text-xs text-muted-foreground">Full project with schema and history, for reloading</div>
+              </div>
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={onSaveProjectWithDocs} disabled={!canUseProjectActions}>
+              <Save className="h-4 w-4 mr-2 shrink-0" />
+              <div>
+                <div>Save Project with Documents (.zip)</div>
+                <div className="text-xs text-muted-foreground">Bundle including the original source files, so previews survive re-import</div>
               </div>
             </DropdownMenuItem>
           </DropdownMenuContent>
@@ -3086,6 +3097,25 @@ function Workspace() {
     }
   }, [sessionId, sessionMode, schema, config, toast]);
 
+  const saveProjectWithDocuments = useCallback(async () => {
+    if (!sessionId) return;
+    const question = schema?.query || config?.query || '';
+    const filename = buildExportFilename(question, 'bundle.zip', sessionId);
+    try {
+      const tzOffset = new Date().getTimezoneOffset();
+      const path = sessionMode === 'schematiq'
+        ? `/schematiq/export-complete/${sessionId}?format=bundle&tz_offset=${tzOffset}`
+        : `/load/export-complete/${sessionId}?format=bundle`;
+      await downloadAs(path, filename);
+    } catch (err: any) {
+      toast({
+        title: 'Save failed',
+        description: err?.response?.data?.detail || err?.message || 'Could not save this project bundle',
+        variant: 'destructive',
+      });
+    }
+  }, [sessionId, sessionMode, schema, config, toast]);
+
   const searchPage = useCallback(() => {
     const term = window.prompt('Find in visible workspace');
     const findInPage = (window as Window & { find?: (text: string) => boolean }).find;
@@ -3530,6 +3560,7 @@ function Workspace() {
         onPrint={printWorkspace}
         onExport={exportCurrentProject}
         onSaveProject={saveCurrentProject}
+        onSaveProjectWithDocs={saveProjectWithDocuments}
         onHome={() => navigate('/workspace')}
         onSearch={searchPage}
         onEstimateCost={estimateCurrentCost}
@@ -3809,7 +3840,7 @@ function Workspace() {
           ref={importInputRef}
           type="file"
           className="hidden"
-          accept=".json,.jsonl,.csv,.schematiq.json,application/json,text/csv"
+          accept=".json,.jsonl,.csv,.zip,.schematiq.json,application/json,text/csv,application/zip"
           onChange={(event) => {
             const file = event.target.files?.[0];
             if (file) importExistingProject(file);


### PR DESCRIPTION
Imported projects carry schema + data but not the original source files, so the document viewer shows every document as unavailable.

**Export** — new 'Save Project with Documents (.zip)' action packs project.json (the existing round-trippable JSON) plus a documents/ folder of the originals, via a new storage-aware helper (document_files.gather_source_documents). Added to both export-complete routes.

**Import** — validate_file accepts .zip; save_uploaded_file unpacks the bundle (project.json at the session root, docs into pending_documents/, zip-slip safe) and the existing JSON parse path reconstructs the project. Import picker accepts .zip.

Backend gather + zip round-trip verified in isolation; JSON export/import unchanged (no regression). Applies clean on main; tsc + py_compile clean.