### PR TITLE
fix(ui): portal tooltip content to prevent clipping

### DIFF
--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -12,16 +12,19 @@ const TooltipTrigger = TooltipPrimitive.Trigger;
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-[140] overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
-    )}
-    {...props}
-  />
+>(({ className, sideOffset = 4, collisionPadding = 8, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      collisionPadding={collisionPadding}
+      className={cn(
+        "z-[140] overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 


### PR DESCRIPTION
## Problem
InfoTooltip content rendered inline in the DOM without a portal, so inside dialogs and panels with overflow-y-auto it was clipped by the scroll container instead of floating above it. Radix collision avoidance could not reposition it either. This was visible on the rightmost advanced-settings field, where the tooltip overflowed the panel edge, and affected tooltips inside other dialogs too.

## Solution
Wrap TooltipContent in TooltipPrimitive.Portal so it renders at the document body and escapes overflow clipping, and add collisionPadding so it shifts away from viewport edges. This is a primitive-level fix that applies to every tooltip.

## Verify
- npx tsc --noEmit passes clean
- git apply --ignore-whitespace --check on a clean clone
- Portal and collisionPadding confirmed present in the installed @radix-ui/react-tooltip