### PR TITLE
fix: convert re-attached source documents to text for preview

### DIFF
--- a/backend/app/api/routes/units.py
+++ b/backend/app/api/routes/units.py
@@ -22,6 +22,7 @@ from app.services.unit_view_service import unit_view_service
 from app.services import session_manager, pubmed_enrichment_service
 from app.services.data_utils import candidate_data_dirs, get_data_dir
 from app.services.file_parser import is_system_file
+from app.services.document_preprocessor import commit_document_to_documents_dir
 from app.storage import get_storage
 
 router = APIRouter()
@@ -301,6 +302,7 @@ async def attach_source_documents(
 
     pending_dir = get_data_dir() / session_id / "pending_documents"
     pending_dir.mkdir(parents=True, exist_ok=True)
+    documents_dir = get_data_dir() / session_id / "documents"
 
     attached: list[str] = []
     skipped: list[dict] = []
@@ -313,7 +315,17 @@ async def attach_source_documents(
             skipped.append({"name": name, "reason": "exceeds 25MB limit"})
             continue
         try:
-            (pending_dir / name).write_bytes(content)
+            written = pending_dir / name
+            written.write_bytes(content)
+            # Convert to a lib-readable text form in documents/ (mirroring the
+            # ingestion pipeline) so previews render as text with reliable
+            # grounding highlights rather than serving raw PDF/office bytes. On
+            # conversion failure the original stays in pending_documents/ as a
+            # best-effort fallback.
+            try:
+                commit_document_to_documents_dir(written, documents_dir)
+            except Exception:  # pragma: no cover - defensive; keep the original
+                pass
             attached.append(name)
         except Exception as e:  # pragma: no cover - defensive
             skipped.append({"name": name, "reason": str(e)})

--- a/frontend/src/components/DocumentViewer/DocumentPreview.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentPreview.tsx
@@ -133,20 +133,32 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
 
   const [text, setText] = useState<string | null>(null);
   const [textError, setTextError] = useState(false);
+  // A recorded name may lack a usable extension (internal periods), so the
+  // text path can be reached for a file the server actually serves as binary
+  // (e.g. a raw PDF whose conversion failed). Detect that and fall back to the
+  // native iframe instead of rendering raw bytes as gibberish.
+  const [contentIsBinary, setContentIsBinary] = useState(false);
 
   useEffect(() => {
     if (!useInlineText || !sessionId || !documentName || availability !== 'ok') {
       setText(null);
       setTextError(false);
+      setContentIsBinary(false);
       return undefined;
     }
     let cancelled = false;
     setText(null);
     setTextError(false);
+    setContentIsBinary(false);
     unitsAPI
       .getDocumentContentText(sessionId, documentName)
       .then((content) => {
-        if (!cancelled) setText(content);
+        if (cancelled) return;
+        if (content.startsWith('%PDF-') || content.indexOf('\u0000') !== -1) {
+          setContentIsBinary(true);
+        } else {
+          setText(content);
+        }
       })
       .catch(() => {
         if (!cancelled) setTextError(true);
@@ -251,7 +263,7 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
         </div>
       );
     }
-    if (useInlineText) {
+    if (useInlineText && !contentIsBinary) {
       return renderInlineText();
     }
     if (canRenderInline) {


### PR DESCRIPTION
## Problem
Uploading source documents via the 'Upload source documents' action saved the raw original to pending_documents/ without conversion. When such a file was previewed, the backend served raw bytes; because recorded names contain internal periods (legal citations) they resolve to no file extension, so the frontend rendered the raw PDF/office bytes as text — gibberish (e.g. '</Length 3508/Filter/FlateDecode>>stream ...').

## Solution
The upload endpoint now converts each file to a lib-readable text form in documents/ via commit_document_to_documents_dir (the same conversion the ingestion pipeline uses), so previews render as text with reliable grounding highlights. As a defensive fallback, the frontend text path detects binary content (%PDF- / NUL byte) and renders the native iframe instead of raw bytes.

## Notes
- Consistent with serving extracted text for grounding fidelity across all upload paths.
- Makes the (unmerged) react-pdf PDF-highlight feature redundant for these flows.

## Verify
- python -m py_compile backend/app/api/routes/units.py
- ( cd frontend && npx tsc --noEmit ) clean
- git apply --ignore-whitespace --check passes on current main