### PR TITLE
fix: latin-1-safe Content-Disposition for non-ASCII source-document names

### DIFF
--- a/backend/app/api/routes/units.py
+++ b/backend/app/api/routes/units.py
@@ -4,6 +4,7 @@ import io
 import mimetypes
 from pathlib import Path
 from typing import List, Optional, Tuple
+from urllib.parse import quote
 
 from fastapi import APIRouter, File, HTTPException, Query, UploadFile
 from fastapi.responses import StreamingResponse
@@ -243,8 +244,15 @@ async def get_document_content(
     if content is None:
         raise HTTPException(status_code=404, detail="Document file is not available")
 
+    # HTTP headers must be latin-1 encodable, but document names often contain
+    # non-latin-1 characters (e.g. the curly apostrophe in "Dep't"). Use an
+    # ASCII fallback plus an RFC 5987 filename* for the real name.
+    raw_name = Path(name).name
+    ascii_fallback = raw_name.encode("ascii", "ignore").decode("ascii").replace('"', "").strip() or "document"
     headers = {
-        "Content-Disposition": f'inline; filename="{Path(name).name}"',
+        "Content-Disposition": (
+            f"inline; filename=\"{ascii_fallback}\"; filename*=UTF-8''{quote(raw_name)}"
+        ),
         "Cache-Control": "private, max-age=60",
     }
     if media_type in _SANDBOXED_MEDIA_TYPES:


### PR DESCRIPTION
## Problem
After PR #250 made source documents with periods resolve, serving one whose name contains a non-latin-1 character (curly apostrophe in 'Dep't') 500s with UnicodeEncodeError: HTTP header values must be latin-1, but Content-Disposition embedded the raw filename. Affects production too.

## Solution
Build Content-Disposition per RFC 5987: an ASCII-only filename fallback plus filename*=UTF-8''<percent-encoded> for the real name. The whole header is now latin-1 safe.

## Verify
- python -m py_compile backend/app/api/routes/units.py
- Confirmed the header encodes to latin-1 for the real failing name ('... Dep't ...')
- git apply --ignore-whitespace --check passes on current main