### PR TITLE
feat(reference): use attached reference documents during value extraction

### DIFF
--- a/backend/app/services/pipeline/value_extraction.py
+++ b/backend/app/services/pipeline/value_extraction.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 from app.services import schematiq_thread_pool
 from app.services.pipeline.callbacks import create_value_extracted_callback, create_warning_callback
+from app.services.reference_context import build_reference_context
 from app.models.session import SkippedDocumentInfo
 
 from schematiq.core.schema import Schema
@@ -72,6 +73,8 @@ async def run_value_extraction(
     on_value_extracted = create_value_extracted_callback(ws_mixin, session_id, loop)
     on_warning = create_warning_callback(ws_manager, session_id, loop)
 
+    reference_context = build_reference_context(session)
+
     extraction_result = {}
 
     def should_stop():
@@ -93,6 +96,7 @@ async def run_value_extraction(
             should_stop=should_stop,
             on_warning=on_warning,
             write_skip_rationale_artifact=write_artifacts,
+            reference_context=reference_context,
         )
         return extraction_result
 

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -27,6 +27,7 @@ from app.core.logging_utils import set_session_context
 
 # ScheMatiQ library imports
 from schematiq.value_extraction.main import build_table_jsonl
+from app.services.reference_context import build_reference_context
 from schematiq.core.llm_backends import GeminiLLM
 from schematiq.core.model_specs import ModelNames
 from schematiq.core import utils as schematiq_utils
@@ -1350,6 +1351,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                         should_stop=should_stop,  # Allow graceful stop
                         known_units=known_units if known_units else None,
                         write_skip_rationale_artifact=session.write_artifacts,
+                        reference_context=build_reference_context(session),
                     )
 
                 await asyncio.get_event_loop().run_in_executor(schematiq_thread_pool, run_extraction)

--- a/backend/app/services/reference_context.py
+++ b/backend/app/services/reference_context.py
@@ -1,0 +1,39 @@
+"""Build the external-reference context string passed into value extraction.
+
+A session may carry external reference documents (supplementary lookup material,
+e.g. a spreadsheet mapping each judge to the president who appointed them). This
+helper concatenates their extracted text into a single labelled blob that the
+extraction pipeline injects into each per-document prompt as supplementary
+context — clearly marked as external so it never yields observation-unit rows.
+
+Reads ``session.reference_documents`` defensively via ``getattr`` so this module
+is safe even where that field is not present on the session model.
+"""
+
+from typing import Optional
+
+# Guard so a single oversized reference can't blow up the extraction prompt.
+MAX_REFERENCE_CONTEXT_CHARS = 200_000
+
+
+def build_reference_context(session) -> Optional[str]:
+    """Return the combined reference text for a session, or None if there is none."""
+    refs = getattr(session, "reference_documents", None) or []
+    if not refs:
+        return None
+
+    parts = []
+    for ref in refs:
+        filename = getattr(ref, "filename", "reference")
+        content = getattr(ref, "content", "") or ""
+        if not content.strip():
+            continue
+        parts.append(f"--- Reference document: {filename} ---\n{content}")
+
+    if not parts:
+        return None
+
+    combined = "\n\n".join(parts)
+    if len(combined) > MAX_REFERENCE_CONTEXT_CHARS:
+        combined = combined[:MAX_REFERENCE_CONTEXT_CHARS]
+    return combined

--- a/backend/tests/test_reference_extraction_injection.py
+++ b/backend/tests/test_reference_extraction_injection.py
@@ -1,0 +1,75 @@
+"""Tests for injecting external reference context into value extraction.
+
+Covers the prompt builder injection, the threading through PaperProcessor /
+TableBuilder, and the backend build_reference_context helper.
+"""
+
+from app.services.reference_context import build_reference_context
+from schematiq.value_extraction.utils.prompt_builder import PromptBuilder
+
+
+COLUMNS = [{"column": "President", "definition": "Appointing president"}]
+
+
+def test_prompt_has_no_reference_block_without_context():
+    messages = PromptBuilder().build_val_messages("q", "Title", "body", COLUMNS, mode="all")
+    assert "EXTERNAL_REFERENCE" not in messages[1]["content"]
+
+
+def test_prompt_injects_reference_block_after_paper_text():
+    pb = PromptBuilder(reference_context="judge,president\nSmith,Trump")
+    content = pb.build_val_messages("q", "Title", "body", COLUMNS, mode="all")[1]["content"]
+    assert "<EXTERNAL_REFERENCE>" in content and "</EXTERNAL_REFERENCE>" in content
+    assert "Smith,Trump" in content
+    # The external reference must come after the source paper text, not replace it.
+    assert content.index("</PAPER_TEXT>") < content.index("<EXTERNAL_REFERENCE>")
+
+
+def test_prompt_injects_reference_in_one_by_one_mode():
+    pb = PromptBuilder(reference_context="ref data")
+    content = pb.build_val_messages("q", "Title", "body", COLUMNS, mode="one_by_one")[1][
+        "content"
+    ]
+    assert "<EXTERNAL_REFERENCE>" in content
+
+
+def test_reference_context_threads_through_table_builder():
+    """PromptBuilder built by the processor must carry the run's reference context
+    when set, and default to None otherwise."""
+    from schematiq.value_extraction.core.table_builder import TableBuilder
+
+    tb = TableBuilder(llm=None, reference_context="ctx-123")
+    assert tb.paper_processor.prompt_builder.reference_context == "ctx-123"
+
+    assert TableBuilder(llm=None).paper_processor.prompt_builder.reference_context is None
+
+
+# --- backend helper ---------------------------------------------------------
+
+class _Ref:
+    def __init__(self, filename, content):
+        self.filename = filename
+        self.content = content
+
+
+class _Session:
+    def __init__(self, refs):
+        self.reference_documents = refs
+
+
+def test_build_reference_context_none_when_empty():
+    assert build_reference_context(_Session([])) is None
+    assert build_reference_context(object()) is None  # missing attribute -> None
+
+
+def test_build_reference_context_concatenates_labelled():
+    ctx = build_reference_context(
+        _Session([_Ref("a.csv", "judge,pres\nSmith,Trump"), _Ref("b.txt", "extra")])
+    )
+    assert "a.csv" in ctx and "Smith,Trump" in ctx
+    assert "b.txt" in ctx and "extra" in ctx
+
+
+def test_build_reference_context_skips_blank():
+    ctx = build_reference_context(_Session([_Ref("blank.txt", "   ")]))
+    assert ctx is None

--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -93,6 +93,7 @@ class PaperProcessor:
         on_value_extracted: Optional[OnValueExtractedCallback] = None,
         should_stop: Optional[ShouldStopCallback] = None,
         on_warning: Optional[OnWarningCallback] = None,
+        reference_context: Optional[str] = None,
     ):
         self.llm = llm
         self.cache = cache or LLMCache()
@@ -100,7 +101,7 @@ class PaperProcessor:
         self.json_parser = JSONResponseParser()
         self.unit_parser = UnitIdentificationParser()
         self.text_processor = TextProcessor()
-        self.prompt_builder = PromptBuilder()
+        self.prompt_builder = PromptBuilder(reference_context=reference_context)
         self.on_value_extracted = on_value_extracted
         self.should_stop = should_stop
         self.on_warning = on_warning

--- a/schematiq-lib/schematiq/value_extraction/core/table_builder.py
+++ b/schematiq-lib/schematiq/value_extraction/core/table_builder.py
@@ -39,7 +39,8 @@ class TableBuilder:
                  should_stop: Optional[ShouldStopCallback] = None,
                  on_warning: Optional[OnWarningCallback] = None,
                  on_document_started: Optional[Callable[[str], None]] = None,
-                 write_skip_rationale_artifact: Optional[bool] = None):
+                 write_skip_rationale_artifact: Optional[bool] = None,
+                 reference_context: Optional[str] = None):
         self.llm = llm
         self.retriever = retriever
         self.cache = cache or LLMCache()
@@ -54,7 +55,7 @@ class TableBuilder:
             else lib_config.write_artifacts
         )
         # Pass should_stop and on_warning to PaperProcessor for fine-grained stop checking and warning reporting
-        self.paper_processor = PaperProcessor(llm, self.cache, retriever, on_value_extracted, should_stop, on_warning)
+        self.paper_processor = PaperProcessor(llm, self.cache, retriever, on_value_extracted, should_stop, on_warning, reference_context=reference_context)
         self.row_manager = RowDataManager()
         self._stopped = False  # Track if we stopped early
         self._skipped_documents: List[SkippedDocument] = []

--- a/schematiq-lib/schematiq/value_extraction/main.py
+++ b/schematiq-lib/schematiq/value_extraction/main.py
@@ -39,6 +39,7 @@ def build_table_jsonl(
     known_units: Optional[Dict[str, List[str]]] = None,
     on_document_started: Optional[Callable[[str], None]] = None,
     write_skip_rationale_artifact: Optional[bool] = None,
+    reference_context: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Extract values from papers and write to JSONL, grouping by row names and merging intelligently.
@@ -79,6 +80,7 @@ def build_table_jsonl(
         on_warning=on_warning,
         on_document_started=on_document_started,
         write_skip_rationale_artifact=write_skip_rationale_artifact,
+        reference_context=reference_context,
     )
     table_builder.build_table_jsonl_multi_dirs(
         schema_path,

--- a/schematiq-lib/schematiq/value_extraction/utils/prompt_builder.py
+++ b/schematiq-lib/schematiq/value_extraction/utils/prompt_builder.py
@@ -10,8 +10,10 @@ from ..config.prompts import SYSTEM_PROMPT_VAL, SYSTEM_PROMPT_VAL_STRICT
 class PromptBuilder:
     """Builds prompts for value extraction LLM calls."""
 
-    def __init__(self):
-        pass
+    def __init__(self, reference_context: str | None = None):
+        # Optional external reference text injected into every value-extraction
+        # prompt as supplementary lookup material (never a source document).
+        self.reference_context = reference_context
 
     def build_val_messages(
         self,
@@ -75,6 +77,20 @@ class PromptBuilder:
             </ALREADY_EXTRACTED_VALUES>
             """.strip()
 
+        reference_block = ""
+        if self.reference_context:
+            reference_block = (
+                "<EXTERNAL_REFERENCE>\n"
+                "The text below is an EXTERNAL REFERENCE supplied separately by the "
+                "user. It is NOT the source document and does NOT define observation "
+                "units - never create a row from it. Use it only as supplementary "
+                "lookup information (for example, to map an entity named in the source "
+                "document to an attribute recorded here) when it is relevant to a "
+                "requested column; otherwise ignore it.\n"
+                f"{self.reference_context}\n"
+                "</EXTERNAL_REFERENCE>"
+            )
+
         user_prompt = f"""
             <QUESTION>
             {query}
@@ -91,6 +107,8 @@ class PromptBuilder:
             <PAPER_TEXT>
             {paper_text}
             </PAPER_TEXT>
+
+            {reference_block}
             """.strip()
 
         system = SYSTEM_PROMPT_VAL_STRICT if strict else SYSTEM_PROMPT_VAL


### PR DESCRIPTION
Threads an optional reference_context (default None, fully additive) from build_table_jsonl through TableBuilder and PaperProcessor into PromptBuilder, which injects a labelled <EXTERNAL_REFERENCE> block after the source paper text so extraction can fill columns from external lookup material without treating it as a row source. Adds build_reference_context helper (reads session.reference_documents defensively) wired into initial extraction and reextraction. Depends on the reference-documents backend PR for the session field. 8 new tests; full backend suite green.