### PR TITLE
feat(schema-discovery): smart token-aware batching with overflow resilience

### DIFF
--- a/backend/app/models/schematiq.py
+++ b/backend/app/models/schematiq.py
@@ -62,6 +62,7 @@ class ScheMatiQConfig(BaseModel):
     upload_pending: bool = False  # True when documents will be uploaded after session creation
     max_keys_schema: int = 100
     documents_batch_size: int = 4
+    batch_strategy: str = "smart"  # "smart" = token-aware bin-packing; "fixed" = legacy fixed-size slices
     initial_schema_path: Optional[str] = None  # Path to schema file
     initial_schema: Optional[List[InitialSchemaColumn]] = None  # Inline schema definition
     initial_observation_unit: Optional[InitialObservationUnit] = None  # Pre-configured observation unit

--- a/backend/app/services/pipeline/batch_execution.py
+++ b/backend/app/services/pipeline/batch_execution.py
@@ -1,0 +1,253 @@
+"""Resilience for schema-discovery batches that exceed model token limits.
+
+Two failure modes exist when a batch is too large (verified against
+``schematiq/core/llm_backends.py``):
+
+1. **Input overflow** — the assembled prompt exceeds the model context window.
+   The provider SDK raises (Gemini: ``400 INVALID_ARGUMENT``). In the base
+   pipeline this propagates out of ``generate_schema`` and crashes the entire
+   discovery run, losing all progress.
+
+2. **Output truncation** — the response hits ``max_output_tokens`` and is cut
+   off silently (Gemini logs ``finish_reason=MAX_TOKENS`` but does not raise).
+   This module does not detect mode 2 directly (it produces no exception), but
+   splitting a batch shrinks the input, which in turn reduces the schema the
+   model must emit, indirectly lowering mode-2 risk.
+
+Strategy: when a batch fails with a token-limit error, split it in half and
+retry each half independently (recursively). A batch of a single document that
+still fails cannot be split — it is skipped for schema discovery, logged, and
+recorded as an artifact so nothing fails silently and we retain a record for
+later improvement. Value extraction is a separate phase and is unaffected: a
+document skipped here is still available downstream.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Substrings that identify a token / context-window overflow across providers.
+# Matched case-insensitively against the string form of the raised exception.
+# Kept deliberately broad; a false positive only triggers an (harmless) split
+# retry, while a false negative would let the original crash through.
+_TOKEN_LIMIT_MARKERS: Tuple[str, ...] = (
+    "context length",
+    "context window",
+    "maximum context",
+    "context_length_exceeded",
+    "too many tokens",
+    "input token count",
+    "exceeds the maximum number of tokens",
+    "request payload size",
+    "reduce the length",
+    "string too long",
+    "token count",
+    "prompt is too long",
+)
+
+# Provider error codes that, combined with token-ish wording, indicate overflow.
+_INVALID_ARG_MARKERS: Tuple[str, ...] = (
+    "invalid_argument",
+    "400",
+    "invalidrequesterror",
+    "bad request",
+)
+
+
+def is_token_limit_error(err: BaseException) -> bool:
+    """Return True if an exception looks like an input/context token overflow.
+
+    Detection is heuristic and provider-agnostic: it inspects the stringified
+    exception for known overflow wording, or for a generic invalid-argument /
+    400 error that also mentions tokens. Rate-limit and auth errors are
+    explicitly excluded so we never misclassify them as splittable overflow.
+    """
+    text = str(err).lower()
+
+    # Never treat quota / rate-limit / auth as splittable overflow.
+    if any(m in text for m in ("rate limit", "resource_exhausted", "quota", "429", "api key", "unauthenticated")):
+        return False
+
+    if any(m in text for m in _TOKEN_LIMIT_MARKERS):
+        return True
+
+    # Generic 400 / invalid argument that also references tokens.
+    if any(m in text for m in _INVALID_ARG_MARKERS) and "token" in text:
+        return True
+
+    return False
+
+
+def _log_skipped_batch(
+    work_dir: Optional[Path],
+    session_id: str,
+    filenames: List[str],
+    reason: str,
+    error: str,
+) -> None:
+    """Append a skipped-batch record to a per-session JSON artifact.
+
+    Writes ``schema_discovery_skips.json`` under ``work_dir/session_id``. The
+    file holds a list of records; each has the filenames, a reason, the raw
+    error string, and a timestamp. Failure to write the artifact is logged but
+    never raised — resilience code must not itself become a failure source.
+    """
+    logger.warning(
+        "Schema discovery skipped batch (%s): %s | error: %s",
+        reason, filenames, error[:500],
+    )
+
+    if not work_dir:
+        return
+
+    try:
+        session_dir = work_dir / session_id
+        session_dir.mkdir(parents=True, exist_ok=True)
+        skip_file = session_dir / "schema_discovery_skips.json"
+
+        records: List[Dict[str, Any]] = []
+        if skip_file.exists():
+            try:
+                with open(skip_file) as f:
+                    loaded = json.load(f)
+                    if isinstance(loaded, list):
+                        records = loaded
+            except Exception:
+                # Corrupt or unreadable prior file: start fresh rather than fail.
+                records = []
+
+        records.append({
+            "timestamp": datetime.now().isoformat(),
+            "filenames": filenames,
+            "reason": reason,
+            "error": error[:2000],
+        })
+
+        with open(skip_file, "w") as f:
+            json.dump(records, f, indent=2)
+        logger.debug("Recorded skipped batch artifact (%d total) at %s", len(records), skip_file)
+    except Exception as e:
+        logger.warning("Could not write skipped-batch artifact: %s", e)
+
+
+async def generate_schema_with_split(
+    *,
+    session_id: str,
+    batch_docs: List[str],
+    batch_names: List[str],
+    run_generate: Callable[[List[str]], Any],
+    is_stop_requested: Callable[[str], bool],
+    work_dir: Optional[Path] = None,
+    notify: Optional[Callable[[str, str], Any]] = None,
+    _depth: int = 0,
+) -> Optional[Any]:
+    """Run schema generation for a batch, splitting on token-limit failure.
+
+    Args:
+        session_id: Session identifier (for stop checks and logging).
+        batch_docs: Documents in this batch.
+        batch_names: Filenames aligned with ``batch_docs``.
+        run_generate: Async callable that takes a list of documents and returns
+            the generated schema (or raises). This wraps content selection +
+            ScheMatiQ.generate_schema for the given documents. It must be safe
+            to call repeatedly with document subsets.
+        is_stop_requested: Stop-signal check.
+        work_dir: Working directory for skip artifacts.
+        notify: Optional async callable ``(level, message)`` used to surface a
+            user-facing note (e.g. in the monitor) when a batch is split or a
+            document is skipped. Failures in the callback are swallowed.
+        _depth: Internal recursion depth (for logging).
+
+    Returns:
+        The generated schema for the batch, a merged schema across split halves,
+        or ``None`` if the entire batch had to be skipped.
+    """
+    async def _notify(level: str, message: str) -> None:
+        if notify is None:
+            return
+        try:
+            result = notify(level, message)
+            if hasattr(result, "__await__"):
+                await result
+        except Exception as notify_err:
+            logger.debug("notify callback failed: %s", notify_err)
+
+    if is_stop_requested(session_id):
+        return None
+
+    try:
+        return await run_generate(batch_docs)
+    except Exception as e:
+        if not is_token_limit_error(e):
+            # Not an overflow — preserve original behavior: propagate.
+            raise
+
+        # Single document that still overflows: cannot split. Skip it.
+        if len(batch_docs) <= 1:
+            _log_skipped_batch(
+                work_dir, session_id, batch_names,
+                reason="single_document_exceeds_token_limit",
+                error=str(e),
+            )
+            skipped_name = batch_names[0] if batch_names else "a document"
+            await _notify(
+                "warning",
+                f"Skipped '{skipped_name}' during schema discovery: it exceeds the "
+                f"model's token limit and cannot be split further. It will still be "
+                f"available for value extraction.",
+            )
+            return None
+
+        # Split in half and retry each half independently.
+        mid = len(batch_docs) // 2
+        logger.warning(
+            "Batch of %d docs hit token limit (depth=%d); splitting into %d + %d and retrying",
+            len(batch_docs), _depth, mid, len(batch_docs) - mid,
+        )
+        if _depth == 0:
+            await _notify(
+                "warning",
+                f"A batch of {len(batch_docs)} documents exceeded the model's token "
+                f"limit and was split into smaller batches automatically. Consider "
+                f"lowering the fixed batch size if this recurs.",
+            )
+
+        left = await generate_schema_with_split(
+            session_id=session_id,
+            batch_docs=batch_docs[:mid],
+            batch_names=batch_names[:mid],
+            run_generate=run_generate,
+            is_stop_requested=is_stop_requested,
+            work_dir=work_dir,
+            notify=notify,
+            _depth=_depth + 1,
+        )
+        right = await generate_schema_with_split(
+            session_id=session_id,
+            batch_docs=batch_docs[mid:],
+            batch_names=batch_names[mid:],
+            run_generate=run_generate,
+            is_stop_requested=is_stop_requested,
+            work_dir=work_dir,
+            notify=notify,
+            _depth=_depth + 1,
+        )
+
+        if left is None:
+            return right
+        if right is None:
+            return left
+
+        # Merge the two half-schemas. Schema objects expose .merge(other).
+        try:
+            return left.merge(right)
+        except Exception as merge_err:
+            logger.error("Failed to merge split-batch schemas: %s", merge_err)
+            # Fall back to the left half rather than losing everything.
+            return left

--- a/backend/app/services/pipeline/batch_planner.py
+++ b/backend/app/services/pipeline/batch_planner.py
@@ -1,0 +1,247 @@
+"""Batch planning for schema discovery.
+
+Schema discovery processes documents in batches. Historically batches were
+built by naive fixed-size slicing in original order:
+
+    batches = [documents[i:i+batch_size] for i in range(0, len(documents), batch_size)]
+
+That ignores document length. A single long document can dominate an LLM
+context window while a batch of short documents wastes most of it, producing
+more API calls than necessary and inconsistent per-batch content density.
+
+This module packs documents into batches by estimated input token size using
+First-Fit-Decreasing bin-packing, so each batch fills the available context
+window budget without exceeding it. A per-batch document count cap keeps
+individual batches from mixing too many documents (which can dilute schema
+signal), and oversized single documents are placed alone in their own batch.
+
+Two strategies are supported:
+
+- ``"smart"`` (default): token-aware FFD bin-packing described above.
+- ``"fixed"``: exact legacy behavior — fixed-size contiguous slices in the
+  original order. Kept for reproducibility and as an escape hatch.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Conservative fallbacks used only when the config / model specs do not provide
+# a value. These mirror the fallbacks already used in schema_discovery.py.
+_DEFAULT_CONTEXT_WINDOW = 8192
+_DEFAULT_SCHEMA_SYSTEM_PROMPT_TOKENS = 700
+_DEFAULT_SCHEMA_USER_TEMPLATE_TOKENS = 50
+
+# Reserve fraction of the context window for model output + drift so we never
+# plan a batch that fills the whole window. Output for schema discovery is a
+# JSON schema; reserving a third of the window is deliberately conservative.
+_OUTPUT_RESERVE_FRACTION = 0.35
+
+# Safety ceiling on documents per batch in smart mode. This is NOT a tuning
+# knob the user sets — smart mode deliberately packs as many documents as fit
+# under the token budget, because seeing more documents together yields a richer
+# schema. The ceiling only guards against pathologically large batches (e.g.
+# thousands of tiny documents) that would produce an unwieldy single prompt.
+_SMART_SAFETY_MAX_DOCS_PER_BATCH = 30
+
+
+@dataclass
+class PlannedBatch:
+    """A single planned batch of documents.
+
+    ``documents`` and ``filenames`` are aligned lists. ``estimated_tokens`` is
+    the summed input-token estimate for the batch (documents only, excluding
+    fixed prompt overhead).
+    """
+
+    documents: List[str]
+    filenames: List[str]
+    estimated_tokens: int
+
+
+def _count_tokens(text: str) -> int:
+    """Count tokens for a single document.
+
+    Reuses the tiktoken-based counter from schematiq-lib when importable so the
+    estimate matches the cost estimator. Falls back to a chars/4 heuristic,
+    identical to the library's own fallback.
+    """
+    try:
+        from schematiq.core.cost_estimator import count_tokens as _lib_count_tokens
+        return _lib_count_tokens(text)
+    except Exception:
+        if not text:
+            return 0
+        return len(text) // 4
+
+
+def _measured_prompt_overhead() -> int:
+    """Fixed per-call prompt overhead (system prompt + user template).
+
+    Uses measured values from schematiq-lib when available, otherwise
+    conservative constants.
+    """
+    try:
+        from schematiq.core.cost_estimator import _measure_prompt_tokens
+        measured = _measure_prompt_tokens()
+        return (
+            measured.get("schema_system_prompt", _DEFAULT_SCHEMA_SYSTEM_PROMPT_TOKENS)
+            + measured.get("schema_user_template", _DEFAULT_SCHEMA_USER_TEMPLATE_TOKENS)
+        )
+    except Exception:
+        return _DEFAULT_SCHEMA_SYSTEM_PROMPT_TOKENS + _DEFAULT_SCHEMA_USER_TEMPLATE_TOKENS
+
+
+def _resolve_context_window(schematiq_config: Dict[str, Any]) -> int:
+    """Resolve the schema-creation context window from config, with fallback."""
+    backend = schematiq_config.get("schema_creation_backend", {}) or {}
+    ctx = backend.get("context_window_size")
+    if isinstance(ctx, int) and ctx > 0:
+        return ctx
+    return _DEFAULT_CONTEXT_WINDOW
+
+
+def _batch_token_budget(schematiq_config: Dict[str, Any]) -> int:
+    """Compute the per-batch document-token budget.
+
+    budget = context_window - prompt_overhead - output_reserve
+
+    The result is floored at a small positive value so planning always
+    terminates even with pathological configs.
+    """
+    context_window = _resolve_context_window(schematiq_config)
+    prompt_overhead = _measured_prompt_overhead()
+    output_reserve = int(context_window * _OUTPUT_RESERVE_FRACTION)
+    budget = context_window - prompt_overhead - output_reserve
+    return max(budget, 256)
+
+
+def _fixed_batches(
+    documents: List[str],
+    filenames: List[str],
+    batch_size: int,
+) -> List[PlannedBatch]:
+    """Legacy fixed-size contiguous slicing in original order."""
+    batch_size = max(1, int(batch_size))
+    planned: List[PlannedBatch] = []
+    for i in range(0, len(documents), batch_size):
+        batch_docs = documents[i:i + batch_size]
+        batch_names = filenames[i:i + batch_size]
+        planned.append(
+            PlannedBatch(
+                documents=batch_docs,
+                filenames=batch_names,
+                estimated_tokens=sum(_count_tokens(d) for d in batch_docs),
+            )
+        )
+    return planned
+
+
+def _smart_batches(
+    documents: List[str],
+    filenames: List[str],
+    token_budget: int,
+    max_docs_per_batch: int,
+) -> List[PlannedBatch]:
+    """First-Fit-Decreasing bin-packing by estimated token size.
+
+    Documents larger than ``token_budget`` are placed alone in their own batch
+    (they cannot be split here). Remaining documents are sorted descending by
+    token count and placed into the first batch that has room for both the
+    tokens and the document-count cap.
+    """
+    # Pair each document with its estimated token count and original filename.
+    items: List[Tuple[int, str, str]] = [
+        (_count_tokens(doc), doc, name)
+        for doc, name in zip(documents, filenames)
+    ]
+
+    # Decreasing order: largest documents placed first (FFD).
+    items.sort(key=lambda t: t[0], reverse=True)
+
+    bins: List[PlannedBatch] = []
+
+    for tokens, doc, name in items:
+        # Oversized document: give it its own batch. It still gets processed;
+        # downstream retrieval/truncation handles content that exceeds the
+        # window. Packing it with others would only make things worse.
+        if tokens >= token_budget:
+            bins.append(PlannedBatch(documents=[doc], filenames=[name], estimated_tokens=tokens))
+            continue
+
+        placed = False
+        for b in bins:
+            fits_tokens = b.estimated_tokens + tokens <= token_budget
+            fits_count = len(b.documents) < max_docs_per_batch
+            # Skip bins already holding an oversized solo document.
+            solo_oversized = len(b.documents) == 1 and b.estimated_tokens >= token_budget
+            if fits_tokens and fits_count and not solo_oversized:
+                b.documents.append(doc)
+                b.filenames.append(name)
+                b.estimated_tokens += tokens
+                placed = True
+                break
+
+        if not placed:
+            bins.append(PlannedBatch(documents=[doc], filenames=[name], estimated_tokens=tokens))
+
+    return bins
+
+
+def plan_batches(
+    documents: List[str],
+    filenames: List[str],
+    schematiq_config: Dict[str, Any],
+) -> List[PlannedBatch]:
+    """Plan document batches for schema discovery.
+
+    Args:
+        documents: Document text contents.
+        filenames: Corresponding filenames (aligned with ``documents``).
+        schematiq_config: Full ScheMatiQ configuration dict. Reads
+            ``batch_strategy`` ("smart" | "fixed"), ``documents_batch_size``,
+            and ``schema_creation_backend.context_window_size``.
+
+    Returns:
+        List of PlannedBatch. Empty input yields an empty list.
+    """
+    if not documents:
+        return []
+
+    if len(documents) != len(filenames):
+        # Defensive: never let misaligned inputs corrupt batching. Fall back to
+        # the shorter length so downstream zip semantics are preserved.
+        n = min(len(documents), len(filenames))
+        logger.warning(
+            "plan_batches received misaligned inputs (%d docs, %d names); truncating to %d",
+            len(documents), len(filenames), n,
+        )
+        documents = documents[:n]
+        filenames = filenames[:n]
+
+    strategy = (schematiq_config.get("batch_strategy") or "smart").lower()
+    batch_size = schematiq_config.get("documents_batch_size", 1) or 1
+
+    if strategy == "fixed":
+        planned = _fixed_batches(documents, filenames, batch_size)
+        logger.debug(
+            "Batch planning (fixed) - %d docs, batch_size=%d, %d batches",
+            len(documents), batch_size, len(planned),
+        )
+        return planned
+
+    # smart (default): pack as many documents as fit under the token budget.
+    # documents_batch_size is intentionally ignored here — it only governs the
+    # fixed strategy. Smart mode maximizes documents per batch (richer schema
+    # signal) up to a high safety ceiling.
+    token_budget = _batch_token_budget(schematiq_config)
+    planned = _smart_batches(documents, filenames, token_budget, _SMART_SAFETY_MAX_DOCS_PER_BATCH)
+    logger.debug(
+        "Batch planning (smart) - %d docs, token_budget=%d, safety_max_docs/batch=%d, %d batches",
+        len(documents), token_budget, _SMART_SAFETY_MAX_DOCS_PER_BATCH, len(planned),
+    )
+    return planned

--- a/backend/app/services/pipeline/config_handler.py
+++ b/backend/app/services/pipeline/config_handler.py
@@ -116,6 +116,7 @@ def convert_config_to_schematiq_format(
         "docs_path": resolved_docs_paths[0] if len(resolved_docs_paths) == 1 else resolved_docs_paths,
         "max_keys_schema": config.max_keys_schema,
         "documents_batch_size": config.documents_batch_size,
+        "batch_strategy": config.batch_strategy,
         "output_path": str(session_dir / "discovered_schema.json"),
         "document_randomization_seed": config.document_randomization_seed,
         "skip_value_extraction": config.skip_value_extraction,

--- a/backend/app/services/pipeline/schema_discovery.py
+++ b/backend/app/services/pipeline/schema_discovery.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from datetime import datetime
 
 from app.services import schematiq_thread_pool
+from app.services.pipeline.batch_execution import generate_schema_with_split
 
 from schematiq.core import schematiq as ScheMatiQ
 from schematiq.core.schema import Schema, Column, ObservationUnit
@@ -56,14 +57,19 @@ async def run_schema_discovery(
     initial_schema = _load_initial_schema(schematiq_config, query, max_keys)
     current_schema = initial_schema or Schema(query=query, columns=[], max_keys=max_keys)
 
-    batch_size = schematiq_config.get("documents_batch_size", 1)
     convergence_threshold = schematiq_config.get("convergence_threshold") or 5
     unchanged_count = 0
 
-    batches = [documents[i:i+batch_size] for i in range(0, len(documents), batch_size)]
-    filename_batches = [filenames[i:i+batch_size] for i in range(0, len(filenames), batch_size)]
+    from app.services.pipeline.batch_planner import plan_batches
 
-    logger.debug("Document batching - %d docs, batch_size=%d, %d batches", len(documents), batch_size, len(batches))
+    planned_batches = plan_batches(documents, filenames, schematiq_config)
+    batches = [pb.documents for pb in planned_batches]
+    filename_batches = [pb.filenames for pb in planned_batches]
+
+    strategy = (schematiq_config.get("batch_strategy") or "smart").lower()
+    logger.debug(
+        "Document batching (%s) - %d docs, %d batches", strategy, len(documents), len(batches)
+    )
 
     evolution = SchemaEvolution(snapshots=[], column_sources={})
     cumulative_docs = 0
@@ -194,26 +200,71 @@ async def run_schema_discovery(
             )
         completion_done = True
 
-        # Generate schema for this iteration
-        logger.debug("[%s] Offloading generate_schema to thread pool", session_id)
-        try:
-            schema_result = await loop.run_in_executor(
+        # Generate schema for this iteration.
+        # Wrapped in a split-aware runner: if the assembled prompt exceeds the
+        # model's token limit, the batch is split in half and each half retried
+        # (content selection re-runs per subset). A single document that still
+        # overflows is skipped and recorded, rather than crashing discovery.
+        ctx_window = schematiq_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192)
+
+        async def _run_generate(sub_docs):
+            # Re-select relevant content for this (possibly reduced) doc subset,
+            # then generate the schema. On the full batch this reuses the passages
+            # already computed above to avoid a redundant retrieval pass.
+            if sub_docs is batch_docs:
+                sub_content = relevant_content
+            else:
+                sub_content = await loop.run_in_executor(
+                    schematiq_thread_pool,
+                    functools.partial(
+                        ScheMatiQ.select_relevant_content,
+                        docs=sub_docs,
+                        query=query,
+                        retriever=retriever,
+                    )
+                )
+            result = await loop.run_in_executor(
                 schematiq_thread_pool,
                 functools.partial(
                     ScheMatiQ.generate_schema,
-                    passages=relevant_content,
+                    passages=sub_content,
                     query=query,
                     max_keys_schema=schematiq_config.get("max_keys_schema", 100),
                     current_schema=current_schema,
                     llm=llm,
-                    context_window_size=schematiq_config["schema_creation_backend"].get("context_window_size") or getattr(llm, 'context_window_size', 8192),
+                    context_window_size=ctx_window,
                 )
             )
-            new_schema = schema_result[0] if isinstance(schema_result, tuple) else schema_result
-            logger.debug("Generated schema with %d columns", len(new_schema.columns))
+            return result[0] if isinstance(result, tuple) else result
+
+        async def _notify_split(level: str, message: str):
+            if ws_manager:
+                await ws_manager.broadcast_log(session_id, {"level": level, "message": message})
+
+        try:
+            new_schema = await generate_schema_with_split(
+                session_id=session_id,
+                batch_docs=batch_docs,
+                batch_names=batch_names,
+                run_generate=_run_generate,
+                is_stop_requested=is_stop_requested,
+                work_dir=work_dir,
+                notify=_notify_split,
+            )
         except Exception as e:
             logger.error("ERROR in generate_schema: %s", e)
             raise
+
+        if new_schema is None:
+            # Entire batch was skipped (all documents exceeded the token limit
+            # even when isolated). Already logged and recorded as an artifact.
+            logger.warning(
+                "Batch %d/%d produced no schema (all documents skipped for token limits); continuing",
+                iteration + 1, len(batches),
+            )
+            continue
+
+        logger.debug("Generated schema with %d columns", len(new_schema.columns))
 
         if is_stop_requested(session_id):
             logger.warning("Stop requested after schema generation - saving partial schema")


### PR DESCRIPTION
## Problem
Batches were built by naive fixed-size slicing in original order, ignoring document length, and a single batch that exceeded the model's token limit crashed the entire discovery run, losing all progress.

## Solution
Two additions. (1) A batch planner with a new default 'smart' strategy that packs documents into batches by estimated token size (First-Fit-Decreasing bin-packing) up to a context-window budget, maximizing documents per batch for richer schema signal. 'fixed' reproduces the exact legacy fixed-size behavior. (2) A resilience layer: when a batch's prompt exceeds the token limit the batch is split in half and each half retried; a single document that still overflows is skipped, logged, and recorded to a per-session artifact (schema_discovery_skips.json), and a warning is surfaced to the monitor via the existing log channel. Skipped documents remain available for value extraction. Non-token errors propagate unchanged.

## Verify
- python -m py_compile on all five changed files
- git apply --ignore-whitespace --check on a clean clone
- Unit tests: smart packing respects token budget and ignores documents_batch_size; fixed produces identical contiguous slices; split retries halves; single-doc overflow skips with artifact; non-token errors propagate; monitor notify fires once per top-level split