### PR TITLE
fix(config): align docs-per-batch field with sibling columns

### DIFF
--- a/frontend/src/components/AdvancedSettings/AdvancedSettingsFields.tsx
+++ b/frontend/src/components/AdvancedSettings/AdvancedSettingsFields.tsx
@@ -202,8 +202,8 @@ export function AdvancedSettingsFields({
           </div>
           {value.batchStrategy === 'fixed' && (
             <div className="space-y-1">
-              <Label htmlFor="adv-batch-size" className="flex items-start gap-1 text-xs text-muted-foreground leading-tight">
-                <span>Docs per batch</span>
+              <Label htmlFor="adv-batch-size" className="text-xs text-muted-foreground inline-flex items-center gap-1">
+                Docs per batch
                 <InfoTooltip text="How many documents are analyzed together in each schema refinement step." />
               </Label>
               <Input


### PR DESCRIPTION
## Problem
The docs-per-batch label used flex items-start with leading-tight (an earlier guard against clipping), while Max Columns and Batching used inline-flex items-center. The differing label box height pushed the number field below the baseline of the other two columns.

## Solution
Now that tooltip content is portaled and the label fits on one line, make the third label identical to its siblings (inline-flex items-center gap-1). All three label boxes share the same height, so the inputs align on one baseline.

## Verify
- npx tsc --noEmit passes clean
- git apply --ignore-whitespace --check on a clean clone