### PR TITLE
LLM quota observability: /api/usage endpoint, rolling window, clearer error

### DIFF
--- a/backend/app/api/routes/schematiq.py
+++ b/backend/app/api/routes/schematiq.py
@@ -38,6 +38,15 @@ data_editor = DataEditor()
 # Project root for path resolution (backend/app/api/routes -> project root = 5 levels up)
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
+# User-facing message for the global LLM quota (LLM_CALL_GLOBAL_LIMIT).
+# Deliberately distinct from the ConcurrencyLimiter's 503 message: hitting the
+# quota is not a transient load issue, so "try again later" would mislead.
+QUOTA_EXCEEDED_USER_MESSAGE = (
+    "This deployment has reached its LLM usage quota, so new extractions are "
+    "paused. This is a usage quota rather than a temporary load issue, so "
+    "retrying will not help - please contact us to restore access."
+)
+
 
 def _resolve_docs_path(path: str, session_id: Optional[str] = None) -> Optional[Path]:
     """Resolve a document path to an existing directory.
@@ -280,19 +289,15 @@ async def run_schematiq(session_id: str, background_tasks: BackgroundTasks):
         # This gives the user an immediate HTTP error instead of a delayed WebSocket error.
         from app.core.config import LLM_CALL_GLOBAL_LIMIT, DEVELOPER_MODE
         from schematiq.core.llm_call_tracker import QuotaExceededError
-        if not DEVELOPER_MODE and LLM_CALL_GLOBAL_LIMIT > 0:
+        if not DEVELOPER_MODE:
             try:
-                schematiq_runner._sync_usage_from_sheets()
-                schematiq_runner._global_usage.check_quota(LLM_CALL_GLOBAL_LIMIT)
+                schematiq_runner.check_global_quota(LLM_CALL_GLOBAL_LIMIT)
             except QuotaExceededError as exc:
                 # Send email alert (once per process lifetime)
                 from app.core.email_alerts import send_quota_exceeded_alert
                 send_quota_exceeded_alert(total_used=exc.used)
 
-                raise HTTPException(
-                    status_code=429,
-                    detail="The system has reached its processing capacity and is unable to start new sessions at this time. Please try again later or contact us for assistance."
-                )
+                raise HTTPException(status_code=429, detail=QUOTA_EXCEEDED_USER_MESSAGE)
 
         # Reserve concurrency slot before starting background task
         await concurrency_limiter.acquire(session_id, "schematiq")
@@ -350,17 +355,13 @@ async def resume_schematiq(session_id: str, background_tasks: BackgroundTasks):
         # Pre-check global LLM quota before starting background task
         from app.core.config import LLM_CALL_GLOBAL_LIMIT, DEVELOPER_MODE
         from schematiq.core.llm_call_tracker import QuotaExceededError
-        if not DEVELOPER_MODE and LLM_CALL_GLOBAL_LIMIT > 0:
+        if not DEVELOPER_MODE:
             try:
-                schematiq_runner._sync_usage_from_sheets()
-                schematiq_runner._global_usage.check_quota(LLM_CALL_GLOBAL_LIMIT)
+                schematiq_runner.check_global_quota(LLM_CALL_GLOBAL_LIMIT)
             except QuotaExceededError as exc:
                 from app.core.email_alerts import send_quota_exceeded_alert
                 send_quota_exceeded_alert(total_used=exc.used)
-                raise HTTPException(
-                    status_code=429,
-                    detail="The system has reached its processing capacity. Please try again later."
-                )
+                raise HTTPException(status_code=429, detail=QUOTA_EXCEEDED_USER_MESSAGE)
 
         # Stop + prepare synchronously so resume cannot race the active pipeline.
         try:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -133,6 +133,12 @@ DATA_COLLECTION_ENABLED = (
 # Set to 0 to allow unlimited calls (no quota enforced).
 LLM_CALL_GLOBAL_LIMIT = int(os.environ.get("LLM_CALL_GLOBAL_LIMIT", "1000"))
 
+# Optional rolling window (in days) for the quota above.
+# 0 (default) keeps the legacy behavior: a lifetime cumulative quota.
+# When > 0, only LLM calls recorded within the last N days count toward
+# LLM_CALL_GLOBAL_LIMIT, so the quota recovers as old usage ages out.
+LLM_CALL_LIMIT_WINDOW_DAYS = int(os.environ.get("LLM_CALL_LIMIT_WINDOW_DAYS", "0"))
+
 # ── Quota Alert Email ────────────────────────────────────────────
 # Send an email when the LLM quota is exceeded.
 # Uses the same Google OAuth credentials as Google Sheets (no extra passwords).

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -164,6 +164,21 @@ async def get_public_config():
         "server_has_api_keys": server_has_api_keys,
     }
 
+@app.get("/api/usage", tags=["root"], summary="LLM Usage", description="Returns global LLM quota usage and recent sessions")
+async def get_llm_usage():
+    """Return global LLM call usage vs the configured quota.
+
+    ``used``/``remaining`` honor the optional rolling window
+    (LLM_CALL_LIMIT_WINDOW_DAYS); ``lifetime_total`` is always cumulative.
+    """
+    from app.api.routes.schematiq import schematiq_runner
+    from app.services import concurrency_limiter
+
+    report = schematiq_runner.get_usage_report()
+    report["active_sessions"] = await concurrency_limiter.get_active_count()
+    report["max_concurrent_sessions"] = MAX_CONCURRENT_SESSIONS
+    return report
+
 if __name__ == "__main__":
     import os
     import uvicorn

--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import threading
+import time
 import uuid
 from typing import Any, Optional
 
+from app.core.config import DEVELOPER_MODE, LLM_CALL_GLOBAL_LIMIT
 from schematiq.core.llm_call_tracker import LLMCallTracker, QuotaExceededError
 
-from .deps import CHAT_MODEL, get_gemini_api_key
+from .deps import CHAT_MODEL, get_gemini_api_key, schematiq_runner
 from .session_store import ChatSessionState, PendingToolCall, chat_session_store
 from .tool_executor import tool_executor
 from .tool_registry import (
@@ -41,11 +44,47 @@ Rules:
 """
 
 
+QUOTA_EXCEEDED_CHAT_MESSAGE = (
+    "The system has reached its LLM usage quota and cannot run this request "
+    "right now. Please contact us to restore access."
+)
+
+
 class ChatAgentService:
     def __init__(self) -> None:
         self._executor = tool_executor
         self._genai_client: Any = None
         self._client_lock = threading.Lock()
+
+    @staticmethod
+    async def _ensure_quota_available() -> None:
+        """Raise ``QuotaExceededError`` if the global LLM quota is exhausted.
+
+        Chat calls Gemini directly (bypassing the schematiq LLM backends), so
+        the quota must be enforced here explicitly. Bypassed in developer
+        mode, mirroring the pipeline routes. Runs in a thread because the
+        check may hit the Google Sheets API.
+        """
+        if DEVELOPER_MODE:
+            return
+        await asyncio.to_thread(
+            schematiq_runner.check_global_quota, LLM_CALL_GLOBAL_LIMIT
+        )
+
+    @staticmethod
+    async def _flush_llm_usage(state: ChatSessionState) -> None:
+        """Record this turn's Gemini calls toward the global LLM quota."""
+        calls = state.pending_llm_calls
+        if not calls:
+            return
+        state.pending_llm_calls = 0
+        try:
+            record_id = f"chat-{(state.chat_id or 'unknown')[:8]}-{int(time.time())}"
+            await asyncio.to_thread(
+                schematiq_runner.record_external_usage, record_id, {"chat": calls}
+            )
+        except Exception as exc:
+            logger.debug("Could not record chat LLM usage: %s", exc)
 
     async def list_tools(
         self,
@@ -85,6 +124,7 @@ class ChatAgentService:
             user_text = f"[User suggested tool: {pinned_tool}]\n{message}"
 
         try:
+            await self._ensure_quota_available()
             result = await self._run_loop(state, user_text, outbound_messages)
             return {
                 "chat_id": state.chat_id,
@@ -93,11 +133,7 @@ class ChatAgentService:
                 "pending_action": result.get("pending_action"),
             }
         except QuotaExceededError:
-            outbound_messages.append(
-                self._text_message(
-                    "The system has reached its LLM usage quota and cannot run this request right now. Please contact us to restore access."
-                )
-            )
+            outbound_messages.append(self._text_message(QUOTA_EXCEEDED_CHAT_MESSAGE))
             return {
                 "chat_id": state.chat_id,
                 "status": "complete",
@@ -116,6 +152,8 @@ class ChatAgentService:
                     "pending_action": result.get("pending_action"),
                 }
             raise
+        finally:
+            await self._flush_llm_usage(state)
 
     async def confirm_pending(
         self,
@@ -127,6 +165,17 @@ class ChatAgentService:
             raise ValueError("Chat session not found. Start a new conversation.")
         if not state.pending:
             raise ValueError("No pending action to confirm.")
+
+        # Check quota before consuming the pending action so a blocked
+        # confirmation can be retried once the quota is restored.
+        try:
+            await self._ensure_quota_available()
+        except QuotaExceededError:
+            return {
+                "chat_id": chat_id,
+                "status": "complete",
+                "messages": [self._text_message(QUOTA_EXCEEDED_CHAT_MESSAGE)],
+            }
 
         pending = state.pending
         state.pending = None
@@ -156,6 +205,13 @@ class ChatAgentService:
                 "messages": outbound_messages,
                 "pending_action": loop_result.get("pending_action"),
             }
+        except QuotaExceededError:
+            outbound_messages.append(self._text_message(QUOTA_EXCEEDED_CHAT_MESSAGE))
+            return {
+                "chat_id": chat_id,
+                "status": "complete",
+                "messages": outbound_messages,
+            }
         except Exception as exc:
             outbound_messages.append(
                 self._tool_log(pending.tool_name, "error", f"Tool failed: {exc}")
@@ -165,6 +221,8 @@ class ChatAgentService:
                 "status": "complete",
                 "messages": outbound_messages,
             }
+        finally:
+            await self._flush_llm_usage(state)
 
     async def cancel_pending(
         self,
@@ -185,6 +243,7 @@ class ChatAgentService:
             state,
             reason="User declined confirmation.",
         )
+        await self._flush_llm_usage(state)
         return {
             "chat_id": chat_id,
             "status": "pending_confirmation" if new_pending else "complete",
@@ -384,6 +443,7 @@ class ChatAgentService:
 
     async def _send_user_message(self, state: ChatSessionState, user_text: str) -> Any:
         LLMCallTracker.get_instance().set_stage("chat")
+        state.pending_llm_calls += 1
         return await state.chat.send_message(user_text)
 
     async def _send_function_response(
@@ -399,6 +459,7 @@ class ChatAgentService:
             response={"result": tool_result},
         )
         LLMCallTracker.get_instance().set_stage("chat")
+        state.pending_llm_calls += 1
         return await state.chat.send_message(part)
 
     def _text_message(self, content: str) -> dict[str, Any]:

--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -95,7 +95,7 @@ class ChatAgentService:
         except QuotaExceededError:
             outbound_messages.append(
                 self._text_message(
-                    "The system has reached its LLM processing capacity. Please try again later."
+                    "The system has reached its LLM usage quota and cannot run this request right now. Please contact us to restore access."
                 )
             )
             return {

--- a/backend/app/services/chat/session_store.py
+++ b/backend/app/services/chat/session_store.py
@@ -22,6 +22,9 @@ class ChatSessionState:
     session_mode: str
     chat_id: Optional[str] = None
     pending: Optional[PendingToolCall] = None
+    # Gemini calls made since the last quota flush (chat bypasses the
+    # schematiq LLM backends, so calls are counted here explicitly).
+    pending_llm_calls: int = 0
 
 
 class ChatSessionStore:

--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -514,9 +514,8 @@ class ToolExecutor:
       session = session_manager.get_session(session_id)
       if not session or session.type != SessionType.SCHEMATIQ:
           raise ValueError("ScheMatiQ session not found")
-      if not DEVELOPER_MODE and LLM_CALL_GLOBAL_LIMIT > 0:
-          schematiq_runner._sync_usage_from_sheets()
-          schematiq_runner._global_usage.check_quota(LLM_CALL_GLOBAL_LIMIT)
+      if not DEVELOPER_MODE:
+          schematiq_runner.check_global_quota(LLM_CALL_GLOBAL_LIMIT)
       await concurrency_limiter.acquire(session_id, "schematiq")
       asyncio.create_task(self._run_schematiq_task(session_id))
       return {"status": "started", "message": "ScheMatiQ execution started."}

--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -11,7 +11,7 @@ from typing import Dict, Any, Optional, List
 from pathlib import Path
 from datetime import datetime
 
-from app.core.config import MAX_DOCUMENTS, DEVELOPER_MODE, LLM_CALL_GLOBAL_LIMIT
+from app.core.config import MAX_DOCUMENTS, DEVELOPER_MODE, LLM_CALL_GLOBAL_LIMIT, LLM_CALL_LIMIT_WINDOW_DAYS
 from app.core.logging_utils import set_session_context
 from app.services import schematiq_thread_pool, concurrency_limiter
 
@@ -96,6 +96,82 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
             sheets.log_llm_usage(session_id, total, counts)
         except Exception as e:
             logger.debug("Could not log LLM usage to Google Sheets: %s", e)
+
+    def _external_usage_total(self, window_days: int = 0) -> int:
+        """Read the cumulative (or windowed) LLM call total from Google Sheets."""
+        try:
+            from app.storage.google_sheets import GoogleSheetsLogger
+            sheets = GoogleSheetsLogger.get_instance()
+            if sheets is None:
+                return 0
+            if window_days > 0:
+                return sheets.read_recent_llm_calls(window_days)
+            return sheets.read_total_llm_calls()
+        except Exception as e:
+            logger.debug("Could not read LLM usage from Google Sheets: %s", e)
+            return 0
+
+    def get_quota_usage(self, limit: int) -> Dict[str, Any]:
+        """Return effective usage vs *limit*, honoring LLM_CALL_LIMIT_WINDOW_DAYS.
+
+        With a rolling window configured, the effective total is the max of
+        the local windowed total and the Google Sheets windowed total (the
+        local file may be wiped by a redeploy; the sheet may lag behind the
+        local file). Without a window, legacy behavior: sync the lifetime
+        scalar from Sheets, then read the local lifetime total.
+        """
+        window = LLM_CALL_LIMIT_WINDOW_DAYS
+        if window > 0:
+            used = max(
+                self._global_usage.get_windowed_total(window),
+                self._external_usage_total(window),
+            )
+        else:
+            self._sync_usage_from_sheets()
+            used = self._global_usage.get_total()
+        return {
+            "used": used,
+            "limit": limit,
+            "window_days": window,
+            "remaining": max(limit - used, 0) if limit > 0 else None,
+        }
+
+    def check_global_quota(self, limit: int) -> None:
+        """Raise ``QuotaExceededError`` when the global LLM quota is exhausted.
+
+        A *limit* of 0 (or less) disables the check. Honors the optional
+        rolling window (``LLM_CALL_LIMIT_WINDOW_DAYS``).
+        """
+        if limit <= 0:
+            return
+        usage = self.get_quota_usage(limit)
+        if usage["used"] >= limit:
+            # Visible on the uvicorn terminal even when logging is minimal
+            print(
+                f"[LLM quota] blocked: used={usage['used']} quota_limit={limit} "
+                f"window_days={usage['window_days']} "
+                f"(raise LLM_CALL_GLOBAL_LIMIT, set a rolling window via "
+                f"LLM_CALL_LIMIT_WINDOW_DAYS, or LLM_CALL_GLOBAL_LIMIT=0 to disable)",
+                flush=True,
+            )
+            raise QuotaExceededError(used=usage["used"], limit=limit)
+
+    def get_usage_report(self) -> Dict[str, Any]:
+        """Full quota usage report for the ``/api/usage`` endpoint."""
+        report = self.get_quota_usage(LLM_CALL_GLOBAL_LIMIT)
+        data = self._global_usage.get_usage()
+        report["enforced"] = (not DEVELOPER_MODE) and LLM_CALL_GLOBAL_LIMIT > 0
+        report["lifetime_total"] = data.get("total_calls", 0)
+        report["per_stage"] = data.get("per_stage", {})
+        report["recent_sessions"] = [
+            {
+                "session_id": (entry.get("session_id") or "")[:8],
+                "calls": entry.get("calls", 0),
+                "timestamp": entry.get("timestamp"),
+            }
+            for entry in data.get("sessions", [])[-10:]
+        ]
+        return report
 
     # ── Stop management ────────────────────────────────────────────
 
@@ -508,9 +584,8 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
                 effective_limit = LLM_CALL_GLOBAL_LIMIT
 
             if effective_limit > 0:
-                self._sync_usage_from_sheets()
                 try:
-                    self._global_usage.check_quota(effective_limit)
+                    self.check_global_quota(effective_limit)
                 except QuotaExceededError as exc:
                     logger.warning("Session %s blocked by global LLM quota: %s", session_id, exc)
                     raise RuntimeError(str(exc)) from exc

--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -7,7 +7,7 @@ import os
 import random
 import threading
 import time
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, Tuple
 from pathlib import Path
 from datetime import datetime
 
@@ -69,11 +69,28 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         self.stop_flags: Dict[str, bool] = {}
         self._state_lock = threading.Lock()
         self._global_usage = GlobalLLMUsageTracker(self.work_dir / "global_llm_usage.json")
+        # Throttle Google Sheets reads made by quota checks. The local usage
+        # file already reflects everything recorded by this process (pipeline
+        # and chat), so the external total only guards against redeploys and
+        # is allowed to be a few minutes stale.
+        self._usage_sync_ttl = float(os.environ.get("LLM_USAGE_SYNC_TTL_SECONDS", "300"))
+        self._usage_sync_lock = threading.Lock()
+        self._last_sheets_sync = 0.0
+        self._external_window_cache: Dict[int, Tuple[float, int]] = {}
 
     # ── Usage tracking ─────────────────────────────────────────────
 
-    def _sync_usage_from_sheets(self) -> None:
-        """Sync the local global usage file from Google Sheets."""
+    def _sync_usage_from_sheets(self, force: bool = False) -> None:
+        """Sync the local global usage file from Google Sheets.
+
+        Reads are throttled to once per LLM_USAGE_SYNC_TTL_SECONDS (default
+        300). Pass ``force=True`` to bypass the throttle (e.g. /api/usage).
+        """
+        now = time.monotonic()
+        with self._usage_sync_lock:
+            if not force and now - self._last_sheets_sync < self._usage_sync_ttl:
+                return
+            self._last_sheets_sync = now
         try:
             from app.storage.google_sheets import GoogleSheetsLogger
             sheets = GoogleSheetsLogger.get_instance()
@@ -97,21 +114,35 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         except Exception as e:
             logger.debug("Could not log LLM usage to Google Sheets: %s", e)
 
-    def _external_usage_total(self, window_days: int = 0) -> int:
-        """Read the cumulative (or windowed) LLM call total from Google Sheets."""
+    def _external_usage_total(self, window_days: int = 0, force: bool = False) -> int:
+        """Read the cumulative (or windowed) LLM call total from Google Sheets.
+
+        Results are cached for LLM_USAGE_SYNC_TTL_SECONDS per window (failures
+        cache as 0, which also avoids hammering a failing Sheets API).
+        """
+        now = time.monotonic()
+        if not force:
+            with self._usage_sync_lock:
+                cached = self._external_window_cache.get(window_days)
+                if cached and now - cached[0] < self._usage_sync_ttl:
+                    return cached[1]
+        total = 0
         try:
             from app.storage.google_sheets import GoogleSheetsLogger
             sheets = GoogleSheetsLogger.get_instance()
-            if sheets is None:
-                return 0
-            if window_days > 0:
-                return sheets.read_recent_llm_calls(window_days)
-            return sheets.read_total_llm_calls()
+            if sheets is not None:
+                if window_days > 0:
+                    total = sheets.read_recent_llm_calls(window_days)
+                else:
+                    total = sheets.read_total_llm_calls()
         except Exception as e:
             logger.debug("Could not read LLM usage from Google Sheets: %s", e)
-            return 0
+            total = 0
+        with self._usage_sync_lock:
+            self._external_window_cache[window_days] = (now, total)
+        return total
 
-    def get_quota_usage(self, limit: int) -> Dict[str, Any]:
+    def get_quota_usage(self, limit: int, force_sync: bool = False) -> Dict[str, Any]:
         """Return effective usage vs *limit*, honoring LLM_CALL_LIMIT_WINDOW_DAYS.
 
         With a rolling window configured, the effective total is the max of
@@ -124,10 +155,10 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         if window > 0:
             used = max(
                 self._global_usage.get_windowed_total(window),
-                self._external_usage_total(window),
+                self._external_usage_total(window, force=force_sync),
             )
         else:
-            self._sync_usage_from_sheets()
+            self._sync_usage_from_sheets(force=force_sync)
             used = self._global_usage.get_total()
         return {
             "used": used,
@@ -157,8 +188,12 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
             raise QuotaExceededError(used=usage["used"], limit=limit)
 
     def get_usage_report(self) -> Dict[str, Any]:
-        """Full quota usage report for the ``/api/usage`` endpoint."""
-        report = self.get_quota_usage(LLM_CALL_GLOBAL_LIMIT)
+        """Full quota usage report for the ``/api/usage`` endpoint.
+
+        Always bypasses the Sheets read throttle so the endpoint reports
+        fresh numbers when you are actively investigating.
+        """
+        report = self.get_quota_usage(LLM_CALL_GLOBAL_LIMIT, force_sync=True)
         data = self._global_usage.get_usage()
         report["enforced"] = (not DEVELOPER_MODE) and LLM_CALL_GLOBAL_LIMIT > 0
         report["lifetime_total"] = data.get("total_calls", 0)

--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -208,6 +208,14 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         ]
         return report
 
+    def record_external_usage(self, source_id: str, counts: Dict[str, int]) -> None:
+        """Record LLM calls made outside the main pipeline (e.g. chat) toward the global quota.
+
+        Writes to the same local usage file and Google Sheet as pipeline runs.
+        """
+        self._global_usage.record_session(source_id, counts)
+        self._log_llm_usage_to_sheets(source_id, counts)
+
     # ── Stop management ────────────────────────────────────────────
 
     def is_stop_requested(self, session_id: str) -> bool:

--- a/backend/app/storage/google_sheets.py
+++ b/backend/app/storage/google_sheets.py
@@ -7,7 +7,7 @@ Entirely optional — skipped if GOOGLE_SHEETS_SPREADSHEET_ID is not set.
 import json
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from app.core.config import (
@@ -260,6 +260,45 @@ class GoogleSheetsLogger:
             return total
         except Exception as e:
             logger.debug("[llm-usage] Could not read LLM usage spreadsheet: %s", e)
+            return 0
+
+    def read_recent_llm_calls(self, window_days: int) -> int:
+        """Sum LLM calls from usage rows whose timestamp falls within the last *window_days*.
+
+        Returns 0 if the spreadsheet is empty, not configured, or on error.
+        """
+        if window_days <= 0:
+            return self.read_total_llm_calls()
+        if not self._enabled or not self._service or not GOOGLE_SHEETS_LLM_USAGE_ID:
+            return 0
+
+        try:
+            result = self._service.spreadsheets().values().get(
+                spreadsheetId=GOOGLE_SHEETS_LLM_USAGE_ID,
+                range="Sheet1!A:C",
+            ).execute()
+            values = result.get("values", [])
+            cutoff = datetime.now(timezone.utc) - timedelta(days=window_days)
+            total = 0
+            for row in values[1:]:  # skip header row
+                if len(row) < 3 or not row[0] or not row[2]:
+                    continue
+                try:
+                    ts = datetime.fromisoformat(str(row[0]))
+                except ValueError:
+                    continue
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts < cutoff:
+                    continue
+                try:
+                    total += int(row[2])
+                except (ValueError, TypeError):
+                    pass
+            logger.debug("[llm-usage] Read %d LLM calls within last %d days", total, window_days)
+            return total
+        except Exception as e:
+            logger.debug("[llm-usage] Could not read windowed LLM usage: %s", e)
             return 0
 
     def log_feedback(

--- a/schematiq-lib/schematiq/core/llm_call_tracker.py
+++ b/schematiq-lib/schematiq/core/llm_call_tracker.py
@@ -266,6 +266,29 @@ class GlobalLLMUsageTracker:
         with self._lock:
             return self._load()
 
+    def get_windowed_total(self, window_days: int) -> int:
+        """Return total calls from sessions recorded within the last *window_days*.
+
+        Only locally recorded sessions carry timestamps; totals synced from an
+        external source via ``sync_from_external`` adjust the lifetime scalar
+        without session entries and are therefore invisible to the window.
+        Callers that need redeploy-safe windowed totals should also consult
+        the external source directly and take the max.
+        """
+        if window_days <= 0:
+            return self.get_total()
+        cutoff = time.time() - window_days * 86400
+        with self._lock:
+            data = self._load()
+            total = 0
+            for entry in data.get("sessions", []):
+                try:
+                    if float(entry.get("timestamp", 0)) >= cutoff:
+                        total += int(entry.get("calls", 0))
+                except (TypeError, ValueError):
+                    continue
+            return total
+
     def check_quota(self, limit: int) -> None:
         """Raise ``QuotaExceededError`` if cumulative calls >= *limit*.
 


### PR DESCRIPTION
## Problem
When the global LLM quota (LLM_CALL_GLOBAL_LIMIT) is exhausted, users see a misleading 'processing capacity' error that suggests transient load, and there is no way to inspect current usage without opening the Google Sheet or the server filesystem. The quota is also lifetime-cumulative, so once crossed the deployment stays blocked until the env var is raised manually.

## Solution
- New GET /api/usage endpoint: used/limit/remaining, per-stage breakdown, last 10 sessions, plus concurrency stats.
- New optional LLM_CALL_LIMIT_WINDOW_DAYS env var (default 0 = legacy lifetime behavior). When set, only calls from the last N days count toward the limit; windowed totals are read both from the local usage file and from the Google Sheet timestamps, so they survive redeploys.
- Quota-exceeded messages (HTTP routes + chat) now clearly state it is a usage quota, distinct from the ConcurrencyLimiter 503.
- Centralized enforcement in ScheMatiQRunner.check_global_quota, removing the duplicated sync+check blocks in /run, /resume and the chat tool.

## Verify
- git apply --ignore-whitespace --check passes on a clean clone of main (dc8f93d).
- python -m py_compile passes on all touched files.
- Unit-level check: with sessions of 500 calls (40 days old) and 300 calls (now), get_windowed_total(30) returns 300 and lifetime total returns 800.
- Manual: curl localhost:8001/api/usage; set LLM_CALL_GLOBAL_LIMIT low and confirm the new 429 message on Start.