### PR TITLE
fix(documents): preserve prior skipped documents when adding more

### DIFF
--- a/backend/app/services/upload_document_processor.py
+++ b/backend/app/services/upload_document_processor.py
@@ -408,8 +408,17 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             # Recompute statistics from merged data
             try:
                 skipped_detail = extraction_result.get("skipped_documents", []) if extraction_result else []
-                skipped_documents = [SkippedDocumentInfo(**d) for d in skipped_detail]
-                
+                new_skipped = [SkippedDocumentInfo(**d) for d in skipped_detail]
+
+                # Statistics is rebuilt from scratch here, so merge the skips from
+                # earlier runs with this batch's skips; otherwise adding documents
+                # would drop the documents skipped by the original extraction.
+                prior_skipped = (session.statistics.skipped_documents or []) if session.statistics else []
+                merged_skipped = {s.document: s for s in prior_skipped}
+                for s in new_skipped:
+                    merged_skipped[s.document] = s
+                skipped_documents = list(merged_skipped.values())
+
                 statistics = self._compute_statistics_from_data(session_id, session, skipped_documents)
                 if statistics:
                     session.statistics = statistics


### PR DESCRIPTION
## Problem
skipped_documents lives in session.statistics, which is rebuilt on every operation. The add-documents flow rebuilt it with only the new batch's skips, dropping documents skipped by the original extraction. After adding documents, the skipped-documents banner lost the earlier entries.

## Solution
Merge prior (session.statistics.skipped_documents) with the new batch, deduped by document name, before recomputing statistics - mirroring how continue-discovery already preserves them. Keeps skipped_documents in statistics (its correct home, next to totals/completeness and what all readers use).

## Verify
- Fresh clone of main: git apply --ignore-whitespace --check passes.
- python -m py_compile backend/app/services/upload_document_processor.py succeeds.
- Manual QA: open a project with a skipped document, add more documents via the Documents tab; after processing the banner still lists the originally skipped document plus any new skips.

## Note
If a skipped document is later removed from the project, its entry is not reconciled against the current document set on rebuild (pre-existing edge, not introduced here). Full reconciliation would be a separate change.