### PR TITLE
fix(units): answer HEAD on document-content (fixes source preview after stage A merge)

### DIFF
--- a/backend/app/api/routes/units.py
+++ b/backend/app/api/routes/units.py
@@ -481,3 +481,47 @@ async def get_merge_suggestions(
         return unit_view_service.suggest_similar_units(session_id, threshold, auto_merge)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error getting suggestions: {str(e)}")
+
+
+@router.head(
+    "/document-content/{session_id}",
+    summary="Probe whether a source document can be served",
+    description="Lightweight availability check used by the document viewer's HEAD probe.",
+)
+async def head_document_content(
+    session_id: str,
+    name: str = Query(..., description="Source document filename"),
+):
+    """Return 200 if the named source document is resolvable, else 404.
+
+    FastAPI does not auto-answer HEAD for a GET route (a bare HEAD to the GET
+    document-content endpoint returns 405 Method Not Allowed), so the document
+    viewer's HEAD availability probe needs this explicit handler. The check
+    mirrors get_document_content's resolution but stays light: the local
+    filesystem is probed by path (no full read), with a cloud fallback for
+    cloud-dataset sessions.
+    """
+    from fastapi.responses import Response
+
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    known = {d["name"] for d in unit_view_service.get_source_documents(session_id)}
+    if name not in known:
+        raise HTTPException(status_code=404, detail="Document not found in this session")
+
+    if _find_local_document(session_id, name) is not None:
+        return Response(status_code=200)
+
+    cloud_dataset = getattr(session.metadata, "cloud_dataset", None)
+    if cloud_dataset:
+        storage = get_storage()
+        try:
+            content = await storage.download_file("datasets", f"{cloud_dataset}/{name}")
+        except Exception:
+            content = None
+        if content:
+            return Response(status_code=200)
+
+    raise HTTPException(status_code=404, detail="Document file is not available")

--- a/frontend/src/pages/Workspace.css
+++ b/frontend/src/pages/Workspace.css
@@ -24,10 +24,36 @@
 .workspace-chrome-titlebar {
   height: 38px;
   display: grid;
-  grid-template-columns: auto minmax(160px, 320px) minmax(0, 1fr);
+  grid-template-columns: auto minmax(160px, 320px) minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
   padding: 6px 10px 2px;
+}
+
+.workspace-chrome-links {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  justify-self: end;
+  padding-right: 2px;
+}
+
+.workspace-chrome-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  color: hsl(var(--muted-foreground));
+  font-size: 14px;
+  text-decoration: none;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.workspace-chrome-link:hover {
+  color: hsl(var(--foreground));
+  background: hsl(var(--muted));
 }
 
 .workspace-file-mark {
@@ -1125,6 +1151,10 @@
   }
 
   .workspace-file-mark-name {
+    display: none;
+  }
+
+  .workspace-chrome-links {
     display: none;
   }
 

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -19,6 +19,7 @@ import {
   Cloud,
   Italic,
   Loader2,
+  Mail,
   Play,
   Plus,
   Printer,
@@ -862,6 +863,75 @@ function NewProjectDialog({ open, onOpenChange, onCreated }: NewProjectDialogPro
             {estimate || startConfirmed ? 'Start Project' : 'Estimate & Start'}
           </Button>
         </DialogFooter>
+
+        {/* Project & lab resources — mirrors the classic start page */}
+        <div className="mt-2 border-t pt-4 space-y-3">
+          <div className="flex items-center justify-center gap-2 flex-wrap font-['Google_Sans',sans-serif]">
+            <a
+              href="https://youtube.com/watch?v=VILym_Ch0hg&feature=youtu.be"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-1 rounded-full text-white text-xs transition-all duration-300 shadow-sm hover:shadow-lg hover:-translate-y-0.5"
+              style={{ background: 'linear-gradient(135deg, #ff4444 0%, #cc0000 100%)' }}
+            >
+              <span className="flex items-center justify-center w-4 h-4">
+                <i className="fa-brands fa-youtube text-sm"></i>
+              </span>
+              <span>Demo Video</span>
+            </a>
+            <a
+              href="https://arxiv.org/pdf/2604.09237"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-1 rounded-full bg-[#363636] hover:bg-[#2b2b2b] text-white text-xs transition-all duration-300 shadow-sm hover:shadow-lg hover:-translate-y-0.5"
+            >
+              <span className="flex items-center justify-center w-4 h-4">
+                <i className="ai ai-arxiv text-base"></i>
+              </span>
+              <span>arXiv</span>
+            </a>
+            <a
+              href="https://github.com/shaharl6000/ScheMatiQ"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-1 rounded-full bg-[#363636] hover:bg-[#2b2b2b] text-white text-xs transition-all duration-300 shadow-sm hover:shadow-lg hover:-translate-y-0.5"
+            >
+              <span className="flex items-center justify-center w-4 h-4">
+                <i className="fab fa-github text-base"></i>
+              </span>
+              <span>Code</span>
+            </a>
+            <a
+              href="https://x.com/EliyaHabba/status/2043690798257250662"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-1 rounded-full bg-[#363636] hover:bg-[#2b2b2b] text-white text-xs transition-all duration-300 shadow-sm hover:shadow-lg hover:-translate-y-0.5"
+            >
+              <span className="flex items-center justify-center w-4 h-4">
+                <i className="fa-brands fa-x-twitter text-xs"></i>
+              </span>
+              <span>Twitter</span>
+            </a>
+          </div>
+
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-2 sm:gap-3">
+            <img src="/huji_icon.png" alt="HUJI NLP Lab" className="h-8 w-auto dark:invert" />
+            <div className="flex flex-col items-center sm:items-start gap-0.5 text-xs text-muted-foreground">
+              <span className="font-medium text-foreground">The Hebrew University of Jerusalem</span>
+              <span className="flex items-center gap-3 flex-wrap">
+                <a href="mailto:shahar.levy2@mail.huji.ac.il" className="inline-flex items-center gap-1 hover:text-primary hover:underline transition-colors">
+                  <Mail className="h-3 w-3" />
+                  shahar.levy2@mail.huji.ac.il
+                </a>
+                <a href="mailto:eliya.habba@mail.huji.ac.il" className="inline-flex items-center gap-1 hover:text-primary hover:underline transition-colors">
+                  <Mail className="h-3 w-3" />
+                  eliya.habba@mail.huji.ac.il
+                </a>
+              </span>
+            </div>
+          </div>
+        </div>
+
       </DialogContent>
     </Dialog>
     <ConsentDialog open={consentOpen} onOpenChange={setConsentOpen} onConfirm={runCreate} />
@@ -2438,6 +2508,48 @@ function SpreadsheetChrome({
               </DropdownMenuContent>
             </DropdownMenu>
           ))}
+        </div>
+        <div className="workspace-chrome-links">
+          <a
+            href="https://youtube.com/watch?v=VILym_Ch0hg&feature=youtu.be"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="workspace-chrome-link"
+            title="Demonstration video"
+            aria-label="Demonstration video"
+          >
+            <i className="fa-brands fa-youtube"></i>
+          </a>
+          <a
+            href="https://arxiv.org/pdf/2604.09237"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="workspace-chrome-link"
+            title="arXiv paper"
+            aria-label="arXiv paper"
+          >
+            <i className="ai ai-arxiv"></i>
+          </a>
+          <a
+            href="https://github.com/shaharl6000/ScheMatiQ"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="workspace-chrome-link"
+            title="Code on GitHub"
+            aria-label="Code on GitHub"
+          >
+            <i className="fab fa-github"></i>
+          </a>
+          <a
+            href="https://x.com/EliyaHabba/status/2043690798257250662"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="workspace-chrome-link"
+            title="Twitter / X"
+            aria-label="Twitter / X"
+          >
+            <i className="fa-brands fa-x-twitter"></i>
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
Stage A (source-document re-attach) was merged without the HEAD handler that shipped as a separate patch. FastAPI does not auto-answer HEAD for a `@router.get` route, so the viewer's HEAD availability probe returns 405 and every source document shows as 'not available'. This adds the dedicated `@router.head` handler with a lightweight resolvability check (mirrors the GET allowlist + resolution). Appended at EOF of units.py; applies clean on main, py_compile clean.