### PR TITLE
feat(workspace): show skipped-documents banner in the Data view

### DIFF
--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -42,6 +42,7 @@ import ScheMatiQMonitor from '@/components/ScheMatiQMonitor/ScheMatiQMonitor';
 import DocumentViewer from '@/components/DocumentViewer/DocumentViewer';
 import DocumentPreview from '@/components/DocumentViewer/DocumentPreview';
 import DocumentUpload from '@/components/DocumentUpload/DocumentUpload';
+import SkippedDocumentsBanner from '@/components/DataTable/SkippedDocumentsBanner';
 import { ViewModeToggle } from '@/components/ViewMode/ViewModeToggle';
 import MissingDocumentsSection from '@/components/SchemaEditor/MissingDocumentsSection';
 import TableFeedbackWidget from '@/components/TableFeedbackWidget/TableFeedbackWidget';
@@ -753,6 +754,12 @@ function Workspace() {
     [sessionId, toast],
   );
 
+  // Documents that produced no observation unit during extraction. Same source
+  // the classic flow reads, so it is populated for both live and loaded sessions.
+  const skippedDocuments = session?.statistics?.skipped_documents ?? [];
+  const skippedTotalDocuments =
+    (session?.statistics?.total_documents ?? session?.statistics?.total_rows ?? 0) + skippedDocuments.length;
+
   const dataGridNode = (
     <div className="workspace-grid-wrap">
       <SpreadsheetSurface
@@ -865,6 +872,15 @@ function Workspace() {
                 {showSourcePanel ? 'Hide source' : 'Show source document'}
               </Button>
               <span style={{ flex: 1 }} />
+            </div>
+          )}
+          {activeSheet === 'data' && skippedDocuments.length > 0 && (
+            <div style={{ flex: '0 0 auto', padding: '0 8px' }}>
+              <SkippedDocumentsBanner
+                skippedDocuments={skippedDocuments}
+                totalDocuments={skippedTotalDocuments}
+                observationUnitName={session?.observation_unit?.name}
+              />
             </div>
           )}
           {activeSheet === 'stats' ? (


### PR DESCRIPTION
## Problem
In the classic flow, documents that produced no observation unit were shown in a banner outside the table with the reason (LLM explanation). The new Workspace flow (now the default) dropped this: skipped documents just silently disappear from the data with no explanation.

## Solution
Reuse the existing components/DataTable/SkippedDocumentsBanner. Source skipped_documents and totals from session.statistics (the same source classic reads, populated for both live and loaded sessions; the Stats sheet already uses session.statistics). Render it below the Data toolbar, above the grid, only when there are skipped documents.

## Verify
- Fresh clone of main: git apply --ignore-whitespace --check passes.
- ( cd frontend && npx tsc --noEmit ) exits 0.
- Manual QA: load a saved project with skipped documents, open Data - the amber banner appears above the grid ('N of M documents skipped'); Show details lists each document and its reason.