### PR TITLE
fix: point missing-docs error to Documents tab

### DIFF
--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -910,11 +910,11 @@ class ReextractionService(WebSocketBroadcasterMixin):
             if missing:
                 raise ValueError(
                     f"{len(missing)} source document(s) are unavailable. "
-                    "Upload them in the Classic Visualizer and try again."
+                    "Add them from the Documents tab, then try again."
                 )
             raise ValueError(
-                "No source documents available. Upload the original source "
-                "documents, then try again."
+                "No source documents available. Add the original source "
+                "documents from the Documents tab, then try again."
             )
 
         return await self.start_reextraction(


### PR DESCRIPTION
## Problem
The re-extraction/reprocess guard told users to upload missing source documents in the Classic Visualizer. Since the Workspace flow is now the default, this points users to the wrong place. Documents can be added directly from the Workspace Documents tab.

## Solution
Update both ValueError messages in start_gated_reextraction to reference the Documents tab instead of the Classic Visualizer.

## Verify
- python -m py_compile backend/app/services/reextraction_service.py
- Trigger reprocess on a session with missing source documents; confirm the chat error now reads "Add them from the Documents tab, then try again."