### PR TITLE
fix(ui): base InfoTooltip on Popover instead of Tooltip

### DIFF
--- a/frontend/src/components/InfoTooltip/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip/InfoTooltip.tsx
@@ -1,10 +1,9 @@
-import { useState } from 'react';
 import { HelpCircle } from 'lucide-react';
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
 
 interface InfoTooltipProps {
   text: string;
@@ -12,24 +11,24 @@ interface InfoTooltipProps {
 }
 
 export function InfoTooltip({ text, side = 'top' }: InfoTooltipProps) {
-  const [open, setOpen] = useState(false);
-
   return (
-    <Tooltip open={open} onOpenChange={setOpen}>
-      <TooltipTrigger
+    <Popover>
+      <PopoverTrigger
         type="button"
-        onClick={(e) => {
-          e.preventDefault();
-          setOpen((prev) => !prev);
-        }}
+        onClick={(e) => e.preventDefault()}
         className="inline-flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
         aria-label="More info"
       >
         <HelpCircle className="h-4 w-4" />
-      </TooltipTrigger>
-      <TooltipContent side={side} className="max-w-[280px]">
-        <p>{text}</p>
-      </TooltipContent>
-    </Tooltip>
+      </PopoverTrigger>
+      <PopoverContent
+        side={side}
+        align="center"
+        collisionPadding={8}
+        className="w-auto max-w-[280px] p-3 text-sm font-normal"
+      >
+        {text}
+      </PopoverContent>
+    </Popover>
   );
 }


### PR DESCRIPTION
## Problem
InfoTooltip is click-to-open but was built on Radix Tooltip, which is designed for hover with short content. Used as a click-controlled overlay inside a scrollable dialog with a transformed ancestor, it produced positioning artifacts: content clipped at the panel edge, and after portaling, an extra scrollable region appeared when opened.

## Solution
Rebuild InfoTooltip on Radix Popover, the primitive intended for click-to-open content. It portals correctly and, unlike the hover Tooltip, has proper dismissable-layer and focus handling. Radix Popper defaults (fixed positioning strategy plus avoidCollisions) keep the content within the viewport without growing the document scroll area. Same public API (text, side), so no call sites change. The generic Tooltip primitive is left untouched for genuine hover tooltips.

## Verify
- npx tsc --noEmit passes clean on a fresh clone
- git apply --ignore-whitespace --check on a clean clone
- Confirmed Radix Popper uses strategy:fixed and avoidCollisions by default