### PR TITLE
docs(workspace): update module map after Stage 2 hook extraction

### DIFF
--- a/frontend/src/pages/Workspace/README.md
+++ b/frontend/src/pages/Workspace/README.md
@@ -11,7 +11,8 @@ know where things live and what depends on what.
 
 | File | Role |
 |------|------|
-| `index.tsx` | The main `Workspace()` component (default export). Owns nearly all state, effects, data fetching, and the top-level layout. This is the orchestrator; the other components are presentational children it wires together. |
+| `index.tsx` | The main `Workspace()` component (default export). Owns the project-data layer (`status`, `session`, `schema`, `data`, `refresh`, etc.), view-local state, and the top-level layout. This is the orchestrator; it wires the child components and the hooks together. |
+| `hooks/` | Custom hooks extracted from `Workspace()`: `useAddDocuments`, `useWorkspaceLayout`, `useReextraction`, `useWorkspaceSocket`. Each owns one cohesive cluster of state + effects and returns the values/handlers `index.tsx` needs. See "State ownership" below. |
 | `types.ts` | Shared TypeScript types used across the module (`SheetId`, `WorkspaceMessage`, `SheetSelection`, `TableDisplayOptions`, `CellFormat`, etc.). No logic. |
 | `constants.ts` | Shared constants and static config (`SHEETS`, `WORKSPACE_MENUS`, tooltip tables, `DEFAULT_PROVIDER`, feature flags like `SHOW_API_KEY_FIELD`). No logic. |
 | `helpers.ts` | Shared pure functions (`buildConfig`, `dataEquals`, `formatCost`, `buildExportFilename`, `schemaFromLoadSession`, HTML-escaping and markup helpers, etc.). Pure and side-effect-free — safe to import anywhere. |
@@ -28,6 +29,10 @@ know where things live and what depends on what.
 
 ```
 index.tsx (Workspace)
+├── hooks/useAddDocuments     ← state + effects, returns handlers
+├── hooks/useWorkspaceLayout  ← chat divider drag
+├── hooks/useReextraction     ← re-extraction lifecycle
+├── hooks/useWorkspaceSocket  ← WebSocket lifecycle (receives refresh + setters)
 ├── SpreadsheetSurface   ← props only
 ├── SpreadsheetChrome    ← props only
 ├── NewProjectDialog     ← props only
@@ -41,10 +46,10 @@ all of the above import from → types.ts · constants.ts · helpers.ts
 
 Rules that keep this clean:
 
-- **State lives in `index.tsx`.** The child components are presentational: they
-  take data and callbacks as props and render. If you need new shared state, add
-  it to `index.tsx` and pass it down — don't introduce cross-imports between
-  siblings.
+- **State lives in `index.tsx` or a hook in `hooks/` — never in a child
+  component.** The child components are presentational: they take data and
+  callbacks as props and render. Shared state belongs either in `index.tsx` or a
+  hook it calls; don't introduce cross-imports between siblings.
 - **`types.ts` / `constants.ts` / `helpers.ts` are leaves.** They must not import
   from any of the component files. Anything shared by two or more files goes
   here.
@@ -57,15 +62,28 @@ Rules that keep this clean:
 - Grid rendering / cell formatting / selection behavior → `SpreadsheetSurface.tsx`
 - Toolbar menus, fonts, export buttons → `SpreadsheetChrome.tsx`
 - Chat UI, message rendering, tool logs → `chat/`
-- Data fetching, WebSocket handling, re-extraction, add-documents, project
-  lifecycle → `index.tsx` (this is the heavy logic; a future refactor may extract
-  it into hooks — see the note below)
+- Add-documents upload flow → `hooks/useAddDocuments.ts`
+- Re-extraction / rerun banner / confirm dialog → `hooks/useReextraction.ts`
+- WebSocket connection and message routing → `hooks/useWorkspaceSocket.ts`
+- Chat divider drag / layout → `hooks/useWorkspaceLayout.ts`
+- Data fetching (`refresh`), project lifecycle, and view-local state → `index.tsx`
 - A new shared type/constant/pure helper → the matching leaf file
 
-## Known follow-up
+## State ownership
 
-`index.tsx` still holds the full `Workspace()` body (~1400 lines of state and
-effects). A planned Stage 2 will extract this into custom hooks
-(`useProjectData`, `useReextraction`, `useAddDocuments`, `useWorkspaceLayout`,
-etc.) to shrink the orchestrator. Until then, treat `index.tsx` as the single
-source of Workspace state.
+`index.tsx` retains the **project-data layer** (`status`, `session`, `schema`,
+`data`, `unitData`, `documents`, `config`, `refresh`, `refreshSilent`, loading
+flags) and **view-local state** (`activeSheet`, `tableDisplay`, `cellFormats`,
+grounding, dialog flags, JSX-bound refs). The data layer stays here on purpose:
+it is tightly coupled to the WebSocket and re-extraction flows, so extracting it
+would require shared refs or dependency-array changes that risk behavior drift.
+
+The four hooks each own one cohesive cluster and take `refresh` plus any needed
+setters (e.g. `setReextraction`, `setActiveSheet`) as arguments, so `index.tsx`
+remains the single wiring point. `useReextraction` returns `setReextraction`,
+which is passed into `useWorkspaceSocket` (progress messages) and used by the
+monitor's optimistic banner update — declare `useReextraction` before
+`useWorkspaceSocket` so that setter exists when the socket hook is wired.
+
+If you add a new cohesive cluster of state + effects, prefer a new hook in
+`hooks/` over growing `Workspace()`.


### PR DESCRIPTION
## Problem
The Workspace module README still described Stage 2 hook extraction as planned future work and routed all heavy logic to index.tsx.

## Solution
Update the file table, dependency diagram, and change-routing to reflect the four extracted hooks. Replace the follow-up note with a State ownership section documenting what remains in index.tsx (the project-data layer) and why, plus the useReextraction-before-useWorkspaceSocket wiring order.

## Verify
Docs-only change. tsc and build unaffected.