### PR TITLE
feat(reference): external reference documents available to the chat agent

### DIFF
--- a/backend/app/api/routes/reference.py
+++ b/backend/app/api/routes/reference.py
@@ -1,0 +1,118 @@
+"""API endpoints for external reference documents attached to a session.
+
+Reference documents are supplementary lookup material (e.g. a spreadsheet that
+maps each judge to the president who appointed them). They are distinct from the
+source documents that define observation units: a reference document never yields
+rows, it is extra context the chat assistant (and, later, value extraction) may
+consult. The extracted text is stored inline on the session.
+"""
+
+import logging
+from typing import List
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from pydantic import BaseModel
+
+from app.services import session_manager, websocket_manager
+from app.services import reference_document_service as refsvc
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["reference"])
+
+
+class ReferenceDocumentInfo(BaseModel):
+    """Reference document metadata (without the full text body)."""
+    id: str
+    filename: str
+    char_count: int
+    truncated: bool
+
+
+class ReferenceDocumentList(BaseModel):
+    session_id: str
+    reference_documents: List[ReferenceDocumentInfo]
+
+
+def _to_info(ref) -> ReferenceDocumentInfo:
+    return ReferenceDocumentInfo(
+        id=ref.id,
+        filename=ref.filename,
+        char_count=ref.char_count,
+        truncated=ref.truncated,
+    )
+
+
+async def _broadcast_updated(session_id: str, session) -> None:
+    try:
+        await websocket_manager.broadcast_to_session(
+            session_id,
+            {
+                "type": "reference_documents_updated",
+                "data": {
+                    "reference_documents": [
+                        _to_info(r).model_dump()
+                        for r in refsvc.list_reference_documents(session)
+                    ]
+                },
+            },
+        )
+    except Exception:  # broadcasting is best-effort; never fail the request on it
+        logger.debug("Failed to broadcast reference update for %s", session_id, exc_info=True)
+
+
+@router.get("/{session_id}", response_model=ReferenceDocumentList)
+async def list_reference_documents(session_id: str) -> ReferenceDocumentList:
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return ReferenceDocumentList(
+        session_id=session_id,
+        reference_documents=[_to_info(r) for r in refsvc.list_reference_documents(session)],
+    )
+
+
+@router.post("/{session_id}/upload", response_model=ReferenceDocumentInfo)
+async def upload_reference_document(
+    session_id: str, file: UploadFile = File(...)
+) -> ReferenceDocumentInfo:
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    filename = file.filename or "reference"
+    raw = await file.read()
+    if not raw:
+        raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
+    try:
+        ref = refsvc.build_reference_document(filename, raw)
+    except refsvc.UnsupportedReferenceFormat as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except refsvc.ReferenceExtractionError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - unexpected conversion failure
+        logger.error("Reference extraction failed for %s: %s", filename, exc, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to process reference file") from exc
+
+    refsvc.add_reference_document(session, ref)
+    session_manager.update_session(session)
+    await _broadcast_updated(session_id, session)
+    logger.info(
+        "Added reference document %s (%s, %d chars) to session %s",
+        ref.id, filename, ref.char_count, session_id,
+    )
+    return _to_info(ref)
+
+
+@router.delete("/{session_id}/{reference_id}")
+async def delete_reference_document(session_id: str, reference_id: str) -> dict:
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    removed = refsvc.remove_reference_document(session, reference_id)
+    if not removed:
+        raise HTTPException(status_code=404, detail="Reference document not found")
+    session_manager.update_session(session)
+    await _broadcast_updated(session_id, session)
+    return {"status": "success", "removed": reference_id}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -45,6 +45,7 @@ from app.api.routes.observation_unit import router as observation_unit_router
 from app.api.routes.units import router as units_router
 from app.api.routes.feedback import router as feedback_router
 from app.api.routes.chat import router as chat_router
+from app.api.routes.reference import router as reference_router
 from app.core.config import (
     API_TITLE, API_DESCRIPTION, API_VERSION,
     ALLOWED_ORIGINS, DEFAULT_HOST, DEFAULT_PORT,
@@ -120,6 +121,7 @@ app.include_router(observation_unit_router, prefix="/api/observation-unit", tags
 app.include_router(units_router, prefix="/api/units", tags=["units"])
 app.include_router(feedback_router, prefix="/api/feedback", tags=["feedback"])
 app.include_router(chat_router, prefix="/api/chat", tags=["chat"])
+app.include_router(reference_router, prefix="/api/reference", tags=["reference"])
 
 logger = logging.getLogger(__name__)
 logger.info(

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -141,6 +141,28 @@ class SessionMetadata(BaseModel):
     # Suppress partial data-collection archive when stop is only preparing rediscovery.
     skip_stop_data_collection: bool = False
 
+class ReferenceDocument(BaseModel):
+    """A user-supplied external reference document attached to a session.
+
+    Unlike the source documents that define observation units (one row per
+    document/unit), a reference document is *supplementary* external information
+    (e.g. a lookup table mapping judges to the president who appointed them).
+    Its text is made available to the chat assistant — and, in a later step, to
+    value extraction — as additional context, clearly labelled as external so it
+    is never mistaken for a source document that yields rows.
+
+    The extracted text is stored inline on the session so it persists through the
+    normal session storage backend (local filesystem or Supabase) without a
+    separate file-path convention.
+    """
+    id: str
+    filename: str
+    content: str  # Plain-text representation of the uploaded file
+    char_count: int = 0
+    truncated: bool = False  # True if content was capped at the size limit
+    uploaded_at: datetime = Field(default_factory=datetime.now)
+
+
 class SkippedDocumentInfo(BaseModel):
     """Metadata for a document that was skipped during extraction."""
     document: str
@@ -179,6 +201,8 @@ class VisualizationSession(BaseModel):
     modification_history: List[ModificationAction] = Field(default_factory=list)  # Schema modification log
     # Observation unit tracking
     observation_unit: Optional[ObservationUnitInfo] = None  # What constitutes a single row
+    # External reference documents (supplementary lookup material, not row sources)
+    reference_documents: List[ReferenceDocument] = Field(default_factory=list)
     # Privacy / data collection
     opt_out_data_collection: bool = False  # User opted out of research data archival
     write_artifacts: Optional[bool] = None  # If True, write debug artifacts like skip rationales

--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -32,6 +32,7 @@ Terminology (do not confuse these):
 - Observation unit: the entity each table row represents (Observation Unit tab). Tools: get_observation_unit, edit_observation_unit.
 - Schema columns: fields in the data table (Schema tab). Tools: get_schema, edit_column, add_column, delete_column.
 - Table rows: individual instances of the observation unit. Tools: preview_data, update_cell, add_unit, remove_unit.
+- Reference documents: optional external lookup material the user attached (e.g. a spreadsheet mapping each judge to the president who appointed them). They are NOT source documents and do NOT define rows; they are supplementary context. Tools: list_reference_sources, read_reference_source.
 
 Rules:
 - Call read tools before edits: get_schema for columns, get_observation_unit for the row entity definition.
@@ -39,6 +40,7 @@ Rules:
 - edit_column can update a column's name, definition, and/or rationale (why the column matters / how to extract it). When the user asks to add or change a rationale, pass the `rationale` argument — do not claim it is unsupported. Confirm WHICH column they mean from get_schema before editing, and never edit several columns unless the user explicitly asked for all of them.
 - After edit_observation_unit or schema definition changes (edit_column, add_column, delete_column), existing table values may be stale. Offer reextract to refresh values from documents, or run_schematiq / continue_discovery when the user wants schema rediscovery.
 - Manual update_cell edits do not require re-extraction unless the user asks to repopulate from documents.
+- When a question may depend on information not in the source documents (e.g. external attributes of an entity), call list_reference_sources to see if the user attached a relevant reference document, then read_reference_source to consult it. You may also combine it with your own knowledge. If a reference document contains an attribute that is not yet a column and looks useful, you may suggest add_column for it.
 - Cheap tools run immediately. Expensive tools (reextract, reprocess, continue_discovery, run_schematiq) require user confirmation.
 - Reply concisely in plain English after completing the requested work.
 """

--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -33,6 +33,10 @@ from .tool_registry import TOOL_BY_NAME
 
 logger = logging.getLogger(__name__)
 
+# Max characters of a reference document returned by read_reference_source. Kept
+# below the tool-result truncation budget so the body is never dropped wholesale.
+READ_REFERENCE_CHAT_BUDGET = 6000
+
 
 class ToolExecutor:
   async def execute(
@@ -211,6 +215,61 @@ class ToolExecutor:
           "warnings": warnings,
           "column_count": len(session.columns),
           "missing_definitions": missing_definitions,
+      }
+
+  async def _handle_list_reference_sources(
+      self, session_id: str, session_mode: str, args: dict[str, Any]
+  ) -> dict[str, Any]:
+      session = session_manager.get_session(session_id)
+      if not session:
+          raise ValueError("Session not found")
+      from app.services import reference_document_service as refsvc
+
+      refs = refsvc.list_reference_documents(session)
+      return {
+          "status": "success",
+          "count": len(refs),
+          "reference_sources": [
+              {
+                  "id": ref.id,
+                  "filename": ref.filename,
+                  "char_count": ref.char_count,
+                  "truncated": ref.truncated,
+              }
+              for ref in refs
+          ],
+      }
+
+  async def _handle_read_reference_source(
+      self, session_id: str, session_mode: str, args: dict[str, Any]
+  ) -> dict[str, Any]:
+      session = session_manager.get_session(session_id)
+      if not session:
+          raise ValueError("Session not found")
+      reference_id = (args.get("reference_id") or "").strip()
+      if not reference_id:
+          raise ValueError("reference_id is required")
+      from app.services import reference_document_service as refsvc
+
+      ref = refsvc.get_reference_document(session, reference_id)
+      if not ref:
+          raise ValueError(f"Reference document '{reference_id}' not found")
+      # Cap the returned text so the whole result stays within the chat
+      # tool-result budget. truncate_result drops an oversized string value
+      # outright, which would hand the model an empty body; clip it here instead
+      # and flag that more text exists. The full document is still used during
+      # value extraction.
+      content = ref.content
+      clipped = len(content) > READ_REFERENCE_CHAT_BUDGET
+      if clipped:
+          content = content[:READ_REFERENCE_CHAT_BUDGET]
+      return {
+          "status": "success",
+          "id": ref.id,
+          "filename": ref.filename,
+          "char_count": ref.char_count,
+          "content_clipped": clipped,
+          "content": content,
       }
 
   async def _handle_add_column(

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -114,6 +114,45 @@ def _all_tools() -> list[ToolSpec]:
             handler="get_validation",
         ),
         ToolSpec(
+            name="list_reference_sources",
+            description=(
+                "List the external reference documents the user attached to this "
+                "session — supplementary lookup material such as a spreadsheet that "
+                "maps entities to extra attributes (e.g. each judge to the president "
+                "who appointed them). These are NOT the source documents that define "
+                "rows; they are additional external context. Use this to discover "
+                "what external information is available before answering a question or "
+                "proposing a new column. Returns each reference's id, filename and "
+                "size; call read_reference_source to read one."
+            ),
+            parameters=EMPTY_PARAMS,
+            cost_class="cheap",
+            handler="list_reference_sources",
+        ),
+        ToolSpec(
+            name="read_reference_source",
+            description=(
+                "Read the text of one external reference document by id (get the id "
+                "from list_reference_sources first). Use its content as supplementary "
+                "context to answer the user's question, or to decide whether to "
+                "propose a new schema column. Treat it as external reference "
+                "information, not as a source document that yields observation-unit "
+                "rows."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "reference_id": {
+                        "type": "string",
+                        "description": "Reference document id from list_reference_sources.",
+                    },
+                },
+                "required": ["reference_id"],
+            },
+            cost_class="cheap",
+            handler="read_reference_source",
+        ),
+        ToolSpec(
             name="add_column",
             description="Add a new column to the schema. Values are extracted later via re-extraction.",
             parameters={
@@ -423,6 +462,8 @@ def tool_running_label(tool_name: str) -> str:
         "edit_observation_unit": "Updating observation unit definition",
         "preview_data": "Loading data preview",
         "get_validation": "Validating schema",
+        "list_reference_sources": "Listing reference documents",
+        "read_reference_source": "Reading reference document",
         "add_column": "Adding column",
         "edit_column": "Editing column",
         "delete_column": "Deleting column",

--- a/backend/app/services/reference_document_service.py
+++ b/backend/app/services/reference_document_service.py
@@ -1,0 +1,179 @@
+"""Service for managing external reference documents attached to a session.
+
+A *reference document* is supplementary lookup material the user uploads to help
+answer questions or fill columns — for example, an Excel sheet mapping each judge
+to the president who appointed them. It is deliberately distinct from the *source
+documents* that define observation units (one row per document/unit): a reference
+document never yields rows on its own; it is extra context the assistant may
+consult.
+
+The extracted plain text is stored inline on the session
+(``VisualizationSession.reference_documents``) so it persists through the normal
+session storage backend (local filesystem or Supabase) without introducing a new
+file-path convention that could silently no-op against Supabase.
+"""
+
+from __future__ import annotations
+
+import io
+import tempfile
+import uuid
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from app.models.session import ReferenceDocument, VisualizationSession
+
+# Cap stored text so a single reference doc can't bloat the session blob
+# unboundedly (the session is serialized on every update).
+MAX_REFERENCE_CHARS = 200_000
+
+# File types we can turn into useful text. Tabular and text-native formats are
+# handled in-process; pdf/docx reuse the existing document_conversion helpers.
+TEXT_NATIVE_EXTENSIONS = {".txt", ".md", ".markdown", ".json"}
+CSV_EXTENSIONS = {".csv"}
+TSV_EXTENSIONS = {".tsv"}
+EXCEL_EXTENSIONS = {".xlsx", ".xls"}
+PDF_EXTENSIONS = {".pdf"}
+DOCX_EXTENSIONS = {".docx"}
+
+SUPPORTED_EXTENSIONS = (
+    TEXT_NATIVE_EXTENSIONS
+    | CSV_EXTENSIONS
+    | TSV_EXTENSIONS
+    | EXCEL_EXTENSIONS
+    | PDF_EXTENSIONS
+    | DOCX_EXTENSIONS
+)
+
+
+class UnsupportedReferenceFormat(ValueError):
+    """Raised when a reference document's file type can't be converted to text."""
+
+
+class ReferenceExtractionError(RuntimeError):
+    """Raised when a supported file type fails to convert (corrupt/empty/etc.)."""
+
+
+def _decode_text(raw: bytes) -> str:
+    text = raw.decode("utf-8", errors="replace")
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _excel_to_text(raw: bytes) -> str:
+    """Render every sheet of a workbook as CSV under a labelled header."""
+    import pandas as pd  # local import: pandas is heavy and only needed here
+
+    buf = io.BytesIO(raw)
+    # dtype=str keeps values verbatim (no float coercion of e.g. years/ids).
+    sheets = pd.read_excel(buf, sheet_name=None, dtype=str)
+    parts: List[str] = []
+    for name, df in sheets.items():
+        df = df.fillna("")
+        parts.append(f"## Sheet: {name}\n{df.to_csv(index=False)}".rstrip())
+    text = "\n\n".join(parts).strip()
+    if not text:
+        raise ReferenceExtractionError("Workbook contained no readable cells.")
+    return text
+
+
+def _converted_text_via_tempfile(filename: str, raw: bytes, converter) -> str:
+    """Run a (input_path, output_dir) -> (ok, msg) converter over in-memory bytes."""
+    safe_name = Path(filename).name or "reference"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        in_path = tmp_dir / safe_name
+        in_path.write_bytes(raw)
+        out_dir = tmp_dir / "out"
+        out_dir.mkdir()
+        ok, msg = converter(in_path, out_dir)
+        if not ok:
+            raise ReferenceExtractionError(msg)
+        out_path = out_dir / (in_path.stem + ".txt")
+        if not out_path.exists():
+            raise ReferenceExtractionError(f"Converter produced no output: {msg}")
+        return out_path.read_text(encoding="utf-8", errors="replace").strip()
+
+
+def extract_text(filename: str, raw: bytes) -> Tuple[str, bool]:
+    """Convert an uploaded reference file to plain text.
+
+    Returns ``(text, truncated)`` where ``truncated`` is True if the text was
+    capped at ``MAX_REFERENCE_CHARS``.
+
+    Raises ``UnsupportedReferenceFormat`` for unknown extensions and
+    ``ReferenceExtractionError`` when a supported type fails to convert.
+    """
+    ext = Path(filename).suffix.lower()
+
+    if ext in TEXT_NATIVE_EXTENSIONS or ext in CSV_EXTENSIONS or ext in TSV_EXTENSIONS:
+        # Already text/tabular text; keep verbatim, just normalise line endings.
+        text = _decode_text(raw)
+    elif ext in EXCEL_EXTENSIONS:
+        text = _excel_to_text(raw)
+    elif ext in PDF_EXTENSIONS:
+        from app.services.document_conversion.convert_to_txt import convert_pdf_to_txt
+
+        text = _converted_text_via_tempfile(filename, raw, convert_pdf_to_txt)
+    elif ext in DOCX_EXTENSIONS:
+        from app.services.document_conversion.convert_to_txt import convert_docx_to_txt
+
+        text = _converted_text_via_tempfile(filename, raw, convert_docx_to_txt)
+    else:
+        raise UnsupportedReferenceFormat(
+            f"Unsupported reference file type '{ext or filename}'. Supported: "
+            + ", ".join(sorted(SUPPORTED_EXTENSIONS))
+        )
+
+    text = text.strip()
+    if not text:
+        raise ReferenceExtractionError("No text could be extracted from the file.")
+
+    truncated = False
+    if len(text) > MAX_REFERENCE_CHARS:
+        text = text[:MAX_REFERENCE_CHARS]
+        truncated = True
+    return text, truncated
+
+
+def build_reference_document(filename: str, raw: bytes) -> ReferenceDocument:
+    """Create a ReferenceDocument (with extracted text) from uploaded bytes."""
+    text, truncated = extract_text(filename, raw)
+    return ReferenceDocument(
+        id=str(uuid.uuid4()),
+        filename=filename,
+        content=text,
+        char_count=len(text),
+        truncated=truncated,
+    )
+
+
+def list_reference_documents(session: VisualizationSession) -> List[ReferenceDocument]:
+    return list(session.reference_documents or [])
+
+
+def get_reference_document(
+    session: VisualizationSession, ref_id: str
+) -> Optional[ReferenceDocument]:
+    for ref in session.reference_documents or []:
+        if ref.id == ref_id:
+            return ref
+    return None
+
+
+def add_reference_document(
+    session: VisualizationSession, ref: ReferenceDocument
+) -> None:
+    """Append a reference document to the session (in place)."""
+    if session.reference_documents is None:  # defensive; default is a list
+        session.reference_documents = []
+    session.reference_documents.append(ref)
+
+
+def remove_reference_document(session: VisualizationSession, ref_id: str) -> bool:
+    """Remove a reference document by id (in place). Returns True if removed."""
+    existing = session.reference_documents or []
+    remaining = [r for r in existing if r.id != ref_id]
+    if len(remaining) == len(existing):
+        return False
+    session.reference_documents = remaining
+    return True

--- a/backend/tests/test_reference_documents.py
+++ b/backend/tests/test_reference_documents.py
@@ -1,0 +1,204 @@
+"""Tests for external reference documents: model, conversion service, chat tools."""
+
+import io
+
+import pytest
+
+from app.models.session import (
+    ColumnInfo,
+    ReferenceDocument,
+    SessionMetadata,
+    SessionStatus,
+    SessionType,
+    VisualizationSession,
+)
+from app.services import reference_document_service as refsvc
+from app.services.chat.tool_executor import ToolExecutor
+from app.services.chat.tool_registry import get_tools_for_context
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+def test_session_reference_documents_roundtrip():
+    """Reference docs survive model_dump() -> VisualizationSession(**) persistence."""
+    ref = ReferenceDocument(id="r1", filename="judges.csv", content="a,b\n1,2", char_count=7)
+    session = VisualizationSession(
+        id="ref-model-roundtrip",
+        type=SessionType.SCHEMATIQ,
+        metadata=SessionMetadata(source="test"),
+        reference_documents=[ref],
+    )
+    restored = VisualizationSession(**session.model_dump())
+    assert len(restored.reference_documents) == 1
+    assert restored.reference_documents[0].filename == "judges.csv"
+    assert restored.reference_documents[0].content == "a,b\n1,2"
+
+
+# ---------------------------------------------------------------------------
+# Text extraction
+# ---------------------------------------------------------------------------
+
+def test_extract_text_csv_passthrough():
+    raw = b"judge,president\r\nSmith,Trump\r\nJones,Obama\r\n"
+    text, truncated = refsvc.extract_text("judges.csv", raw)
+    assert "judge,president" in text
+    assert "Smith,Trump" in text
+    assert "\r" not in text  # CRLF normalised
+    assert truncated is False
+
+
+def test_extract_text_xlsx():
+    pd = pytest.importorskip("pandas")
+    pytest.importorskip("openpyxl")
+    df = pd.DataFrame({"judge": ["Smith", "Jones"], "president": ["Trump", "Obama"]})
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False, sheet_name="mapping")
+    text, truncated = refsvc.extract_text("judges.xlsx", buf.getvalue())
+    assert "Sheet: mapping" in text
+    assert "judge" in text and "president" in text
+    assert "Smith" in text and "Trump" in text
+    assert truncated is False
+
+
+def test_extract_text_unsupported_extension():
+    with pytest.raises(refsvc.UnsupportedReferenceFormat):
+        refsvc.extract_text("archive.zip", b"PK\x03\x04")
+
+
+def test_extract_text_empty_raises():
+    with pytest.raises(refsvc.ReferenceExtractionError):
+        refsvc.extract_text("empty.txt", b"   \n  ")
+
+
+def test_extract_text_truncates_at_cap(monkeypatch):
+    monkeypatch.setattr(refsvc, "MAX_REFERENCE_CHARS", 10)
+    text, truncated = refsvc.extract_text("big.txt", b"x" * 50)
+    assert len(text) == 10
+    assert truncated is True
+
+
+# ---------------------------------------------------------------------------
+# Session helpers
+# ---------------------------------------------------------------------------
+
+def _session(sid: str) -> VisualizationSession:
+    return VisualizationSession(
+        id=sid, type=SessionType.SCHEMATIQ, metadata=SessionMetadata(source="test")
+    )
+
+
+def test_add_list_get_remove_reference():
+    session = _session("ref-helpers")
+    ref = refsvc.build_reference_document("judges.csv", b"judge,president\nSmith,Trump")
+    refsvc.add_reference_document(session, ref)
+
+    assert len(refsvc.list_reference_documents(session)) == 1
+    assert refsvc.get_reference_document(session, ref.id) is ref
+    assert refsvc.get_reference_document(session, "nope") is None
+
+    assert refsvc.remove_reference_document(session, ref.id) is True
+    assert refsvc.list_reference_documents(session) == []
+    assert refsvc.remove_reference_document(session, ref.id) is False
+
+
+# ---------------------------------------------------------------------------
+# Chat tools
+# ---------------------------------------------------------------------------
+
+def test_reference_tools_present_in_schematiq_and_load():
+    for mode in ("schematiq", "load"):
+        names = {t.name for t in get_tools_for_context("s1", mode)}
+        assert "list_reference_sources" in names
+        assert "read_reference_source" in names
+
+
+@pytest.fixture
+def executor() -> ToolExecutor:
+    return ToolExecutor()
+
+
+@pytest.fixture
+def session_with_reference(session_manager_fixture):
+    session_manager = session_manager_fixture
+    session = VisualizationSession(
+        id="ref-chat-session",
+        type=SessionType.SCHEMATIQ,
+        status=SessionStatus.COMPLETED,
+        metadata=SessionMetadata(source="test"),
+        columns=[ColumnInfo(name="Judge", definition="Judge name")],
+    )
+    ref = refsvc.build_reference_document(
+        "appointments.csv", b"judge,president\nSmith,Trump\nJones,Obama"
+    )
+    refsvc.add_reference_document(session, ref)
+    session_manager.create_session(session)
+    return session, ref
+
+
+@pytest.mark.asyncio
+async def test_list_reference_sources_tool(executor, session_with_reference):
+    session, ref = session_with_reference
+    result = await executor.execute("list_reference_sources", session.id, "schematiq", {})
+    assert result["count"] == 1
+    entry = result["reference_sources"][0]
+    assert entry["id"] == ref.id
+    assert entry["filename"] == "appointments.csv"
+    assert "content" not in entry  # listing must not dump full bodies
+
+
+@pytest.mark.asyncio
+async def test_read_reference_source_tool(executor, session_with_reference):
+    session, ref = session_with_reference
+    result = await executor.execute(
+        "read_reference_source", session.id, "schematiq", {"reference_id": ref.id}
+    )
+    assert result["filename"] == "appointments.csv"
+    assert "Smith,Trump" in result["content"]
+
+
+@pytest.mark.asyncio
+async def test_read_reference_source_missing_id(executor, session_with_reference):
+    session, _ = session_with_reference
+    with pytest.raises(ValueError, match="reference_id is required"):
+        await executor.execute("read_reference_source", session.id, "schematiq", {})
+
+
+@pytest.mark.asyncio
+async def test_read_reference_source_large_content_survives_truncation(
+    executor, session_manager_fixture
+):
+    """A reference bigger than the chat budget must still return usable content.
+
+    Regression: truncate_result drops an oversized string value outright, so the
+    handler must pre-clip content to survive."""
+    from app.services.chat.tool_executor import READ_REFERENCE_CHAT_BUDGET
+
+    session_manager = session_manager_fixture
+    big = "judge_{i},president_{i}\n".format(i="X") * 2000  # well over 8 KB
+    session = VisualizationSession(
+        id="ref-large-session",
+        type=SessionType.SCHEMATIQ,
+        status=SessionStatus.COMPLETED,
+        metadata=SessionMetadata(source="test"),
+    )
+    ref = refsvc.build_reference_document("big.csv", big.encode("utf-8"))
+    refsvc.add_reference_document(session, ref)
+    session_manager.create_session(session)
+
+    result = await executor.execute(
+        "read_reference_source", session.id, "schematiq", {"reference_id": ref.id}
+    )
+    assert result.get("content"), "content must not be dropped by truncation"
+    assert len(result["content"]) <= READ_REFERENCE_CHAT_BUDGET
+    assert result["content_clipped"] is True
+
+
+@pytest.mark.asyncio
+async def test_read_reference_source_unknown_id(executor, session_with_reference):
+    session, _ = session_with_reference
+    with pytest.raises(ValueError, match="not found"):
+        await executor.execute(
+            "read_reference_source", session.id, "schematiq", {"reference_id": "nope"}
+        )


### PR DESCRIPTION
Lets users attach an external reference document (CSV/TSV/XLSX/TXT/MD/JSON/PDF/DOCX) to a session as supplementary lookup material, distinct from source documents that define observation units. Adds the ReferenceDocument model + session field (stored inline, storage-backend agnostic), a conversion service, upload/list/delete routes under /api/reference, and two cheap chat tools (list_reference_sources, read_reference_source) plus a system-prompt note so the agent consults the reference when answering questions or proposing columns. Backend only; frontend attach button (PR 2) and extraction-prompt injection (PR 3) follow. 15 new tests; full backend suite green.