### PR TITLE
fix(quota): stray cells in the usage sheet double the synced total

### DIFF
--- a/backend/app/storage/google_sheets.py
+++ b/backend/app/storage/google_sheets.py
@@ -238,6 +238,12 @@ class GoogleSheetsLogger:
     def read_total_llm_calls(self) -> int:
         """Read the sum of all LLM calls from the LLM usage spreadsheet (column C).
 
+        Only rows that look like real usage entries are counted: the row must
+        carry a parseable ISO timestamp in column A. This makes the total
+        immune to stray numeric cells in column C (e.g. a manually added
+        =SUM() cell), which previously inflated the synced total - and, being
+        max-only, the inflation then stuck in the local counter.
+
         Returns 0 if the spreadsheet is empty or not configured.
         """
         if not self._enabled or not self._service or not GOOGLE_SHEETS_LLM_USAGE_ID:
@@ -246,16 +252,21 @@ class GoogleSheetsLogger:
         try:
             result = self._service.spreadsheets().values().get(
                 spreadsheetId=GOOGLE_SHEETS_LLM_USAGE_ID,
-                range="Sheet1!C:C",
+                range="Sheet1!A:C",
             ).execute()
             values = result.get("values", [])
             total = 0
             for row in values[1:]:  # skip header row
-                if row and row[0]:
-                    try:
-                        total += int(row[0])
-                    except (ValueError, TypeError):
-                        pass
+                if len(row) < 3 or not row[0] or not row[2]:
+                    continue
+                try:
+                    datetime.fromisoformat(str(row[0]))
+                except ValueError:
+                    continue  # not a logged usage row (e.g. a SUM cell)
+                try:
+                    total += int(row[2])
+                except (ValueError, TypeError):
+                    pass
             logger.debug("[llm-usage] Read total LLM calls: %d", total)
             return total
         except Exception as e:


### PR DESCRIPTION
## Problem
read_total_llm_calls sums every numeric cell in column C of the usage spreadsheet. A manually added =SUM() / total cell in that column makes the read return roughly double the real usage. sync_from_external is max-only, so the inflated total then sticks in the local counter and can push the deployment over LLM_CALL_GLOBAL_LIMIT. This is exactly what blocked production: the sheet's real rows sum to ~28.5k, but /api/usage showed used=57,062 (~2x) against a 50k limit.

## Solution
Read A:C and count a row only if column A holds a parseable ISO timestamp, i.e. only rows actually written by log_llm_usage. Stray formula/total cells have no timestamp and are skipped. read_recent_llm_calls already required a timestamp and is unaffected.

## Verify
- git apply --ignore-whitespace --check passes on clean main (cef4ef1)
- python -m py_compile passes
- Post-merge: remove the stray cell from the sheet (or keep it - it is now ignored), redeploy so the local counter resets, then curl /api/usage and confirm lifetime_total matches the manual sum of real rows (~28.5k)