### PR TITLE
fix(ui): restore InfoTooltip click-to-open

### DIFF
--- a/frontend/src/components/InfoTooltip/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip/InfoTooltip.tsx
@@ -15,7 +15,6 @@ export function InfoTooltip({ text, side = 'top' }: InfoTooltipProps) {
     <Popover>
       <PopoverTrigger
         type="button"
-        onClick={(e) => e.preventDefault()}
         className="inline-flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
         aria-label="More info"
       >


### PR DESCRIPTION
## Problem
The Popover-based InfoTooltip trigger had an onClick handler calling preventDefault, intended to block form submission. On a Radix PopoverTrigger the open toggle fires through that same click event, so preventDefault suppressed it and clicking the info icon did nothing.

## Solution
Remove the onClick preventDefault. type=button already prevents any form submission (and no form wraps these fields), and Radix handles the open toggle internally.

## Verify
- npx tsc --noEmit passes clean
- git apply --ignore-whitespace --check on a clean clone