### PR TITLE
feat(config): batch strategy toggle (smart vs fixed)

### DIFF
--- a/frontend/src/components/AdvancedSettings/AdvancedSettingsFields.tsx
+++ b/frontend/src/components/AdvancedSettings/AdvancedSettingsFields.tsx
@@ -38,6 +38,7 @@ import type { InitialSchemaColumn } from '@/types';
 export interface AdvancedSettingsValue {
   skipValueExtraction: boolean;
   maxKeysSchema: number;
+  batchStrategy: 'smart' | 'fixed';
   documentsBatchSize: number;
   // Developer-mode schema params
   seed: number;
@@ -79,6 +80,7 @@ export const RETRIEVER_DEFAULTS = {
 export const DEFAULT_ADVANCED_SETTINGS: AdvancedSettingsValue = {
   skipValueExtraction: false,
   maxKeysSchema: DEFAULT_MAX_KEYS_SCHEMA,
+  batchStrategy: 'smart',
   documentsBatchSize: DEFAULT_DOCUMENTS_BATCH_SIZE,
   seed: DEFAULT_DOCUMENT_RANDOMIZATION_SEED,
   convergenceThreshold: null,
@@ -183,9 +185,28 @@ export function AdvancedSettingsFields({
             />
           </div>
           <div className="space-y-1">
+            <Label htmlFor="adv-batch-strategy" className="text-xs text-muted-foreground inline-flex items-center gap-1">
+              Batching
+              <InfoTooltip text="How documents are grouped for schema discovery. Smart packs as many documents as fit the model context automatically. Fixed lets you set an exact number per batch." />
+            </Label>
+            <Select
+              value={value.batchStrategy}
+              onValueChange={(strategy) => onChange({ batchStrategy: strategy as 'smart' | 'fixed' })}
+            >
+              <SelectTrigger id="adv-batch-strategy"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="smart">Smart (automatic)</SelectItem>
+                <SelectItem value="fixed">Fixed size</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {value.batchStrategy === 'fixed' ? (
+          <div className="space-y-1">
             <Label htmlFor="adv-batch-size" className="text-xs text-muted-foreground inline-flex items-center gap-1">
-              Batch Size
-              <InfoTooltip text="Documents per schema refinement batch." />
+              Documents per batch
+              <InfoTooltip text="How many documents are analyzed together in each schema refinement step." />
             </Label>
             <Input
               id="adv-batch-size"
@@ -195,9 +216,21 @@ export function AdvancedSettingsFields({
               value={value.documentsBatchSize}
               onChange={(e) => onChange({ documentsBatchSize: parseInt(e.target.value, 10) || DEFAULT_DOCUMENTS_BATCH_SIZE })}
             />
+            <p className="text-xs text-muted-foreground">
+              Analyzing more documents together gives the model more context and usually
+              produces a richer schema. Higher values raise the chance of exceeding the
+              model's token limit; batches that do are split automatically.
+            </p>
           </div>
-          {developerMode && (
-            <>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Documents are grouped automatically to fit as many as possible into each
+            step, giving the model broad context for a richer schema without exceeding
+            token limits.
+          </p>
+        )}
+        {developerMode && (
+          <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1">
                 <Label htmlFor="adv-seed" className="text-xs text-muted-foreground">Seed</Label>
                 <Input
@@ -225,9 +258,8 @@ export function AdvancedSettingsFields({
                   }}
                 />
               </div>
-            </>
-          )}
-        </div>
+          </div>
+        )}
       </div>
 
       <hr />

--- a/frontend/src/pages/ScheMatiQConfig.tsx
+++ b/frontend/src/pages/ScheMatiQConfig.tsx
@@ -59,6 +59,7 @@ const DEFAULT_CONFIG: ScheMatiQConfig = {
   docs_path: [],
   max_keys_schema: DEFAULT_MAX_KEYS_SCHEMA,
   documents_batch_size: DEFAULT_DOCUMENTS_BATCH_SIZE,
+  batch_strategy: 'smart',
   schema_creation_backend: {
     provider: 'gemini',
     model: DEFAULT_SCHEMA_MODEL,
@@ -316,6 +317,7 @@ const ScheMatiQConfigPage = () => {
       docs_path: restoredConfig.docs_path || [],
       max_keys_schema: restoredConfig.max_keys_schema ?? DEFAULT_MAX_KEYS_SCHEMA,
       documents_batch_size: restoredConfig.documents_batch_size ?? DEFAULT_DOCUMENTS_BATCH_SIZE,
+      batch_strategy: restoredConfig.batch_strategy ?? 'smart',
       document_randomization_seed: restoredConfig.document_randomization_seed ?? DEFAULT_DOCUMENT_RANDOMIZATION_SEED,
       convergence_threshold: restoredConfig.convergence_threshold,
       skip_value_extraction: restoredConfig.skip_value_extraction ?? false,
@@ -353,6 +355,7 @@ const ScheMatiQConfigPage = () => {
     const hasAdvancedChanges =
       (restoredConfig.max_keys_schema ?? DEFAULT_MAX_KEYS_SCHEMA) !== DEFAULT_MAX_KEYS_SCHEMA ||
       (restoredConfig.documents_batch_size ?? DEFAULT_DOCUMENTS_BATCH_SIZE) !== DEFAULT_DOCUMENTS_BATCH_SIZE ||
+      (restoredConfig.batch_strategy ?? 'smart') !== 'smart' ||
       (restoredConfig.document_randomization_seed ?? DEFAULT_DOCUMENT_RANDOMIZATION_SEED) !== DEFAULT_DOCUMENT_RANDOMIZATION_SEED ||
       (restoredConfig.convergence_threshold != null && restoredConfig.convergence_threshold !== DEFAULT_CONVERGENCE_THRESHOLD) ||
       restoredConfig.initial_observation_unit ||
@@ -454,6 +457,7 @@ const ScheMatiQConfigPage = () => {
   const advancedValue: AdvancedSettingsValue = useMemo(() => ({
     skipValueExtraction: config.skip_value_extraction ?? false,
     maxKeysSchema: config.max_keys_schema,
+    batchStrategy: config.batch_strategy ?? 'smart',
     documentsBatchSize: config.documents_batch_size,
     seed: config.document_randomization_seed,
     convergenceThreshold: config.convergence_threshold ?? null,
@@ -481,6 +485,7 @@ const ScheMatiQConfigPage = () => {
     if (patch.skipValueExtraction !== undefined) handleConfigChange('skip_value_extraction', patch.skipValueExtraction);
     if (patch.maxKeysSchema !== undefined) handleConfigChange('max_keys_schema', patch.maxKeysSchema);
     if (patch.documentsBatchSize !== undefined) handleConfigChange('documents_batch_size', patch.documentsBatchSize);
+    if (patch.batchStrategy !== undefined) handleConfigChange('batch_strategy', patch.batchStrategy);
     if (patch.seed !== undefined) handleConfigChange('document_randomization_seed', patch.seed);
     if ('convergenceThreshold' in patch) handleConfigChange('convergence_threshold', patch.convergenceThreshold ?? undefined);
     if (patch.reviewObservationUnit !== undefined) handleConfigChange('review_observation_unit', patch.reviewObservationUnit);
@@ -691,6 +696,7 @@ const ScheMatiQConfigPage = () => {
     if (config.query !== '') return true;
     if (config.max_keys_schema !== DEFAULT_MAX_KEYS_SCHEMA) return true;
     if (config.documents_batch_size !== DEFAULT_DOCUMENTS_BATCH_SIZE) return true;
+    if ((config.batch_strategy ?? 'smart') !== 'smart') return true;
     if (config.document_randomization_seed !== DEFAULT_DOCUMENT_RANDOMIZATION_SEED) return true;
     if (config.convergence_threshold != null && config.convergence_threshold !== DEFAULT_CONVERGENCE_THRESHOLD) return true;
     if (config.skip_value_extraction) return true;
@@ -727,6 +733,7 @@ const ScheMatiQConfigPage = () => {
     if (observationUnitMode !== 'auto') parts.push('Custom unit');
     if (config.max_keys_schema !== DEFAULT_MAX_KEYS_SCHEMA ||
         config.documents_batch_size !== DEFAULT_DOCUMENTS_BATCH_SIZE ||
+        (config.batch_strategy ?? 'smart') !== 'smart' ||
         config.document_randomization_seed !== DEFAULT_DOCUMENT_RANDOMIZATION_SEED ||
         (config.convergence_threshold != null && config.convergence_threshold !== DEFAULT_CONVERGENCE_THRESHOLD)) {
       parts.push('Custom params');
@@ -738,7 +745,7 @@ const ScheMatiQConfigPage = () => {
     if (config.retriever) parts.push('Custom retriever');
     if (limitBypassEnabled) parts.push('Bypass enabled');
     return parts;
-  }, [initialSchemaData, initialSchemaPath, observationUnitMode, config.max_keys_schema, config.documents_batch_size, config.document_randomization_seed, config.convergence_threshold, config.schema_creation_backend.provider, config.schema_creation_backend.model, config.retriever, allowLlmConfig, limitBypassEnabled]);
+  }, [initialSchemaData, initialSchemaPath, observationUnitMode, config.max_keys_schema, config.documents_batch_size, config.batch_strategy, config.document_randomization_seed, config.convergence_threshold, config.schema_creation_backend.provider, config.schema_creation_backend.model, config.retriever, allowLlmConfig, limitBypassEnabled]);
 
   return (
     <div className="max-w-4xl mx-auto">

--- a/frontend/src/pages/Workspace/ProjectDetailsDialog.tsx
+++ b/frontend/src/pages/Workspace/ProjectDetailsDialog.tsx
@@ -52,7 +52,10 @@ export function ProjectDetailsDialog({
     { label: 'Schema model', value: config?.schema_creation_backend?.model || '' },
     { label: 'Value provider', value: config?.value_extraction_backend?.provider || '' },
     { label: 'Value model', value: config?.value_extraction_backend?.model || '' },
-    { label: 'Documents batch size', value: config?.documents_batch_size ?? '' },
+    { label: 'Batching', value: (config?.batch_strategy ?? 'smart') === 'fixed' ? 'Fixed size' : 'Smart (automatic)' },
+    ...((config?.batch_strategy ?? 'smart') === 'fixed'
+      ? [{ label: 'Documents per batch', value: config?.documents_batch_size ?? '' }]
+      : []),
     { label: 'Max schema columns', value: config?.max_keys_schema ?? '' },
   ];
 

--- a/frontend/src/pages/Workspace/helpers.ts
+++ b/frontend/src/pages/Workspace/helpers.ts
@@ -183,6 +183,7 @@ export function buildConfig(
     opt_out_data_collection: optOut,
     max_keys_schema: advanced.maxKeysSchema,
     documents_batch_size: advanced.documentsBatchSize,
+    batch_strategy: advanced.batchStrategy,
     schema_creation_backend: {
       provider: advanced.schemaProvider,
       model: advanced.schemaModel,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -242,6 +242,8 @@ export interface ScheMatiQConfig {
   upload_pending?: boolean;
   max_keys_schema: number;
   documents_batch_size: number;
+  /** "smart" = token-aware auto batching (default); "fixed" = user-set batch size */
+  batch_strategy?: 'smart' | 'fixed';
   initial_schema_path?: string;  // Path to schema file
   initial_schema?: InitialSchemaColumn[];  // Inline schema definition
   initial_observation_unit?: InitialObservationUnit;  // Pre-configured observation unit
@@ -772,6 +774,7 @@ export interface ContinueDiscoveryRequest {
   };
   max_keys_schema?: number;
   documents_batch_size?: number;
+  batch_strategy?: 'smart' | 'fixed';
   convergence_threshold?: number;
   document_randomization_seed?: number;
   skip_value_extraction?: boolean;


### PR DESCRIPTION
## Problem
The advanced settings exposed a fixed 'Batch Size' number even though the backend now defaults to smart token-aware batching, which was confusing and gave no way to opt into fixed batching or explain its tradeoff.

## Solution
Replace the batch size number field with a Smart/Fixed toggle. Smart (default) hides the number and explains documents are packed automatically. Fixed reveals the documents-per-batch input plus a note explaining that grouping more documents together yields a richer schema but raises token-limit risk (auto-split on overflow). Wired through both the classic config flow and the Workspace new-project flow; project details reflect the chosen strategy.

## Verify
- npx tsc --noEmit passes clean
- git apply --ignore-whitespace --check on a clean clone