### PR TITLE
fix: friendly LLM provider errors + full server-side logging

### DIFF
--- a/backend/app/services/pipeline/error_reporting.py
+++ b/backend/app/services/pipeline/error_reporting.py
@@ -1,0 +1,87 @@
+"""Translate raw LLM-provider exceptions into user-facing messages.
+
+Provider SDKs (google-genai, openai, together) raise errors whose ``str()`` is a
+raw protocol dump, e.g. ``"400 INVALID_ARGUMENT. {'error': {'code': 400, ...}}"``.
+Surfacing that verbatim in the UI is unhelpful and leaks internals, while the
+detail we actually need for debugging (status, code, field violations) belongs in
+the server logs. :func:`describe_llm_error` splits those two concerns.
+"""
+
+from typing import Tuple
+
+# Exception classes from these modules are treated as provider API errors.
+_PROVIDER_MODULE_HINTS = (
+    "google.genai",
+    "google.api_core",
+    "google.generativeai",
+    "openai",
+    "together",
+)
+
+
+def _looks_like_provider_error(exc: BaseException) -> bool:
+    """True when ``exc`` originates from a known LLM-provider SDK.
+
+    Detected either by the defining module of the exception class or, as a
+    fallback, by the SDK convention of exposing both a ``status`` and a ``code``.
+    """
+    module = (type(exc).__module__ or "").lower()
+    if any(hint in module for hint in _PROVIDER_MODULE_HINTS):
+        return True
+    return getattr(exc, "status", None) is not None and getattr(exc, "code", None) is not None
+
+
+def describe_llm_error(exc: BaseException) -> Tuple[str, str]:
+    """Return ``(user_message, log_detail)`` for an exception raised during a run.
+
+    ``user_message`` is safe, human-readable text for the UI and
+    ``session.error_message``. ``log_detail`` is verbose technical detail for the
+    server logs only (status, code, and the provider's raw ``details`` payload,
+    which carries any field-level violations) and is never shown to users.
+
+    Non-provider exceptions fall through to ``str(exc)`` so existing behavior and
+    any already-friendly ``RuntimeError`` messages are preserved unchanged.
+    """
+    fields = {}
+    for attr in ("code", "status", "message", "details"):
+        value = getattr(exc, attr, None)
+        if value is not None:
+            fields[attr] = value
+
+    log_detail = f"{type(exc).__name__}: {exc!r}"
+    if fields:
+        log_detail = f"{log_detail} | {fields}"
+
+    if not _looks_like_provider_error(exc):
+        return str(exc), log_detail
+
+    text = str(exc).upper()
+    status = str(fields.get("status") or "").upper()
+    code = fields.get("code")
+
+    def _mentions(token: str) -> bool:
+        return token in status or token in text
+
+    if _mentions("INVALID_ARGUMENT") or code == 400:
+        user_message = (
+            "The AI provider rejected the request (400 INVALID_ARGUMENT), usually "
+            "an unsupported model parameter or an oversized request. Please try "
+            "again; if it keeps happening, contact support."
+        )
+    elif _mentions("RESOURCE_EXHAUSTED") or code == 429:
+        user_message = (
+            "The AI provider is rate-limiting requests right now. Please wait a "
+            "moment and try again."
+        )
+    elif _mentions("PERMISSION_DENIED") or _mentions("UNAUTHENTICATED") or code in (401, 403):
+        user_message = (
+            "The AI provider rejected the API key (authentication error). Please "
+            "check the configured key and try again."
+        )
+    else:
+        user_message = (
+            "The AI provider returned an error while processing this request. "
+            "Please try again; if it keeps happening, contact support."
+        )
+
+    return user_message, log_detail

--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -21,6 +21,7 @@ from app.services.pipeline.config_handler import (
     resolve_docs_paths, convert_config_to_schematiq_format, validate_config as _validate_config,
 )
 from app.services.pipeline.schema_discovery import run_schema_discovery
+from app.services.pipeline.error_reporting import describe_llm_error
 from app.services.pipeline.value_extraction import run_value_extraction
 from app.services.pipeline.data_query import (
     compute_statistics, get_status as _get_status, get_schema as _get_schema, get_data as _get_data,
@@ -290,10 +291,11 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
             await task
 
         except Exception as e:
-            logger.error("ScheMatiQ run failed for session %s: %s", session_id, e)
+            user_message, log_detail = describe_llm_error(e)
+            logger.error("ScheMatiQ run failed for session %s: %s", session_id, log_detail)
             session = self.session_manager.get_session(session_id)
             session.status = SessionStatus.ERROR
-            session.error_message = str(e)
+            session.error_message = user_message
             self.session_manager.update_session(session)
 
             is_quota_error = "quota exceeded" in str(e).lower()
@@ -311,7 +313,7 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
                     "timestamp": datetime.now().isoformat(),
                 })
             else:
-                await self.broadcast_error(session_id, str(e))
+                await self.broadcast_error(session_id, user_message)
 
         finally:
             with self._state_lock:
@@ -833,12 +835,13 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
             self._move_pending_documents(session_id)
 
         except Exception as e:
-            logger.error("ScheMatiQ execution failed: %s", e, exc_info=True)
+            user_message, log_detail = describe_llm_error(e)
+            logger.error("ScheMatiQ execution failed: %s", log_detail, exc_info=True)
             session = self.session_manager.get_session(session_id)
             session.status = SessionStatus.ERROR
-            session.error_message = str(e)
+            session.error_message = user_message
             self.session_manager.update_session(session)
-            await self.broadcast_error(session_id, str(e))
+            await self.broadcast_error(session_id, user_message)
             raise
 
     # ── Private orchestration helpers ──────────────────────────────


### PR DESCRIPTION
## Problem
When a run fails on a provider API error (e.g. Gemini 400 INVALID_ARGUMENT), the raw SDK exception string is shown in the UI (session.error_message and broadcast_error both use str(e)). This leaks internals, is unreadable, and the field-level detail we need for debugging never reaches the logs in a usable form.

## Solution
New helper describe_llm_error(exc) returns (user_message, log_detail). The runner's two except blocks now show user_message in the UI and log log_detail, which includes the provider's code/status/details payload (carrying any fieldViolations). Provider errors are detected by exception module or status+code and mapped to category messages (INVALID_ARGUMENT/400, RESOURCE_EXHAUSTED/429, auth). Non-provider exceptions (including the quota RuntimeError path) fall through to str(exc) unchanged.

## Verify
- git apply --ignore-whitespace --check passes on clean main
- python -m py_compile passes for both files
- Unit-checked classification: 400, 429, RuntimeError passthrough, quota-string preserved
- Backend-only; no frontend impact