### PR TITLE
feat: highlight grounding excerpts in PDF source documents

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -48,6 +48,7 @@
         "react-dropzone": "^14.2.3",
         "react-json-view": "^1.21.3",
         "react-markdown": "^9.0.1",
+        "react-pdf": "^10.4.1",
         "react-query": "^3.39.3",
         "react-router-dom": "^6.20.1",
         "react-scripts": "5.0.1",
@@ -2956,6 +2957,256 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -13126,6 +13377,15 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/make-cancellable-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-2.0.0.tgz",
+      "integrity": "sha512-3SEQqTpV9oqVsIWqAcmDuaNeo7yBO3tqPtqGRcKkEo0lrzD3wqbKG9mkxO65KoOgXqj+zH2phJ2LiAsdzlogSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-cancellable-promise?sponsor=1"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -13152,6 +13412,15 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
+    "node_modules/make-event-props": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-2.0.0.tgz",
+      "integrity": "sha512-G/hncXrl4Qt7mauJEXSg3AcdYzmpkIITTNl5I+rH9sog5Yw0kK6vseJjCaPfOXqOqQuPUP89Rkhfz5kPS8ijtw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
+      }
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -13500,6 +13769,23 @@
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-refs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-2.0.0.tgz",
+      "integrity": "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/merge-refs?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/merge-stream": {
@@ -14799,6 +15085,18 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
       }
     },
     "node_modules/performance-now": {
@@ -16655,6 +16953,35 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-pdf": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-10.4.1.tgz",
+      "integrity": "sha512-kS/35staVCBqS29verTQJQZXw7RfsRCPO3fdJoW1KXylcv7A9dw6DZ3vJXC2w+bIBgLw5FN4pOFvKSQtkQhPfA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "dequal": "^2.0.3",
+        "make-cancellable-promise": "^2.0.0",
+        "make-event-props": "^2.0.0",
+        "merge-refs": "^2.0.0",
+        "pdfjs-dist": "5.4.296",
+        "tiny-invariant": "^1.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-query": {
@@ -19978,6 +20305,15 @@
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "react-dropzone": "^14.2.3",
     "react-json-view": "^1.21.3",
     "react-markdown": "^9.0.1",
+    "react-pdf": "^10.4.1",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.20.1",
     "react-scripts": "5.0.1",

--- a/frontend/src/components/DocumentViewer/DocumentPreview.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentPreview.tsx
@@ -1,8 +1,11 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { Suspense, lazy, useEffect, useMemo, useRef, useState } from 'react';
 import { FileText, ExternalLink, Download, FileX, Upload } from 'lucide-react';
 
 import { unitsAPI } from '../../services/api';
 import { findHighlightRanges } from './highlightUtils';
+
+// react-pdf/pdfjs are heavy; load them only when a PDF is previewed.
+const PdfHighlightViewer = lazy(() => import('./PdfHighlightViewer'));
 
 /** Extensions the browser can render inline in an <iframe>. */
 const INLINE_EXTENSIONS = new Set([
@@ -124,6 +127,10 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
   const highlightEnabled = highlightTexts !== undefined;
   const isTextRenderable = ext === '' || TEXT_EXTENSIONS.has(ext);
   const useInlineText = highlightEnabled && isTextRenderable;
+  // PDFs render via react-pdf when highlight mode is on, so excerpts can be
+  // marked in the text layer. With highlight mode off (e.g. the Documents tab)
+  // PDFs keep the native iframe.
+  const usePdfHighlight = highlightEnabled && ext === 'pdf';
 
   const [text, setText] = useState<string | null>(null);
   const [textError, setTextError] = useState(false);
@@ -248,6 +255,19 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
     if (useInlineText) {
       return renderInlineText();
     }
+    if (usePdfHighlight && contentUrl) {
+      return (
+        <Suspense
+          fallback={<div className="h-full flex items-center justify-center text-sm text-muted-foreground">Loading…</div>}
+        >
+          <PdfHighlightViewer
+            fileUrl={contentUrl}
+            highlightTexts={highlightTexts}
+            scrollNonce={scrollNonce}
+          />
+        </Suspense>
+      );
+    }
     if (canRenderInline) {
       return (
         <iframe
@@ -281,6 +301,7 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
     highlightEnabled &&
     Boolean(highlightTexts && highlightTexts.length > 0) &&
     !isTextRenderable &&
+    !usePdfHighlight &&
     availability === 'ok' &&
     canRenderInline;
 

--- a/frontend/src/components/DocumentViewer/PdfHighlightViewer.tsx
+++ b/frontend/src/components/DocumentViewer/PdfHighlightViewer.tsx
@@ -1,0 +1,233 @@
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Document, Page, pdfjs } from 'react-pdf';
+import type { PDFDocumentProxy } from 'pdfjs-dist';
+
+import 'react-pdf/dist/Page/TextLayer.css';
+import {
+  computeItemHighlightIntervals,
+  wrapItemHtml,
+  PdfTextItemLike,
+} from './pdfHighlightUtils';
+
+// Self-host the pdfjs worker: `new URL(..., import.meta.url)` makes webpack
+// (CRA 5) emit the worker as a hashed asset served from our own origin, so it is
+// version-locked to the installed pdfjs-dist and needs no CDN (no CSP concerns).
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.mjs',
+  import.meta.url,
+).toString();
+
+/** itemIndex -> character intervals to highlight within that item's str. */
+type PageIntervals = Map<number, Array<[number, number]>>;
+
+interface HighlightedPageProps {
+  pageNumber: number;
+  width?: number;
+  intervals?: PageIntervals;
+  onItems: (pageNumber: number, items: PdfTextItemLike[]) => void;
+}
+
+/**
+ * One PDF page. Its `customTextRenderer`/`onGetTextSuccess` are memoized on the
+ * page's own inputs, so react-pdf only rebuilds this page's text layer when its
+ * highlights actually change — not on unrelated parent re-renders (e.g. a
+ * same-cell re-click that only bumps the scroll nonce).
+ */
+const HighlightedPage: React.FC<HighlightedPageProps> = ({
+  pageNumber,
+  width,
+  intervals,
+  onItems,
+}) => {
+  const handleGetTextSuccess = useCallback(
+    (textContent: { items: unknown[] }) => {
+      onItems(pageNumber, textContent.items as PdfTextItemLike[]);
+    },
+    [pageNumber, onItems],
+  );
+
+  const customTextRenderer = useCallback(
+    (item: { str: string; itemIndex: number }): string =>
+      wrapItemHtml(item.str, intervals?.get(item.itemIndex)),
+    [intervals],
+  );
+
+  return (
+    <Page
+      pageNumber={pageNumber}
+      width={width || undefined}
+      renderTextLayer
+      renderAnnotationLayer={false}
+      onGetTextSuccess={handleGetTextSuccess}
+      customTextRenderer={customTextRenderer}
+      className="shadow-sm"
+    />
+  );
+};
+
+interface PdfHighlightViewerProps {
+  /** URL the PDF is served from (same-origin content endpoint). */
+  fileUrl: string;
+  /** Grounding excerpts to highlight; null/empty renders the PDF unmarked. */
+  highlightTexts?: string[] | null;
+  /** Bumped on each grounded-cell click to re-scroll to the first highlight. */
+  scrollNonce?: number;
+}
+
+/**
+ * Renders a PDF with react-pdf and highlights a cell's grounding excerpts in the
+ * text layer. Each page's text items are captured via `onGetTextSuccess` (the
+ * exact array react-pdf indexes, so `itemIndex` lines up), then matched in
+ * pdfHighlightUtils; react-pdf's per-item `customTextRenderer` wraps the covered
+ * substrings in <mark>, so highlights stay aligned inside the positioned spans.
+ * Intervals are derived with useMemo so they recompute when the selected cell
+ * (highlightTexts) changes, not only on document load. Scanned PDFs (no text
+ * layer) render normally but cannot be marked.
+ */
+const PdfHighlightViewer: React.FC<PdfHighlightViewerProps> = ({
+  fileUrl,
+  highlightTexts,
+  scrollNonce,
+}) => {
+  const [numPages, setNumPages] = useState(0);
+  const [itemsByPage, setItemsByPage] = useState<Map<number, PdfTextItemLike[]>>(new Map());
+  const [error, setError] = useState(false);
+  const [pageWidth, setPageWidth] = useState(0);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // Fit pages to the panel width.
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return undefined;
+    const measure = () => setPageWidth(Math.max(0, el.clientWidth - 24));
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Forget cached page text when the document changes.
+  useEffect(() => {
+    setItemsByPage(new Map());
+    setNumPages(0);
+    setError(false);
+  }, [fileUrl]);
+
+  const onLoadSuccess = useCallback((pdf: PDFDocumentProxy) => {
+    setError(false);
+    setNumPages(pdf.numPages);
+  }, []);
+
+  // Cache each page's items once (page text is stable for a document). Ignoring
+  // repeat calls also keeps this stable callback loop-safe if react-pdf
+  // re-invokes onGetTextSuccess.
+  const handleItems = useCallback((pageNumber: number, items: PdfTextItemLike[]) => {
+    setItemsByPage((prev) => {
+      if (prev.has(pageNumber)) return prev;
+      const next = new Map(prev);
+      next.set(pageNumber, items);
+      return next;
+    });
+  }, []);
+
+  // Recompute highlight intervals whenever the cached text or the selected
+  // cell's excerpts change.
+  const intervalsByPage = useMemo(() => {
+    const result = new Map<number, PageIntervals>();
+    if (!highlightTexts || highlightTexts.length === 0) return result;
+    itemsByPage.forEach((items, pageNumber) => {
+      const intervals = computeItemHighlightIntervals(items, highlightTexts);
+      if (intervals.size > 0) result.set(pageNumber, intervals);
+    });
+    return result;
+  }, [itemsByPage, highlightTexts]);
+
+  // Scroll to the first mark when a new selection's highlights become available
+  // or on an explicit re-click. A guard keyed on the current selection prevents
+  // repeated jumps as pages stream in during load, and avoids re-scrolling on
+  // resize. The poll waits for the text layer to paint the mark.
+  const scrolledForRef = useRef<{ texts: string[] | null | undefined; nonce: number | undefined }>({
+    texts: undefined,
+    nonce: undefined,
+  });
+  useEffect(() => {
+    if (intervalsByPage.size === 0) return undefined;
+    const done = scrolledForRef.current;
+    if (done.texts === highlightTexts && done.nonce === scrollNonce) return undefined;
+
+    let raf = 0;
+    let tries = 0;
+    const tryScroll = () => {
+      const mark = containerRef.current?.querySelector('mark');
+      if (mark) {
+        mark.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        scrolledForRef.current = { texts: highlightTexts, nonce: scrollNonce };
+        return;
+      }
+      tries += 1;
+      if (tries < 30) raf = requestAnimationFrame(tryScroll);
+    };
+    raf = requestAnimationFrame(tryScroll);
+    return () => cancelAnimationFrame(raf);
+  }, [intervalsByPage, scrollNonce, highlightTexts]);
+
+  const pages = useMemo(
+    () => Array.from({ length: numPages }, (_, i) => i + 1),
+    [numPages],
+  );
+
+  // A highlight was requested, every page's text has been scanned, and nothing
+  // matched — either a scanned/image PDF (no text layer) or wording that differs
+  // from the document. Tell the user rather than showing the PDF silently.
+  const highlightRequested = Boolean(highlightTexts && highlightTexts.length > 0);
+  const allPagesScanned = numPages > 0 && itemsByPage.size >= numPages;
+  const showNoMatchNote = highlightRequested && allPagesScanned && intervalsByPage.size === 0;
+
+  if (error) {
+    return (
+      <div className="h-full flex items-center justify-center text-sm text-muted-foreground text-center px-4">
+        Could not load this PDF for preview.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-full w-full overflow-auto bg-muted/20 flex flex-col items-center gap-3 py-3"
+    >
+      {showNoMatchNote && (
+        <div className="sticky top-0 z-10 w-full px-3 py-1.5 text-[11px] text-muted-foreground bg-muted/80 backdrop-blur border-b border-border text-center">
+          Couldn&apos;t locate this excerpt in the PDF text (it may be scanned or worded differently).
+        </div>
+      )}
+      <Document
+        file={fileUrl}
+        onLoadSuccess={onLoadSuccess}
+        onLoadError={() => setError(true)}
+        loading={<div className="text-sm text-muted-foreground p-4">Loading…</div>}
+        error={<div className="text-sm text-muted-foreground p-4">Could not load this PDF.</div>}
+      >
+        {pages.map((pageNumber) => (
+          <HighlightedPage
+            key={pageNumber}
+            pageNumber={pageNumber}
+            width={pageWidth}
+            intervals={intervalsByPage.get(pageNumber)}
+            onItems={handleItems}
+          />
+        ))}
+      </Document>
+    </div>
+  );
+};
+
+export default PdfHighlightViewer;

--- a/frontend/src/components/DocumentViewer/pdfHighlightUtils.ts
+++ b/frontend/src/components/DocumentViewer/pdfHighlightUtils.ts
@@ -1,0 +1,151 @@
+/**
+ * Map grounding excerpts onto a PDF page's text layer.
+ *
+ * PDF.js exposes a page's text as many separate text items (roughly one per
+ * text run), not one continuous string, so we cannot wrap a match the way the
+ * plain-text preview does. Instead we:
+ *   1. concatenate the page's items into a single string with a separator
+ *      between items, recording the `[start, end)` span each item occupies;
+ *   2. reuse `findHighlightRanges` (ellipsis-split + quote/whitespace folding +
+ *      overlap removal) to locate the excerpts in that string;
+ *   3. intersect each matched range with the item spans to get per-item
+ *      character intervals so the caller can wrap the covered substrings in
+ *      <mark>.
+ *
+ * This module is pure (no DOM, no pdfjs imports) and unit-testable. The React
+ * component feeds it the items from `getTextContent()` and uses the result in
+ * react-pdf's `customTextRenderer` (which renders per item and expects an HTML
+ * string), so highlights live inside the already-positioned text-layer spans
+ * and stay aligned automatically.
+ */
+
+import { findHighlightRanges } from './highlightUtils';
+
+/** The subset of a PDF.js text-content item we rely on. The array from
+ *  `getTextContent()`/`onGetTextSuccess` also contains marked-content items that
+ *  have no `str`; those occupy an index but contribute no text. */
+export interface PdfTextItemLike {
+  str?: string;
+  /** PDF.js marks the item that ends a line; we join those with a newline. */
+  hasEOL?: boolean;
+}
+
+/** A text item's span within the concatenated page text: `[start, end)`. */
+interface Segment {
+  item: number;
+  start: number;
+  end: number;
+}
+
+export interface PageText {
+  text: string;
+  segments: Segment[];
+}
+
+/**
+ * Concatenate a page's text items into one string, inserting a separator after
+ * each text item (newline after an end-of-line item, otherwise a space), and
+ * return the `[start, end)` span each item occupies in that string. Item indices
+ * are the item's position in the ORIGINAL items array so they line up with the
+ * `itemIndex` react-pdf passes to `customTextRenderer`; marked-content items
+ * (no `str`) are skipped but still consume their index. The separators let an
+ * excerpt that spans two items match under the whitespace-tolerant matcher.
+ */
+export function buildPageText(items: PdfTextItemLike[]): PageText {
+  const parts: string[] = [];
+  const segments: Segment[] = [];
+  let offset = 0;
+
+  items.forEach((item, itemIndex) => {
+    const str = typeof item.str === 'string' ? item.str : '';
+    if (!str) return;
+    parts.push(str);
+    segments.push({ item: itemIndex, start: offset, end: offset + str.length });
+    offset += str.length;
+    const separator = item.hasEOL ? '\n' : ' ';
+    parts.push(separator);
+    offset += separator.length;
+  });
+
+  return { text: parts.join(''), segments };
+}
+
+/**
+ * Locate every excerpt in `queries` on this page and return, per item index,
+ * the list of `[start, end)` character intervals within that item's `str` to
+ * highlight. Intervals per item are sorted and merged so wrapping is simple.
+ */
+export function computeItemHighlightIntervals(
+  items: PdfTextItemLike[],
+  queries: ReadonlyArray<string | null | undefined> | null | undefined,
+): Map<number, Array<[number, number]>> {
+  const result = new Map<number, Array<[number, number]>>();
+  if (!items.length || !queries || queries.length === 0) return result;
+
+  const { text, segments } = buildPageText(items);
+  const ranges = findHighlightRanges(text, queries);
+  if (ranges.length === 0) return result;
+
+  // Intersect each matched range with the item segments it overlaps. Segments
+  // are sorted by start, so we can stop once a segment begins past the range.
+  ranges.forEach(([rangeStart, rangeEnd]) => {
+    for (let s = 0; s < segments.length; s += 1) {
+      const seg = segments[s];
+      if (seg.end <= rangeStart) continue;
+      if (seg.start >= rangeEnd) break;
+      const overlapStart = Math.max(rangeStart, seg.start);
+      const overlapEnd = Math.min(rangeEnd, seg.end);
+      if (overlapEnd <= overlapStart) continue;
+      const list = result.get(seg.item) ?? [];
+      list.push([overlapStart - seg.start, overlapEnd - seg.start]);
+      result.set(seg.item, list);
+    }
+  });
+
+  // Merge/sort intervals within each item (adjacent ranges can touch).
+  result.forEach((intervals, item) => {
+    intervals.sort((a, b) => a[0] - b[0]);
+    const merged: Array<[number, number]> = [];
+    intervals.forEach(([start, end]) => {
+      const last = merged[merged.length - 1];
+      if (last && start <= last[1]) {
+        last[1] = Math.max(last[1], end);
+      } else {
+        merged.push([start, end]);
+      }
+    });
+    result.set(item, merged);
+  });
+
+  return result;
+}
+
+const escapeHtml = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+/**
+ * Build the HTML string for one text item, wrapping the given character
+ * intervals in <mark>. Returned to react-pdf's `customTextRenderer`. The mark
+ * inherits the text layer's transparent text color, so only the yellow
+ * background paints over the canvas glyphs (the standard PDF marker look).
+ */
+export function wrapItemHtml(str: string, intervals: Array<[number, number]> | undefined): string {
+  if (!intervals || intervals.length === 0) return escapeHtml(str);
+
+  const out: string[] = [];
+  let cursor = 0;
+  for (const [start, end] of intervals) {
+    const s = Math.max(0, Math.min(start, str.length));
+    const e = Math.max(s, Math.min(end, str.length));
+    if (e <= s) continue;
+    if (s > cursor) out.push(escapeHtml(str.slice(cursor, s)));
+    out.push(
+      '<mark style="background-color:rgba(253,224,71,0.45);color:inherit;padding:0;border-radius:2px;">',
+      escapeHtml(str.slice(s, e)),
+      '</mark>',
+    );
+    cursor = e;
+  }
+  if (cursor < str.length) out.push(escapeHtml(str.slice(cursor)));
+  return out.join('');
+}


### PR DESCRIPTION
## Problem
The source panel highlights a cell's grounding excerpts for text documents, but PDFs render in a native iframe that cannot be annotated, so they only showed a 'not available' note.

## Solution
When highlight mode is on, PDFs render with react-pdf. Per page, the text layer items are concatenated (with an offset map) and matched with the existing findHighlightRanges (ellipsis split, quote/whitespace folding, overlap removal); matched ranges are mapped back to per-item character intervals and wrapped in <mark> via customTextRenderer, so highlights stay aligned inside the positioned text spans. The first match is scrolled into view and re-scroll works on re-click (scrollNonce). react-pdf is lazy-loaded (separate chunk). New pure module pdfHighlightUtils.ts holds the mapping logic. The Documents-tab iframe preview and the text-document path are unchanged.

## Limitations
- Scanned/image-only PDFs have no text layer, so they render without highlights (OCR-text fallback is a possible follow-up needing a backend endpoint to serve extracted text).
- The pdfjs worker is loaded from unpkg pinned to the installed version; if a strict production CSP blocks it, host the worker locally.

## Verify
- CRA production build succeeds; pdfjs is isolated in a lazy chunk (main bundle unaffected)
- ( cd frontend && npx tsc --noEmit ) clean; eslint clean on changed files
- pdfHighlightUtils unit-checked for multi-item spans, whitespace/quote folding, and HTML wrapping
- Manual QA needed: highlight alignment on real PDFs, scroll timing, and worker CSP in production