### PR TITLE
feat: use Gemini 3.5 Flash-Lite for chat

### DIFF
--- a/backend/app/services/chat/deps.py
+++ b/backend/app/services/chat/deps.py
@@ -47,7 +47,7 @@ schematiq_runner = ScheMatiQRunner(
     uniprot_enrichment_service=uniprot_enrichment_service,
 )
 
-CHAT_MODEL = "gemini-3.1-flash-lite"
+CHAT_MODEL = "gemini-3.5-flash-lite"
 WORK_DIR = Path("./schematiq_work")
 
 

--- a/frontend/src/constants/llmModels.ts
+++ b/frontend/src/constants/llmModels.ts
@@ -100,6 +100,15 @@ export const LLM_MODELS: LLMModelDefinition[] = [
     contextWindow: 1000000,
   },
   {
+    id: 'gemini-3.5-flash-lite',
+    provider: 'gemini',
+    label: 'Gemini 3.5 Flash Lite',
+    description: 'Fastest, lowest-cost 3.5 model; best value for extraction',
+    cost: 'low',
+    speed: 'very_fast',
+    contextWindow: 1000000,
+  },
+  {
     id: 'gemini-3.5-flash',
     provider: 'gemini',
     label: 'Gemini 3.5 Flash',
@@ -124,8 +133,8 @@ export const LLM_MODELS: LLMModelDefinition[] = [
 
 // ── Default model constants ─────────────────────────────────────────
 export const DEFAULT_SCHEMA_MODEL = 'gemini-3.5-flash';
-export const DEFAULT_EXTRACTION_MODEL = 'gemini-3.1-flash-lite';
-export const DEFAULT_RELEASE_EXTRACTION_MODEL = 'gemini-3.1-flash-lite';
+export const DEFAULT_EXTRACTION_MODEL = 'gemini-3.5-flash-lite';
+export const DEFAULT_RELEASE_EXTRACTION_MODEL = 'gemini-3.5-flash-lite';
 
 // ============================================================================
 // Helper Functions

--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -326,7 +326,7 @@ export function ChatPanel({
           Chat
         </div>
         <div className="flex items-center gap-2">
-          <Badge variant="outline">gemini-3.1-flash-lite</Badge>
+          <Badge variant="outline">gemini-3.5-flash-lite</Badge>
           <Button size="sm" variant="outline" onClick={showToolsList} disabled={busy}>
             Tools
           </Button>


### PR DESCRIPTION
## Problem
Chat used gemini-3.1-flash-lite (hardcoded), and the frontend model constants were stale after extraction moved to gemini-3.5-flash-lite.

## Solution
Set CHAT_MODEL to gemini-3.5-flash-lite, update the chat header badge to match, add a gemini-3.5-flash-lite entry to llmModels, and fix DEFAULT_EXTRACTION_MODEL / DEFAULT_RELEASE_EXTRACTION_MODEL.

## Notes
- In-app lite/regular chat-model selector is intentionally deferred: it needs the model plumbed through the chat request plus backend chat-session recreation on model change, and UI that requires visual verification. Happy to follow up with a dedicated patch or an agent brief.

## Verify
- python -m py_compile backend/app/services/chat/deps.py
- ( cd frontend && npx tsc --noEmit ) clean
- CRLF preserved in llmModels.ts; patch applies cleanly on current main