### PR TITLE
feat(reference): RAG over large reference documents

### DIFF
--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -44,6 +44,7 @@ from ..config.prompts import (
     SYSTEM_PROMPT_VAL_REEXTRACT,
 )
 from ..utils.schema_builder import build_extraction_response_schema
+from ..utils.reference_retrieval import ReferenceRetriever
 from ..utils.excerpt_grounder import ExcerptGrounder
 
 # Type alias for warning callback: (paper_title, warning_type, message) -> None
@@ -63,6 +64,11 @@ FALLBACK_BATCH_SIZE = 3
 # This effectively disables chunking/passage-selection so the entire
 # document is sent together with the schema.
 DISABLE_RETRIEVER = True
+
+# External reference below this size is injected whole into each extraction
+# prompt (cheap, no retrieval). Above it, the reference is indexed once and only
+# the passages relevant to the current unit + columns are injected per prompt.
+REFERENCE_FULL_INJECT_MAX_CHARS = 12000
 
 # When True, use Gemini controlled generation (response_schema) for
 # value extraction. Only applies when the LLM backend is Gemini.
@@ -101,7 +107,16 @@ class PaperProcessor:
         self.json_parser = JSONResponseParser()
         self.unit_parser = UnitIdentificationParser()
         self.text_processor = TextProcessor()
-        self.prompt_builder = PromptBuilder(reference_context=reference_context)
+        # Small reference -> inject whole (cheap, no retrieval). Large reference ->
+        # index once and retrieve per unit so we never blow the context window.
+        reference_retriever = None
+        if reference_context and len(reference_context) > REFERENCE_FULL_INJECT_MAX_CHARS:
+            reference_retriever = ReferenceRetriever(reference_context)
+            reference_context = None
+        self.prompt_builder = PromptBuilder(
+            reference_context=reference_context,
+            reference_retriever=reference_retriever,
+        )
         self.on_value_extracted = on_value_extracted
         self.should_stop = should_stop
         self.on_warning = on_warning
@@ -1625,6 +1640,7 @@ class PaperProcessor:
                 [c.to_dict() for c in col_batch],
                 mode="all",
                 strict=False,
+                reference_query=unit_name,
             )
             msgs[0]["content"] = system_prompt
 

--- a/schematiq-lib/schematiq/value_extraction/utils/prompt_builder.py
+++ b/schematiq-lib/schematiq/value_extraction/utils/prompt_builder.py
@@ -5,15 +5,26 @@ from typing import List, Dict
 from schematiq.core.schema import Column
 
 from ..config.prompts import SYSTEM_PROMPT_VAL, SYSTEM_PROMPT_VAL_STRICT
+from .reference_retrieval import ReferenceRetriever, build_reference_query
 
 
 class PromptBuilder:
     """Builds prompts for value extraction LLM calls."""
 
-    def __init__(self, reference_context: str | None = None):
-        # Optional external reference text injected into every value-extraction
-        # prompt as supplementary lookup material (never a source document).
+    def __init__(
+        self,
+        reference_context: str | None = None,
+        reference_retriever: "ReferenceRetriever | None" = None,
+        reference_k: int = 5,
+    ):
+        # Optional external reference injected into every value-extraction prompt
+        # as supplementary lookup material (never a source document). When the
+        # reference is small it is injected whole (reference_context). When it is
+        # large a retriever is supplied instead, and only the passages relevant to
+        # the current observation unit + columns are injected.
         self.reference_context = reference_context
+        self.reference_retriever = reference_retriever
+        self.reference_k = reference_k
 
     def build_val_messages(
         self,
@@ -25,6 +36,7 @@ class PromptBuilder:
         *,
         strict: bool = False,
         already_extracted: Dict[str, str] | None = None,
+        reference_query: str | None = None,
     ) -> List[Dict[str, str]]:
         """
         Build messages for value extraction LLM calls.
@@ -78,7 +90,14 @@ class PromptBuilder:
             """.strip()
 
         reference_block = ""
-        if self.reference_context:
+        ref_text = self.reference_context
+        if self.reference_retriever is not None:
+            # Prefer the explicit observation-unit descriptor (e.g. the unit name)
+            # as the retrieval key; fall back to the document title otherwise.
+            rq = build_reference_query(reference_query or paper_title, columns)
+            passages = self.reference_retriever.retrieve(rq, k=self.reference_k)
+            ref_text = "\n\n--- REFERENCE PASSAGE ---\n\n".join(passages) if passages else None
+        if ref_text:
             reference_block = (
                 "<EXTERNAL_REFERENCE>\n"
                 "The text below is an EXTERNAL REFERENCE supplied separately by the "
@@ -87,7 +106,7 @@ class PromptBuilder:
                 "lookup information (for example, to map an entity named in the source "
                 "document to an attribute recorded here) when it is relevant to a "
                 "requested column; otherwise ignore it.\n"
-                f"{self.reference_context}\n"
+                f"{ref_text}\n"
                 "</EXTERNAL_REFERENCE>"
             )
 

--- a/schematiq-lib/schematiq/value_extraction/utils/reference_retrieval.py
+++ b/schematiq-lib/schematiq/value_extraction/utils/reference_retrieval.py
@@ -1,0 +1,237 @@
+"""Retrieval over an external reference document for value extraction.
+
+An external reference is supplementary material the user attaches (e.g. a table
+mapping judges to the president who appointed them, or a long prose handbook).
+It can be far larger than the model's context window, so instead of injecting the
+whole document into every extraction prompt we index it once and, per observation
+unit, retrieve only the passages relevant to what we are trying to fill.
+
+Design goals:
+- Domain-agnostic: no assumption that the reference is a table, or that any
+  particular column is a key. The only thing we rely on is what the extractor
+  always knows anyway: the observation unit and the column(s) being filled.
+- Structure-aware chunking that works for both tabular text (keep the header with
+  each row group) and free prose (pack paragraphs to a word budget).
+- Lexical BM25 ranking: strong, deterministic and explainable for the dominant
+  case where a unit's identifier (a name, an id) appears in the relevant passage.
+  The scorer is isolated behind ``ReferenceRetriever`` so a semantic/hybrid stage
+  can be layered on later without changing callers.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+
+# BM25 free parameters (standard Okapi defaults).
+_BM25_K1 = 1.5
+_BM25_B = 0.75
+
+
+def _tokenize(text: str) -> List[str]:
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _looks_tabular(lines: List[str]) -> bool:
+    """Heuristic: a delimited header plus rows with a consistent column count.
+
+    Deliberately conservative — if unsure, we treat the text as prose, which is
+    always safe (chunking still works, just without header replication).
+    """
+    non_empty = [ln for ln in lines if ln.strip()]
+    if len(non_empty) < 3:
+        return False
+    for delim in (",", "\t", "|"):
+        counts = [ln.count(delim) for ln in non_empty[:20]]
+        if counts[0] >= 1 and sum(c == counts[0] for c in counts) >= max(3, int(0.7 * len(counts))):
+            return True
+    return False
+
+
+def _word_count(text: str) -> int:
+    return len(text.split())
+
+
+@dataclass
+class ReferenceChunk:
+    text: str
+    index: int
+
+
+def chunk_reference(
+    text: str, max_words: int = 120, overlap_records: int = 1
+) -> List[ReferenceChunk]:
+    """Split reference text into retrievable chunks, structure-aware.
+
+    Tabular text: the header line is kept out of the record stream and prepended
+    to every emitted chunk, so each chunk stays interpretable on its own. Prose:
+    split into paragraphs (blank-line separated), falling back to single lines.
+    Records are packed up to ``max_words`` with a small record-level overlap so a
+    fact spanning a boundary still appears whole in one chunk.
+    """
+    if not text or not text.strip():
+        return []
+
+    raw_lines = text.splitlines()
+    tabular = _looks_tabular(raw_lines)
+
+    header = ""
+    if tabular:
+        # First non-empty line is the header; records are the remaining rows.
+        records: List[str] = []
+        seen_header = False
+        for ln in raw_lines:
+            if not ln.strip():
+                continue
+            if not seen_header:
+                header = ln.strip()
+                seen_header = True
+                continue
+            records.append(ln.strip())
+    else:
+        # Prose: paragraphs first; if there are none, fall back to lines.
+        paras = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
+        records = paras if paras else [ln.strip() for ln in raw_lines if ln.strip()]
+
+    if not records:
+        # Header-only tabular file, or nothing usable.
+        return [ReferenceChunk(text=header, index=0)] if header else []
+
+    header_words = _word_count(header)
+    chunks: List[ReferenceChunk] = []
+    i = 0
+    n = len(records)
+    while i < n:
+        bucket: List[str] = []
+        words = header_words
+        j = i
+        while j < n:
+            rw = _word_count(records[j])
+            if bucket and words + rw > max_words:
+                break
+            bucket.append(records[j])
+            words += rw
+            j += 1
+        body = "\n".join(bucket)
+        chunk_text = f"{header}\n{body}" if header else body
+        chunks.append(ReferenceChunk(text=chunk_text, index=len(chunks)))
+        if j >= n:
+            break
+        # Advance with a small overlap so boundary records aren't isolated.
+        i = max(j - overlap_records, i + 1)
+    return chunks
+
+
+@dataclass
+class ReferenceRetriever:
+    """BM25 retriever over the chunks of a single reference document.
+
+    Build once per reference (chunking + statistics are computed up front); call
+    :meth:`retrieve` cheaply per observation unit.
+    """
+
+    text: str
+    max_words: int = 120
+    overlap_records: int = 1
+    chunks: List[ReferenceChunk] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.chunks = chunk_reference(self.text, self.max_words, self.overlap_records)
+        self._tokens: List[List[str]] = [_tokenize(c.text) for c in self.chunks]
+        self._len: List[int] = [len(t) for t in self._tokens]
+        self._avgdl: float = (sum(self._len) / len(self._len)) if self._len else 0.0
+        # Document frequency per term.
+        self._df: dict[str, int] = {}
+        for toks in self._tokens:
+            for term in set(toks):
+                self._df[term] = self._df.get(term, 0) + 1
+        self._n = len(self._tokens)
+
+    def _idf(self, term: str) -> float:
+        df = self._df.get(term, 0)
+        if df == 0:
+            return 0.0
+        # BM25 idf with +1 to stay non-negative.
+        return math.log(1 + (self._n - df + 0.5) / (df + 0.5))
+
+    def _score(self, query_terms: List[str], doc_idx: int) -> float:
+        if self._avgdl == 0:
+            return 0.0
+        toks = self._tokens[doc_idx]
+        if not toks:
+            return 0.0
+        dl = self._len[doc_idx]
+        tf: dict[str, int] = {}
+        for t in toks:
+            tf[t] = tf.get(t, 0) + 1
+        score = 0.0
+        for term in query_terms:
+            f = tf.get(term, 0)
+            if f == 0:
+                continue
+            idf = self._idf(term)
+            denom = f + _BM25_K1 * (1 - _BM25_B + _BM25_B * dl / self._avgdl)
+            score += idf * (f * (_BM25_K1 + 1)) / denom
+        return score
+
+    def retrieve(self, query: str, k: int = 5, rel_threshold: float = 0.3) -> List[str]:
+        """Return up to ``k`` chunk texts most relevant to ``query``.
+
+        Only chunks with a positive score are considered, and — after the best
+        match — a chunk is kept only if its score is at least ``rel_threshold`` of
+        the top score. This drops chunks that matched merely on ubiquitous terms
+        (e.g. a column word that appears in every row), so a query that truly
+        matches one region doesn't drag in unrelated rows just to fill ``k``.
+        """
+        if not self.chunks:
+            return []
+        query_terms = _tokenize(query)
+        if not query_terms:
+            return []
+        scored = [
+            (self._score(query_terms, idx), idx) for idx in range(len(self.chunks))
+        ]
+        scored = [s for s in scored if s[0] > 0]
+        if not scored:
+            return []
+        scored.sort(key=lambda s: (-s[0], s[1]))
+        top = scored[0][0]
+        cutoff = top * rel_threshold
+        kept = [(score, idx) for score, idx in scored[:k] if score >= cutoff]
+        return [self.chunks[idx].text for _, idx in kept]
+
+
+def build_reference_query(
+    unit_descriptor: str,
+    columns: Optional[List] = None,
+) -> str:
+    """Compose the retrieval query from the observation unit and the columns.
+
+    The unit descriptor (its name/identifier, and definition if available) is the
+    part the existing source-document query builder omits, yet it is exactly the
+    join signal for a reference lookup. ``columns`` may be Column-like objects
+    (with ``.name`` / ``.definition``) or plain strings.
+    """
+    parts: List[str] = []
+    if unit_descriptor:
+        parts.append(unit_descriptor)
+    for col in columns or []:
+        if isinstance(col, str):
+            name, definition = col, None
+        elif isinstance(col, dict):
+            # build_val_messages passes column dicts keyed by "column"; Column.to_dict
+            # uses "name". Accept either.
+            name = col.get("column") or col.get("name")
+            definition = col.get("definition")
+        else:
+            name = getattr(col, "name", None)
+            definition = getattr(col, "definition", None)
+        if name:
+            parts.append(name)
+        if definition:
+            parts.append(definition)
+    return " ".join(p for p in parts if p).strip()

--- a/schematiq-lib/tests/test_reference_retrieval.py
+++ b/schematiq-lib/tests/test_reference_retrieval.py
@@ -1,0 +1,145 @@
+"""Tests for domain-agnostic reference retrieval (chunking + BM25 + query)."""
+
+from schematiq.value_extraction.utils.reference_retrieval import (
+    ReferenceRetriever,
+    build_reference_query,
+    chunk_reference,
+    _looks_tabular,
+)
+
+
+def _big_tabular():
+    header = "nid,jid,Last Name,First Name,Birth Year,appointing_president"
+    rows = [f"{1300000+i},{i},Surname{i},First{i},19{i%100:02d},President{i%5}" for i in range(2000)]
+    rows.insert(1000, "13761857,13761857,Acker,William,1927,Ronald Reagan")
+    return header + "\n" + "\n".join(rows)
+
+
+def test_tabular_detection_and_header_replication():
+    text = _big_tabular()
+    assert _looks_tabular(text.splitlines())
+    chunks = chunk_reference(text, max_words=60)
+    assert len(chunks) > 1
+    assert all(c.text.startswith("nid,jid,Last Name") for c in chunks)
+
+
+def test_keyed_lookup_retrieves_target_row():
+    retr = ReferenceRetriever(_big_tabular(), max_words=60)
+    query = build_reference_query("William Acker", ["appointing_president"])
+    res = retr.retrieve(query, k=3)
+    assert res and "Acker" in res[0] and "Ronald Reagan" in res[0]
+
+
+def test_absent_token_returns_no_chunks():
+    retr = ReferenceRetriever(_big_tabular(), max_words=60)
+    assert retr.retrieve("zzzqqxx", k=3) == []
+
+
+def test_prose_retrieval():
+    prose = (
+        "The handbook describes courtroom procedures in detail.\n\n"
+        "Judge William Marsh Acker Jr. was appointed by President Ronald Reagan in 1982 "
+        "and served in Birmingham.\n\n"
+        "Filing deadlines for civil motions are in the local rules."
+    )
+    assert not _looks_tabular(prose.splitlines())
+    retr = ReferenceRetriever(prose, max_words=40)
+    res = retr.retrieve(build_reference_query("William Marsh Acker", ["appointing president"]), k=1)
+    assert res and "Reagan" in res[0]
+
+
+def test_build_reference_query_includes_unit_and_columns():
+    class Col:
+        name = "President"
+        definition = "Appointing president"
+
+    q = build_reference_query("Unit Y", [Col()])
+    assert "Unit Y" in q and "President" in q and "Appointing president" in q
+    # string columns are supported too
+    q2 = build_reference_query("Unit X", ["colA"])
+    assert "Unit X" in q2 and "colA" in q2
+
+
+def test_chunking_edge_cases():
+    assert chunk_reference("") == []
+    assert chunk_reference("   \n  ") == []
+    assert ReferenceRetriever("").retrieve("anything") == []
+
+
+def test_relative_cutoff_drops_weak_chunks():
+    """When only one region truly matches, weak chunks matching only ubiquitous
+    column terms are not dragged in just to fill k."""
+    header = "judge,appointing_president"
+    rows = [f"Judge{i},President{i % 5}" for i in range(5000)]
+    rows.insert(2500, "William Acker,Ronald Reagan")
+    big = header + "\n" + "\n".join(rows)
+    retr = ReferenceRetriever(big)
+    res = retr.retrieve(build_reference_query("William Acker", ["appointing_president"]), k=5)
+    joined = "\n".join(res)
+    assert "Ronald Reagan" in joined
+    assert "Judge0,President0" not in joined
+
+
+def test_prompt_builder_small_reference_injected_whole():
+    from schematiq.value_extraction.utils.prompt_builder import PromptBuilder
+
+    cols = [{"column": "appointing_president", "definition": "President who appointed"}]
+    pb = PromptBuilder(reference_context="judge,appointing_president\nAcker,Reagan")
+    content = pb.build_val_messages("q", "Acker ruling", "body", cols, mode="all")[1]["content"]
+    assert "<EXTERNAL_REFERENCE>" in content and "Acker,Reagan" in content
+
+
+def test_prompt_builder_large_reference_injects_only_retrieved():
+    from schematiq.value_extraction.utils.prompt_builder import PromptBuilder
+
+    cols = [{"column": "appointing_president", "definition": "President who appointed"}]
+    header = "judge,appointing_president"
+    rows = [f"Judge{i},President{i % 5}" for i in range(5000)]
+    rows.insert(2500, "William Acker,Ronald Reagan")
+    retr = ReferenceRetriever(header + "\n" + "\n".join(rows))
+    pb = PromptBuilder(reference_retriever=retr, reference_k=3)
+    content = pb.build_val_messages("q", "William Acker", "body", cols, mode="all")[1]["content"]
+    assert "Ronald Reagan" in content
+    assert "Judge0,President0" not in content
+    assert len(content) < 5000  # retrieval actually bounded the prompt
+
+
+def test_prompt_builder_explicit_reference_query_is_precise():
+    """The explicit reference_query (the identified unit) pins the right passage
+    regardless of the document title."""
+    from schematiq.value_extraction.utils.prompt_builder import PromptBuilder
+
+    cols = [{"column": "appointing_president", "definition": "President who appointed"}]
+    header = "judge,appointing_president"
+    rows = [f"Judge{i},President{i % 5}" for i in range(5000)]
+    rows.insert(2500, "William Acker,Ronald Reagan")
+    retr = ReferenceRetriever(header + "\n" + "\n".join(rows))
+    pb = PromptBuilder(reference_retriever=retr, reference_k=3)
+    content = pb.build_val_messages(
+        "q", "unrelated_filename", "body", cols, mode="all", reference_query="William Acker"
+    )[1]["content"]
+    assert "Ronald Reagan" in content
+    assert "Judge0,President0" not in content
+
+
+def test_paper_processor_gates_on_reference_size():
+    from schematiq.value_extraction.core.paper_processor import (
+        PaperProcessor,
+        REFERENCE_FULL_INJECT_MAX_CHARS,
+    )
+
+    small = "judge,pres\nAcker,Reagan"
+    big = "judge,pres\n" + "\n".join(f"Judge{i},P{i}" for i in range(5000))
+    assert len(big) > REFERENCE_FULL_INJECT_MAX_CHARS
+
+    pp_big = PaperProcessor(llm=None, reference_context=big)
+    assert pp_big.prompt_builder.reference_retriever is not None
+    assert pp_big.prompt_builder.reference_context is None
+
+    pp_small = PaperProcessor(llm=None, reference_context=small)
+    assert pp_small.prompt_builder.reference_retriever is None
+    assert pp_small.prompt_builder.reference_context == small
+
+    pp_none = PaperProcessor(llm=None)
+    assert pp_none.prompt_builder.reference_retriever is None
+    assert pp_none.prompt_builder.reference_context is None


### PR DESCRIPTION
Retrieve-then-read over external references. Structure-aware chunking, BM25 with relative cutoff, unit name as explicit retrieval key. Small refs injected whole (<12K chars); large refs indexed once and retrieved per unit. 11 tests.