### PR TITLE
feat(workspace-chat): collapse per-turn tool activity into an expandable group

### DIFF
--- a/frontend/src/pages/Workspace/Workspace.css
+++ b/frontend/src/pages/Workspace/Workspace.css
@@ -637,18 +637,78 @@
   background: hsl(var(--background));
 }
 
-.workspace-chat-tool-log {
-  font-size: 0.85rem;
-  color: hsl(var(--muted-foreground));
-  border-style: dashed;
+/* Collapsible group summarizing the tool activity in an assistant turn. */
+.workspace-chat-tool-group {
+  width: fit-content;
+  max-width: calc(100% - 28px);
+  margin-bottom: 10px;
+  border: 1px dashed hsl(var(--border));
+  border-radius: 8px;
   background: hsl(var(--muted) / 0.35);
+  overflow: hidden;
 }
 
-.workspace-chat-tool-log[data-tool-status="running"] {
+.workspace-chat-tool-group-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 7px 10px;
+  border: 0;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  font-size: 0.85rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.workspace-chat-tool-group-toggle:hover {
+  color: hsl(var(--foreground));
+}
+
+.workspace-chat-tool-group-summary {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-chat-tool-group-chevron {
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+}
+
+.workspace-chat-tool-group-chevron.is-open {
+  transform: rotate(90deg);
+}
+
+.workspace-chat-tool-group[data-tool-status="running"] .workspace-chat-tool-group-summary {
   font-style: italic;
 }
 
-.workspace-chat-tool-log[data-tool-status="error"] {
+.workspace-chat-tool-group[data-tool-status="error"] .workspace-chat-tool-group-toggle {
+  color: hsl(var(--destructive));
+}
+
+.workspace-chat-tool-group-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 4px 10px 10px 24px;
+}
+
+.workspace-chat-tool-group-item {
+  font-size: 0.85rem;
+  color: hsl(var(--muted-foreground));
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.workspace-chat-tool-group-item[data-tool-status="running"] {
+  font-style: italic;
+}
+
+.workspace-chat-tool-group-item[data-tool-status="error"] {
   color: hsl(var(--destructive));
 }
 

--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -19,6 +19,36 @@ import {
 import { formatToolsList, mapChatTurnMessage } from '../helpers';
 import type { PendingChatAction, PendingRerunKind, WorkspaceMessage, WorkspaceSessionMode } from '../types';
 import { ChatMessageBody } from './ChatMessageBody';
+import { ToolActivityGroup } from './ToolActivityGroup';
+
+// Fold a flat message list into render groups so that consecutive tool_log
+// messages collapse into a single expandable block, while text/user messages
+// pass through untouched.
+type ChatRenderItem =
+  | { kind: 'message'; message: WorkspaceMessage }
+  | { kind: 'tool_group'; id: string; logs: WorkspaceMessage[] };
+
+function groupChatMessages(messages: WorkspaceMessage[]): ChatRenderItem[] {
+  const items: ChatRenderItem[] = [];
+  let pending: WorkspaceMessage[] = [];
+
+  const flush = () => {
+    if (pending.length === 0) return;
+    items.push({ kind: 'tool_group', id: `tools-${pending[0].id}`, logs: pending });
+    pending = [];
+  };
+
+  for (const message of messages) {
+    if (message.kind === 'tool_log') {
+      pending.push(message);
+    } else {
+      flush();
+      items.push({ kind: 'message', message });
+    }
+  }
+  flush();
+  return items;
+}
 
 export function ChatPanel({
   sessionId,
@@ -352,16 +382,19 @@ export function ChatPanel({
       )}
 
       <div className="workspace-chat-messages" ref={messagesRef}>
-        {messages.map((message) => (
-          <div
-            key={message.id}
-            className={`workspace-chat-message${message.kind === 'tool_log' ? ' workspace-chat-tool-log' : ''}`}
-            data-role={message.role}
-            data-tool-status={message.toolStatus}
-          >
-            <ChatMessageBody message={message} />
-          </div>
-        ))}
+        {groupChatMessages(messages).map((item) =>
+          item.kind === 'tool_group' ? (
+            <ToolActivityGroup key={item.id} logs={item.logs} />
+          ) : (
+            <div
+              key={item.message.id}
+              className="workspace-chat-message"
+              data-role={item.message.role}
+            >
+              <ChatMessageBody message={item.message} />
+            </div>
+          ),
+        )}
 
         {pendingAction && (
           <div className="rounded-md border bg-muted/30 p-3 text-sm">

--- a/frontend/src/pages/Workspace/chat/ToolActivityGroup.tsx
+++ b/frontend/src/pages/Workspace/chat/ToolActivityGroup.tsx
@@ -1,0 +1,63 @@
+// Collapsible summary of the tool activity within a single assistant turn.
+// Parent: ChatPanel. By default it shows a one-line summary ("Used N tools")
+// and expands on click to reveal each individual tool-log entry.
+
+import { useState } from 'react';
+import { ChevronRight, Loader2, Wrench } from 'lucide-react';
+
+import type { WorkspaceMessage } from '../types';
+import { ChatMessageBody } from './ChatMessageBody';
+
+function summarize(logs: WorkspaceMessage[]): string {
+  const names = Array.from(
+    new Set(logs.map((log) => log.toolName).filter((name): name is string => Boolean(name))),
+  );
+  const count = names.length || logs.length;
+  const noun = count === 1 ? 'step' : 'steps';
+  if (names.length === 1) {
+    return `Ran 1 step (${names[0]})`;
+  }
+  return `Ran ${count} ${noun}`;
+}
+
+export function ToolActivityGroup({ logs }: { logs: WorkspaceMessage[] }) {
+  const [open, setOpen] = useState(false);
+  const running = logs.some((log) => log.toolStatus === 'running');
+  const errored = logs.some((log) => log.toolStatus === 'error');
+  const status = running ? 'running' : errored ? 'error' : 'done';
+
+  return (
+    <div className="workspace-chat-tool-group" data-tool-status={status}>
+      <button
+        type="button"
+        className="workspace-chat-tool-group-toggle"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <ChevronRight
+          className={`workspace-chat-tool-group-chevron h-3.5 w-3.5${open ? ' is-open' : ''}`}
+        />
+        {running ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Wrench className="h-3.5 w-3.5" />
+        )}
+        <span className="workspace-chat-tool-group-summary">{summarize(logs)}</span>
+      </button>
+
+      {open && (
+        <div className="workspace-chat-tool-group-body">
+          {logs.map((log) => (
+            <div
+              key={log.id}
+              className="workspace-chat-tool-group-item"
+              data-tool-status={log.toolStatus}
+            >
+              <ChatMessageBody message={log} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem
Every tool the chat runs is rendered as its own fully-expanded bubble. A single request that fires several tools produces a long list of tool-log bubbles before the final answer, which is noisy and pushes the actual response down. This applies to all chat actions, not only file/column fills.

## Solution
Group consecutive tool_log messages within a turn into a single collapsible block (`ToolActivityGroup`). By default it shows a one-line summary ("Ran N steps") and expands on click to reveal each individual tool log. Text and user messages render unchanged, so the model's final answer stays visible. The group reflects aggregate status (running with spinner / error / done). Purely presentational: no type or backend changes.

## Verify
- `git apply --ignore-whitespace --check` passes on a clean clone.
- `( cd frontend && npx tsc --noEmit )` passes.
- Manual: run a chat request that triggers multiple tools; confirm a single collapsed "Ran N steps" block appears, expands to show all logs, shows a spinner while running, and that the final assistant answer remains visible.