### PR TITLE
fix: resolve source-document previews for names containing periods

### DIFF
--- a/backend/app/api/routes/units.py
+++ b/backend/app/api/routes/units.py
@@ -139,16 +139,38 @@ def _media_type_for(name: str) -> str:
     return guessed or "application/octet-stream"
 
 
+# Document extensions we may strip when matching a recorded source name (which
+# often omits the extension, or was recorded before PDF->txt conversion) against
+# a stored file. We strip ONLY these known suffixes — never a generic
+# "everything after the last dot" (Path.stem / lastIndexOf('.')), because
+# document names routinely contain periods (e.g. "... Order No. 19-cv-7151",
+# "Dep't", "Inc."), which such splitting would truncate and break matching.
+_DOC_MATCH_EXTENSIONS = (
+    ".pdf", ".txt", ".md", ".markdown", ".html", ".htm",
+    ".doc", ".docx", ".rtf", ".json", ".csv", ".tsv",
+)
+
+
+def _strip_doc_extension(filename: str) -> str:
+    """Return the filename without a trailing known document extension."""
+    lower = filename.lower()
+    for ext in _DOC_MATCH_EXTENSIONS:
+        if lower.endswith(ext) and len(filename) > len(ext):
+            return filename[: -len(ext)]
+    return filename
+
+
 def _find_local_document(session_id: str, name: str) -> Optional[Path]:
     """Locate an uploaded source document on the local filesystem.
 
     Searches documents/ and pending_documents/ across every known data dir
     (CWD, backend, dev.sh instances). Matches the exact filename first, then
-    falls back to stem matching since the recorded source_document name may
-    omit the extension.
+    compares ignoring a known extension on either side, since the recorded
+    source_document name may omit the extension or differ from the stored file
+    (e.g. an original ``.pdf`` converted to ``.txt``).
     """
-    target_stem = Path(name).stem.lower()
     target_name = name.lower()
+    target_base = _strip_doc_extension(name).lower()
     for base in candidate_data_dirs():
         for sub in ("documents", "pending_documents"):
             doc_dir = base / session_id / sub
@@ -160,7 +182,9 @@ def _find_local_document(session_id: str, name: str) -> Optional[Path]:
             for f in doc_dir.iterdir():
                 if not f.is_file() or f.name.startswith("."):
                     continue
-                if f.name.lower() == target_name or f.stem.lower() == target_stem:
+                file_name = f.name.lower()
+                file_base = _strip_doc_extension(f.name).lower()
+                if target_name in (file_name, file_base) or target_base in (file_name, file_base):
                     return f
     return None
 

--- a/frontend/src/components/DocumentViewer/DocumentPreview.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentPreview.tsx
@@ -23,7 +23,13 @@ const TEXT_EXTENSIONS = new Set(['txt', 'text', 'md', 'markdown', 'csv', 'tsv', 
 
 const extensionOf = (name: string): string => {
   const dot = name.lastIndexOf('.');
-  return dot >= 0 ? name.slice(dot + 1).toLowerCase() : '';
+  if (dot < 0) return '';
+  const ext = name.slice(dot + 1).toLowerCase();
+  // Only treat the suffix as a real extension if it looks like one. Document
+  // names often contain internal periods (e.g. "... Order No. 19-cv-7151"),
+  // where the text after the last dot is not an extension; those resolve to ''
+  // so they take the text-renderable path instead of the download fallback.
+  return /^[a-z0-9]{1,8}$/.test(ext) && /[a-z]/.test(ext) ? ext : '';
 };
 
 type Availability = 'idle' | 'checking' | 'ok' | 'unavailable';


### PR DESCRIPTION
## Problem
Source documents whose names contain internal periods (legal citations like '... Order No. 19-cv-7151', 'Dep't', 'Sec.') never resolved for preview — the panel showed 'This document isn't available to preview', and manually re-uploading the original did not help. Root cause: backend _find_local_document used Path(name).stem and the frontend used lastIndexOf('.'), both of which split at the last period and truncated the name, so it matched neither the converted .txt in documents/ nor a re-uploaded original in pending_documents/. Names without periods (e.g. 'WMM2025-04-17NDTX') worked, which is why this looked intermittent.

## Solution
Match by stripping only a known document extension (.pdf/.txt/.md/.html/... ) from either side, never a generic 'everything after the last dot'. Backend adds _strip_doc_extension and compares name/base on both the requested name and the stored file; frontend's extensionOf only treats a suffix as an extension when it looks like one, so period-containing names resolve to '' and take the text-renderable path.

## Verify
- python -m py_compile backend/app/api/routes/units.py
- ( cd frontend && npx tsc --noEmit ) clean
- Unit-checked matching on the real failing name against .txt/.pdf (match) and unrelated docs (no match); extensionOf returns '' for period names and correct extensions otherwise
- Pre-existing bug on main; independent of the PDF grounding-highlight work