### PR TITLE
fix(workspace): prevent default focus ring on New Project dialog open

### DIFF
--- a/frontend/src/pages/Workspace/NewProjectDialog.tsx
+++ b/frontend/src/pages/Workspace/NewProjectDialog.tsx
@@ -219,7 +219,10 @@ export function NewProjectDialog({ open, onOpenChange, onCreated }: NewProjectDi
   return (
     <>
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <DialogContent
+        className="max-w-2xl max-h-[90vh] overflow-y-auto"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
         <DialogHeader>
           <div className="flex items-start justify-between gap-2">
             <DialogTitle>New Project</DialogTitle>


### PR DESCRIPTION
## Problem
When the New Project dialog opens, Radix auto-focuses the first focusable element, which is the 'How it works' button. The resulting focus outline looks like an intentional highlight, partially overlaps the close (X) button, and vanishes on the next click, which is confusing.

## Solution
Add onOpenAutoFocus with preventDefault to DialogContent so no element is auto-focused on open. Keyboard users still Tab into the dialog and reach the button with a normal focus-visible ring.

## Verify
- Fresh clone of main: git apply --ignore-whitespace --check passes.
- ( cd frontend && npx tsc --noEmit ) exits 0.
- Manual QA: open New Project - no blue box around 'How it works', X fully visible; Tab still focuses controls normally.