### PR TITLE
fix(workspace): resolve anchor-has-content a11y warning

### DIFF
--- a/frontend/src/pages/Workspace/chat/ChatMessageBody.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatMessageBody.tsx
@@ -16,8 +16,10 @@ export function ChatMessageBody({ message }: { message: WorkspaceMessage }) {
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          a: ({ node, ...props }) => (
-            <a {...props} target="_blank" rel="noopener noreferrer" />
+          a: ({ node, children, ...props }) => (
+            <a {...props} target="_blank" rel="noopener noreferrer">
+              {children}
+            </a>
           ),
         }}
       >


### PR DESCRIPTION
## Problem
The custom markdown anchor renderer in ChatMessageBody spread props without an explicit children prop, tripping the jsx-a11y/anchor-has-content rule (pre-existing warning surfaced during the Workspace split).

## Solution
Explicitly destructure and forward children to the rendered <a>.

## Verify
- ( cd frontend && npx tsc --noEmit ) passes
- eslint no longer reports anchor-has-content for ChatMessageBody