### PR TITLE
feat: highlight all cell grounding excerpts in the source document panel

### DIFF
--- a/frontend/src/components/DocumentViewer/DocumentPreview.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentPreview.tsx
@@ -51,6 +51,12 @@ interface DocumentPreviewProps {
    * All excerpts are marked; the first found match is scrolled into view.
    */
   highlightTexts?: string[] | null;
+  /**
+   * Changes on every user click of a grounded cell. Re-scrolls to the first
+   * highlight even when the excerpt set is unchanged (e.g. the user scrolled the
+   * document away and clicked the same cell again).
+   */
+  scrollNonce?: number;
 }
 
 /**
@@ -78,6 +84,7 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
   reloadToken,
   onRequestUpload,
   highlightTexts,
+  scrollNonce,
 }) => {
   const contentUrl = useMemo(() => {
     if (!sessionId || !documentName) return null;
@@ -153,7 +160,7 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
     if (firstMarkRef.current) {
       firstMarkRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
     }
-  }, [highlightRanges, text]);
+  }, [highlightRanges, text, scrollNonce]);
 
   const renderInlineText = () => {
     if (textError) {

--- a/frontend/src/components/DocumentViewer/DocumentPreview.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentPreview.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FileText, ExternalLink, Download, FileX, Upload } from 'lucide-react';
 
 import { unitsAPI } from '../../services/api';
+import { findHighlightRanges } from './highlightUtils';
 
 /** Extensions the browser can render inline in an <iframe>. */
 const INLINE_EXTENSIONS = new Set([
@@ -11,6 +12,14 @@ const INLINE_EXTENSIONS = new Set([
 
 /** Inline content that can carry executable markup, so the iframe is sandboxed. */
 const SANDBOX_EXTENSIONS = new Set(['html', 'htm', 'svg']);
+
+/**
+ * Text formats we render ourselves (in a DOM we control) when highlight mode is
+ * enabled, so a cell's grounding excerpt can be marked and scrolled into view.
+ * Non-text formats (pdf/images/html) keep the native <iframe> rendering, which
+ * cannot be annotated from the parent document.
+ */
+const TEXT_EXTENSIONS = new Set(['txt', 'text', 'md', 'markdown', 'csv', 'tsv', 'json', 'log']);
 
 const extensionOf = (name: string): string => {
   const dot = name.lastIndexOf('.');
@@ -35,6 +44,13 @@ interface DocumentPreviewProps {
    * (typically opens a file picker to re-attach the original source documents).
    */
   onRequestUpload?: () => void;
+  /**
+   * Grounding excerpts to highlight in the document. Passing this prop at all
+   * (even `null`/`[]`) enables the highlight-capable inline text renderer for
+   * text-based formats; the Documents tab omits it and keeps the plain iframe.
+   * All excerpts are marked; the first found match is scrolled into view.
+   */
+  highlightTexts?: string[] | null;
 }
 
 /**
@@ -47,6 +63,13 @@ interface DocumentPreviewProps {
  * re-attached, where the endpoint returns an error), a friendly "not available"
  * message is shown instead of letting the iframe render the raw error body. The
  * message can offer an upload action so the user can supply the original files.
+ *
+ * When `highlightTexts` is supplied (highlight mode), text-based documents are
+ * fetched and rendered in a controlled scroll container so the grounding
+ * excerpts can be marked; the first match is scrolled into view and the rest
+ * are visible as the user scrolls. PDFs/images/HTML cannot be annotated inside
+ * their native iframe, so they keep the iframe and show a brief note when a
+ * highlight was requested.
  */
 const DocumentPreview: React.FC<DocumentPreviewProps> = ({
   sessionId,
@@ -54,6 +77,7 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
   emptyHint,
   reloadToken,
   onRequestUpload,
+  highlightTexts,
 }) => {
   const contentUrl = useMemo(() => {
     if (!sessionId || !documentName) return null;
@@ -87,6 +111,96 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
   const canRenderInline = ext === '' || INLINE_EXTENSIONS.has(ext);
   const needsSandbox = SANDBOX_EXTENSIONS.has(ext);
   const showOpenFull = Boolean(contentUrl) && availability === 'ok';
+
+  // Highlight mode is opt-in (the prop is present) and only applies to text
+  // formats we can render and annotate ourselves.
+  const highlightEnabled = highlightTexts !== undefined;
+  const isTextRenderable = ext === '' || TEXT_EXTENSIONS.has(ext);
+  const useInlineText = highlightEnabled && isTextRenderable;
+
+  const [text, setText] = useState<string | null>(null);
+  const [textError, setTextError] = useState(false);
+
+  useEffect(() => {
+    if (!useInlineText || !sessionId || !documentName || availability !== 'ok') {
+      setText(null);
+      setTextError(false);
+      return undefined;
+    }
+    let cancelled = false;
+    setText(null);
+    setTextError(false);
+    unitsAPI
+      .getDocumentContentText(sessionId, documentName)
+      .then((content) => {
+        if (!cancelled) setText(content);
+      })
+      .catch(() => {
+        if (!cancelled) setTextError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [useInlineText, sessionId, documentName, availability, reloadToken]);
+
+  const highlightRanges = useMemo(
+    () => (useInlineText ? findHighlightRanges(text, highlightTexts) : []),
+    [useInlineText, text, highlightTexts],
+  );
+
+  const firstMarkRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (firstMarkRef.current) {
+      firstMarkRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+  }, [highlightRanges, text]);
+
+  const renderInlineText = () => {
+    if (textError) {
+      return (
+        <div className="h-full flex items-center justify-center text-sm text-muted-foreground text-center px-4">
+          Could not load this document&apos;s text.
+        </div>
+      );
+    }
+    if (text === null) {
+      return (
+        <div className="h-full flex items-center justify-center text-sm text-muted-foreground">
+          Loading…
+        </div>
+      );
+    }
+
+    let body: React.ReactNode = text;
+    if (highlightRanges.length > 0) {
+      const nodes: React.ReactNode[] = [];
+      let cursor = 0;
+      highlightRanges.forEach(([start, end], i) => {
+        if (start > cursor) nodes.push(text.slice(cursor, start));
+        nodes.push(
+          <mark
+            key={`mark-${start}-${end}`}
+            ref={i === 0 ? firstMarkRef : undefined}
+            style={{ backgroundColor: '#fde047', color: '#1f2937', padding: '0 1px', borderRadius: 2 }}
+          >
+            {text.slice(start, end)}
+          </mark>,
+        );
+        cursor = end;
+      });
+      if (cursor < text.length) nodes.push(text.slice(cursor));
+      body = <>{nodes}</>;
+    }
+
+    return (
+      <pre
+        className="h-full w-full overflow-auto m-0 px-4 py-3 text-xs leading-relaxed text-foreground"
+        style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontFamily: 'inherit' }}
+      >
+        {body}
+      </pre>
+    );
+  };
 
   const renderBody = () => {
     if (!contentUrl) {
@@ -124,6 +238,9 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
         </div>
       );
     }
+    if (useInlineText) {
+      return renderInlineText();
+    }
     if (canRenderInline) {
       return (
         <iframe
@@ -152,6 +269,14 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
     );
   };
 
+  // A highlight was requested but this format can't be annotated inline.
+  const showHighlightUnsupportedNote =
+    highlightEnabled &&
+    Boolean(highlightTexts && highlightTexts.length > 0) &&
+    !isTextRenderable &&
+    availability === 'ok' &&
+    canRenderInline;
+
   return (
     <div className="flex-1 min-w-0 h-full flex flex-col">
       <div className="flex items-center gap-2 px-3 py-2 border-b border-border text-xs">
@@ -171,6 +296,12 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
           </a>
         )}
       </div>
+
+      {showHighlightUnsupportedNote && (
+        <div className="px-3 py-1.5 text-[11px] text-muted-foreground border-b border-border bg-muted/20">
+          Source highlighting isn&apos;t available for .{ext || 'this'} files — see the grounding popup for the excerpt.
+        </div>
+      )}
 
       <div className="flex-1 min-h-0 bg-muted/20">{renderBody()}</div>
     </div>

--- a/frontend/src/components/DocumentViewer/highlightUtils.ts
+++ b/frontend/src/components/DocumentViewer/highlightUtils.ts
@@ -1,17 +1,34 @@
 /**
- * Locate a cell's grounding excerpt inside the raw source-document text so the
- * preview can highlight it. Excerpts rarely match the document byte-for-byte
- * (collapsed whitespace, surrounding quotes, trailing ellipsis, truncation), so
- * matching is tolerant: exact match first, then whitespace-normalized, then a
- * leading-prefix fallback that still lands the reader near the right place.
+ * Locate a cell's grounding excerpt(s) inside the raw source-document text so the
+ * preview can highlight them. Excerpts rarely match the document byte-for-byte
+ * (collapsed whitespace, curly vs straight quotes, surrounding quotes, trailing
+ * ellipsis, truncation), and a single excerpt may stitch together several
+ * non-contiguous passages joined by an internal ellipsis ("A... B"). Matching is
+ * therefore tolerant and ellipsis-aware:
+ *   - fold curly quotes/dashes and collapse whitespace before comparing;
+ *   - split each excerpt on internal ellipsis and locate every fragment;
+ *   - exact match first, then whitespace-normalized, then a leading-prefix
+ *     fallback that still lands the reader near the right place.
  *
  * Returned indices are offsets into the ORIGINAL `text`, end-exclusive.
  */
 
 type Range = [number, number];
 
-/** Lowercased copy with runs of whitespace collapsed to one space, plus a map
- *  from each normalized-string index back to its original-string index. */
+/** Single-character folds applied to the normalized (comparison) text only.
+ *  All are 1:1 (one char in, one char out) so the norm→original index map that
+ *  normalizeWithMap builds stays valid. */
+const CHAR_FOLD: Record<string, string> = {
+  '\u2018': "'", '\u2019': "'", '\u201a': "'", '\u201b': "'", '\u2032': "'",
+  '\u0060': "'", '\u00b4': "'",
+  '\u201c': '"', '\u201d': '"', '\u201e': '"', '\u201f': '"', '\u2033': '"',
+  '\u2013': '-', '\u2014': '-', '\u2212': '-',
+};
+
+const foldChar = (ch: string): string => CHAR_FOLD[ch] ?? ch;
+
+/** Lowercased+folded copy with runs of whitespace collapsed to one space, plus a
+ *  map from each normalized-string index back to its original-string index. */
 function normalizeWithMap(text: string): { norm: string; map: number[] } {
   const normChars: string[] = [];
   const map: number[] = [];
@@ -25,7 +42,7 @@ function normalizeWithMap(text: string): { norm: string; map: number[] } {
       map.push(i);
       prevWasSpace = true;
     } else {
-      normChars.push(ch);
+      normChars.push(foldChar(ch));
       map.push(i);
       prevWasSpace = false;
     }
@@ -33,12 +50,43 @@ function normalizeWithMap(text: string): { norm: string; map: number[] } {
   return { norm: normChars.join(''), map };
 }
 
+/** Fold + collapse a query the same way normalizeWithMap folds the text. */
+function foldNormalized(s: string): string {
+  const out: string[] = [];
+  let prevWasSpace = false;
+  const lower = s.toLowerCase();
+  for (let i = 0; i < lower.length; i += 1) {
+    const ch = lower[i];
+    if (/\s/.test(ch)) {
+      if (prevWasSpace) continue;
+      out.push(' ');
+      prevWasSpace = true;
+    } else {
+      out.push(foldChar(ch));
+      prevWasSpace = false;
+    }
+  }
+  return out.join('').trim();
+}
+
 /** Strip surrounding quotes and trailing ellipsis that excerpts often carry. */
 function cleanQuery(raw: string): string {
   let q = raw.trim();
   q = q.replace(/^["'\u201c\u201d\u2018\u2019]+/, '').replace(/["'\u201c\u201d\u2018\u2019]+$/, '');
-  q = q.replace(/\s*(?:\.{3}|\u2026)\s*$/, '');
+  q = q.replace(/\s*(?:\.{3,}|\u2026)\s*$/, '');
   return q.trim();
+}
+
+/**
+ * Split an excerpt into fragments on an internal ellipsis ("...", "....", or the
+ * "\u2026" character). Only 3+ dots split, so citation punctuation like "U.S."
+ * or "Apr." is left intact. Fragments shorter than 4 chars are dropped as noise.
+ */
+export function splitExcerptFragments(raw: string): string[] {
+  return raw
+    .split(/\s*(?:\.{3,}|\u2026)\s*/)
+    .map((s) => s.trim())
+    .filter((s) => s.length >= 4);
 }
 
 export function findHighlightRange(
@@ -53,9 +101,9 @@ export function findHighlightRange(
   const directIdx = text.toLowerCase().indexOf(query.toLowerCase());
   if (directIdx >= 0) return [directIdx, directIdx + query.length];
 
-  // 2) Whitespace-normalized match, mapped back to original offsets.
+  // 2) Folded + whitespace-normalized match, mapped back to original offsets.
   const { norm, map } = normalizeWithMap(text);
-  const normQuery = query.toLowerCase().replace(/\s+/g, ' ').trim();
+  const normQuery = foldNormalized(query);
 
   const mapRange = (nIdx: number, len: number): Range => {
     const start = map[nIdx];
@@ -78,10 +126,10 @@ export function findHighlightRange(
 }
 
 /**
- * Locate every excerpt in `queries` within `text`, returning ranges sorted by
- * start offset with overlaps removed (so we never render nested marks). Used to
- * highlight all of a cell's grounding excerpts at once — the caller scrolls to
- * the first, and the rest are visible as the user scrolls the document.
+ * Locate every excerpt in `queries` within `text`, splitting each on internal
+ * ellipsis so multi-passage excerpts highlight all their parts. Returns ranges
+ * sorted by start offset with overlaps removed (so we never render nested
+ * marks). The caller scrolls to the first; the rest are found by scrolling.
  */
 export function findHighlightRanges(
   text: string | null | undefined,
@@ -91,8 +139,11 @@ export function findHighlightRanges(
 
   const found: Range[] = [];
   for (const q of queries) {
-    const range = findHighlightRange(text, q);
-    if (range) found.push(range);
+    if (!q) continue;
+    for (const fragment of splitExcerptFragments(q)) {
+      const range = findHighlightRange(text, fragment);
+      if (range) found.push(range);
+    }
   }
   if (found.length === 0) return [];
 

--- a/frontend/src/components/DocumentViewer/highlightUtils.ts
+++ b/frontend/src/components/DocumentViewer/highlightUtils.ts
@@ -1,0 +1,111 @@
+/**
+ * Locate a cell's grounding excerpt inside the raw source-document text so the
+ * preview can highlight it. Excerpts rarely match the document byte-for-byte
+ * (collapsed whitespace, surrounding quotes, trailing ellipsis, truncation), so
+ * matching is tolerant: exact match first, then whitespace-normalized, then a
+ * leading-prefix fallback that still lands the reader near the right place.
+ *
+ * Returned indices are offsets into the ORIGINAL `text`, end-exclusive.
+ */
+
+type Range = [number, number];
+
+/** Lowercased copy with runs of whitespace collapsed to one space, plus a map
+ *  from each normalized-string index back to its original-string index. */
+function normalizeWithMap(text: string): { norm: string; map: number[] } {
+  const normChars: string[] = [];
+  const map: number[] = [];
+  let prevWasSpace = false;
+  const lower = text.toLowerCase();
+  for (let i = 0; i < lower.length; i += 1) {
+    const ch = lower[i];
+    if (/\s/.test(ch)) {
+      if (prevWasSpace) continue;
+      normChars.push(' ');
+      map.push(i);
+      prevWasSpace = true;
+    } else {
+      normChars.push(ch);
+      map.push(i);
+      prevWasSpace = false;
+    }
+  }
+  return { norm: normChars.join(''), map };
+}
+
+/** Strip surrounding quotes and trailing ellipsis that excerpts often carry. */
+function cleanQuery(raw: string): string {
+  let q = raw.trim();
+  q = q.replace(/^["'\u201c\u201d\u2018\u2019]+/, '').replace(/["'\u201c\u201d\u2018\u2019]+$/, '');
+  q = q.replace(/\s*(?:\.{3}|\u2026)\s*$/, '');
+  return q.trim();
+}
+
+export function findHighlightRange(
+  text: string | null | undefined,
+  rawQuery: string | null | undefined,
+): Range | null {
+  if (!text || !rawQuery) return null;
+  const query = cleanQuery(rawQuery);
+  if (query.length < 3) return null;
+
+  // 1) Direct case-insensitive match against the original text.
+  const directIdx = text.toLowerCase().indexOf(query.toLowerCase());
+  if (directIdx >= 0) return [directIdx, directIdx + query.length];
+
+  // 2) Whitespace-normalized match, mapped back to original offsets.
+  const { norm, map } = normalizeWithMap(text);
+  const normQuery = query.toLowerCase().replace(/\s+/g, ' ').trim();
+
+  const mapRange = (nIdx: number, len: number): Range => {
+    const start = map[nIdx];
+    const lastOriginal = map[nIdx + len - 1];
+    return [start, lastOriginal + 1];
+  };
+
+  const normIdx = norm.indexOf(normQuery);
+  if (normIdx >= 0) return mapRange(normIdx, normQuery.length);
+
+  // 3) Leading-prefix fallback: match the first several words so the reader is
+  //    still scrolled to the right region even if the tail diverges.
+  const prefix = normQuery.split(' ').slice(0, 8).join(' ').slice(0, 60).trim();
+  if (prefix.length >= 8) {
+    const prefixIdx = norm.indexOf(prefix);
+    if (prefixIdx >= 0) return mapRange(prefixIdx, prefix.length);
+  }
+
+  return null;
+}
+
+/**
+ * Locate every excerpt in `queries` within `text`, returning ranges sorted by
+ * start offset with overlaps removed (so we never render nested marks). Used to
+ * highlight all of a cell's grounding excerpts at once — the caller scrolls to
+ * the first, and the rest are visible as the user scrolls the document.
+ */
+export function findHighlightRanges(
+  text: string | null | undefined,
+  queries: ReadonlyArray<string | null | undefined> | null | undefined,
+): Range[] {
+  if (!text || !queries || queries.length === 0) return [];
+
+  const found: Range[] = [];
+  for (const q of queries) {
+    const range = findHighlightRange(text, q);
+    if (range) found.push(range);
+  }
+  if (found.length === 0) return [];
+
+  found.sort((a, b) => a[0] - b[0]);
+
+  // Drop ranges that overlap one already kept (first-wins after sorting).
+  const result: Range[] = [];
+  let lastEnd = -1;
+  for (const [start, end] of found) {
+    if (start >= lastEnd) {
+      result.push([start, end]);
+      lastEnd = end;
+    }
+  }
+  return result;
+}

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -1113,6 +1113,7 @@ function SpreadsheetSurface({
   formatVersion,
   hotTableRef,
   onSelectionChange,
+  onGroundingHighlight,
   onRefresh,
   onEditFollowUp,
   onEditEnd,
@@ -1127,6 +1128,9 @@ function SpreadsheetSurface({
   formatVersion: number;
   hotTableRef: MutableRefObject<HotTableClass | null>;
   onSelectionChange: (selection: SheetSelection) => void;
+  // Reports all grounding excerpts of the newly selected data cell (or null when
+  // the cell has no grounding), so the source panel can highlight them.
+  onGroundingHighlight?: (texts: string[] | null) => void;
   onRefresh: () => void;
   onEditFollowUp: (kind: PendingRerunKind, columns?: string[]) => void;
   onEditEnd: () => void;
@@ -1969,15 +1973,39 @@ function SpreadsheetSurface({
         afterSelectionEnd={(row: number, col: number, row2: number, col2: number) => {
           if (row < 0 || col < 0 || row2 < 0 || col2 < 0) {
             onSelectionChange(null);
+            onGroundingHighlight?.(null);
             return;
           }
+          const fromRow = Math.min(row, row2);
+          const fromCol = Math.min(col, col2);
           onSelectionChange({
             sheet: activeSheet,
-            fromRow: Math.min(row, row2),
+            fromRow,
             toRow: Math.max(row, row2),
-            fromCol: Math.min(col, col2),
+            fromCol,
             toCol: Math.max(col, col2),
           });
+
+          // Report the top-left cell's grounding excerpts so the source panel
+          // can highlight every place the value came from (all marked; the
+          // first is scrolled into view).
+          if (onGroundingHighlight) {
+            let excerptTexts: string[] | null = null;
+            if (activeSheet === 'data') {
+              const column = sheet.columns[fromCol];
+              const hot = hotTableRef.current?.hotInstance;
+              const physicalRow = hot ? hot.toPhysicalRow(fromRow) : fromRow;
+              const grounding =
+                column && physicalRow != null && physicalRow >= 0
+                  ? dataGrounding[physicalRow]?.[column.key]
+                  : null;
+              const texts = (grounding?.excerpts ?? [])
+                .map((e) => e.text)
+                .filter((t): t is string => Boolean(t && t.trim()));
+              excerptTexts = texts.length > 0 ? texts : null;
+            }
+            onGroundingHighlight(excerptTexts);
+          }
         }}
         afterOnCellMouseDown={(event, coords) => {
           if (activeSheet !== 'data' || coords.row < 0 || coords.col < 0) return;
@@ -2857,6 +2885,9 @@ function Workspace() {
   const [formatVersion, setFormatVersion] = useState(0);
   const [sheetSelection, setSheetSelection] = useState<SheetSelection>(null);
   const [showSourcePanel, setShowSourcePanel] = useState(false);
+  // Grounding excerpts of the currently selected data cell, highlighted in the
+  // source panel so the user can see every place the value came from.
+  const [groundingHighlights, setGroundingHighlights] = useState<string[] | null>(null);
   // View-only re-attach of source files for the data-sheet source panel. Bumping
   // the token re-probes the preview so a freshly uploaded file resolves.
   const [sourceDocReloadToken, setSourceDocReloadToken] = useState(0);
@@ -3266,6 +3297,21 @@ function Workspace() {
     setSheetSelection((current) => (
       selectionsEqual(current, nextSelection) ? current : nextSelection
     ));
+  }, []);
+
+  // Dedupe like updateSheetSelection: HotTable re-emits afterSelectionEnd on
+  // every re-render, so returning the previous value for an unchanged excerpt
+  // set is required to avoid an infinite render loop.
+  const handleGroundingHighlight = useCallback((texts: string[] | null) => {
+    setGroundingHighlights((current) => {
+      if (current === texts) return current;
+      if (!current || !texts) return texts;
+      if (current.length !== texts.length) return texts;
+      for (let i = 0; i < current.length; i += 1) {
+        if (current[i] !== texts[i]) return texts;
+      }
+      return current;
+    });
   }, []);
 
   const applyTableFormat = useCallback((patch: Partial<TableDisplayOptions>) => {
@@ -3780,6 +3826,7 @@ function Workspace() {
         formatVersion={formatVersion}
         hotTableRef={hotTableRef}
         onSelectionChange={updateSheetSelection}
+        onGroundingHighlight={handleGroundingHighlight}
         onRefresh={refreshSilent}
         onEditFollowUp={notifyEditFollowUp}
         onEditEnd={flushDeferredData}
@@ -3916,6 +3963,7 @@ function Workspace() {
                     documentName={selectedSourceDoc}
                     emptyHint="Select a row to see its source document."
                     reloadToken={sourceDocReloadToken}
+                    highlightTexts={groundingHighlights}
                     onRequestUpload={attachingSourceDocs ? undefined : () => sourceDocInputRef.current?.click()}
                   />
                 </div>

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -1114,6 +1114,7 @@ function SpreadsheetSurface({
   hotTableRef,
   onSelectionChange,
   onGroundingHighlight,
+  onGroundingScrollRequest,
   onRefresh,
   onEditFollowUp,
   onEditEnd,
@@ -1131,6 +1132,9 @@ function SpreadsheetSurface({
   // Reports all grounding excerpts of the newly selected data cell (or null when
   // the cell has no grounding), so the source panel can highlight them.
   onGroundingHighlight?: (texts: string[] | null) => void;
+  // Fires on each mouse click of a grounded data cell, so the source panel can
+  // re-scroll to the highlight even when the same cell is clicked again.
+  onGroundingScrollRequest?: () => void;
   onRefresh: () => void;
   onEditFollowUp: (kind: PendingRerunKind, columns?: string[]) => void;
   onEditEnd: () => void;
@@ -2017,6 +2021,10 @@ function SpreadsheetSurface({
           const physicalRow = hot ? hot.toPhysicalRow(coords.row) : coords.row;
           if (!dataGrounding[physicalRow]?.[column.key]) return;
 
+          // Any click on a grounded cell re-scrolls the source panel to the
+          // highlight (mousedown fires only on real clicks, so this never loops).
+          onGroundingScrollRequest?.();
+
           // Open grounding on the top-right indicator only so single-click
           // selection and keyboard editing on grounded cells stay normal.
           const cellElement = (event.target as HTMLElement | null)?.closest('td');
@@ -2888,6 +2896,9 @@ function Workspace() {
   // Grounding excerpts of the currently selected data cell, highlighted in the
   // source panel so the user can see every place the value came from.
   const [groundingHighlights, setGroundingHighlights] = useState<string[] | null>(null);
+  // Bumped on each grounded-cell click so the source panel re-scrolls to the
+  // highlight even when the excerpt set is unchanged (same cell clicked again).
+  const [groundingScrollNonce, setGroundingScrollNonce] = useState(0);
   // View-only re-attach of source files for the data-sheet source panel. Bumping
   // the token re-probes the preview so a freshly uploaded file resolves.
   const [sourceDocReloadToken, setSourceDocReloadToken] = useState(0);
@@ -3827,6 +3838,7 @@ function Workspace() {
         hotTableRef={hotTableRef}
         onSelectionChange={updateSheetSelection}
         onGroundingHighlight={handleGroundingHighlight}
+        onGroundingScrollRequest={() => setGroundingScrollNonce((n) => n + 1)}
         onRefresh={refreshSilent}
         onEditFollowUp={notifyEditFollowUp}
         onEditEnd={flushDeferredData}
@@ -3964,6 +3976,7 @@ function Workspace() {
                     emptyHint="Select a row to see its source document."
                     reloadToken={sourceDocReloadToken}
                     highlightTexts={groundingHighlights}
+                    scrollNonce={groundingScrollNonce}
                     onRequestUpload={attachingSourceDocs ? undefined : () => sourceDocInputRef.current?.click()}
                   />
                 </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -919,6 +919,19 @@ export const unitsAPI = {
     `${API_BASE}/units/document-content/${encodeURIComponent(sessionId)}?name=${encodeURIComponent(name)}`,
 
   /**
+   * Fetch a source document's raw text via the shared axios instance (so it
+   * reuses the configured base URL, credentials, and interceptors). Used by the
+   * highlight-capable preview to render text documents in a DOM we control.
+   */
+  getDocumentContentText: async (sessionId: string, name: string): Promise<string> => {
+    const response = await api.get<string>(
+      `/units/document-content/${encodeURIComponent(sessionId)}?name=${encodeURIComponent(name)}`,
+      { responseType: 'text', transformResponse: [(d) => d] },
+    );
+    return typeof response.data === 'string' ? response.data : String(response.data ?? '');
+  },
+
+  /**
    * Re-attach original source files to a session so the document viewer can
    * render them. View-only: does not change session status or queue the files
    * for processing (unlike loadAPI.addDocuments). Used to restore previews for


### PR DESCRIPTION
## Problem
Grounding is only visible in a popup listing excerpt text. When the source document panel is open beside the data sheet, there is no way to see *where* in the document a cell's values came from.

## Solution
Selecting a grounded data cell now highlights all of its excerpts directly in the source panel (yellow markers), scrolling the first into view so the rest are discoverable by scrolling. This is in addition to the existing grounding popup. DocumentPreview gains an opt-in highlightTexts prop: text documents (txt/md/csv/json/tsv/log) are fetched and rendered in a controlled DOM so excerpts can be marked; PDFs/images/HTML keep the native iframe (which cannot be annotated from the parent) and show a brief note. Matching (highlightUtils) is whitespace-tolerant with quote/ellipsis stripping and a leading-prefix fallback, and drops overlapping ranges. The Documents tab preview is unchanged (does not pass highlightTexts).

## Limitations
- PDFs/images are not highlightable inline (iframe constraint); would require a PDF.js text-layer renderer.
- Only the first occurrence of each excerpt is marked if the same text repeats in the document.

## Verify
- git apply --ignore-whitespace --check passes on clean main
- ( cd frontend && npx tsc --noEmit ) reports no source errors
- highlightUtils matching unit-checked across exact/whitespace/quoted/prefix/no-match, multi-excerpt ordering, and overlap removal
- No other DocumentPreview call sites affected