### PR TITLE
feat: use Gemini 3.5 Flash-Lite for value extraction

### DIFF
--- a/schematiq-lib/schematiq/core/model_specs.py
+++ b/schematiq-lib/schematiq/core/model_specs.py
@@ -38,6 +38,7 @@ class ModelNames:
     GEMINI_25_PRO = "gemini-2.5-pro"
     GEMINI_31_FLASH_LITE = "gemini-3.1-flash-lite"
     GEMINI_35_FLASH = "gemini-3.5-flash"
+    GEMINI_35_FLASH_LITE = "gemini-3.5-flash-lite"
     GEMINI_31_PRO_PREVIEW = "gemini-3.1-pro-preview"
     GEMINI_15_FLASH = "gemini-1.5-flash"
 
@@ -61,8 +62,8 @@ class ModelNames:
 
     # Role-based defaults
     DEFAULT_SCHEMA_CREATION = GEMINI_35_FLASH
-    DEFAULT_VALUE_EXTRACTION = GEMINI_31_FLASH_LITE
-    DEFAULT_RELEASE_EXTRACTION = GEMINI_31_FLASH_LITE
+    DEFAULT_VALUE_EXTRACTION = GEMINI_35_FLASH_LITE
+    DEFAULT_RELEASE_EXTRACTION = GEMINI_35_FLASH_LITE
     DEFAULT_EVALUATION = GEMINI_15_FLASH
     DEFAULT_TOGETHER = LLAMA_33_70B_TURBO
     DEFAULT_OPENAI = GPT_41
@@ -77,6 +78,7 @@ MODEL_SPECS: Dict[str, Dict[str, ModelSpec]] = {
         ModelNames.GEMINI_25_PRO: ModelSpec(1_048_576, 65_535, supports_thinking=True),
         ModelNames.GEMINI_31_FLASH_LITE: ModelSpec(1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True),
         ModelNames.GEMINI_35_FLASH: ModelSpec(1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True),
+        ModelNames.GEMINI_35_FLASH_LITE: ModelSpec(1_048_576, 64_000, supports_thinking=True, uses_thinking_level=True),
         ModelNames.GEMINI_31_PRO_PREVIEW: ModelSpec(1_000_000, 64_000, supports_thinking=True, uses_thinking_level=True),
         "_default": ModelSpec(1_000_000, 32_000, supports_thinking=False),
     },

--- a/schematiq-lib/schematiq/core/model_specs.py
+++ b/schematiq-lib/schematiq/core/model_specs.py
@@ -78,7 +78,7 @@ MODEL_SPECS: Dict[str, Dict[str, ModelSpec]] = {
         ModelNames.GEMINI_25_PRO: ModelSpec(1_048_576, 65_535, supports_thinking=True),
         ModelNames.GEMINI_31_FLASH_LITE: ModelSpec(1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True),
         ModelNames.GEMINI_35_FLASH: ModelSpec(1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True),
-        ModelNames.GEMINI_35_FLASH_LITE: ModelSpec(1_048_576, 64_000, supports_thinking=True, uses_thinking_level=True),
+        ModelNames.GEMINI_35_FLASH_LITE: ModelSpec(1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True),
         ModelNames.GEMINI_31_PRO_PREVIEW: ModelSpec(1_000_000, 64_000, supports_thinking=True, uses_thinking_level=True),
         "_default": ModelSpec(1_000_000, 32_000, supports_thinking=False),
     },


### PR DESCRIPTION
## Problem
Value extraction used gemini-3.1-flash-lite. We want to move to gemini-3.5-flash-lite (stronger price/performance, higher throughput for extraction).

## Solution
Add the GEMINI_35_FLASH_LITE model name and spec (1M context, 64k max output, supports_thinking + uses_thinking_level), and point DEFAULT_VALUE_EXTRACTION and DEFAULT_RELEASE_EXTRACTION at it. As a Gemini 3.x model it is handled by the thinking-level translation from #235 (uses thinking_level, drops deprecated sampling params), avoiding the 400 INVALID_ARGUMENT class of errors.

## Notes
- Schema creation model unchanged (gemini-3.5-flash).
- Chat model (chat/deps.py) unchanged; separate concern.
- max_output_tokens set to 64k per Google's launch specs for the 3.5 Flash-Lite family.

## Verify
- python -m py_compile schematiq-lib/schematiq/core/model_specs.py
- Confirmed defaults resolve to gemini-3.5-flash-lite and the spec loads (1M/64k/thinking_level)
- git apply --ignore-whitespace --check passes on current main