### PR TITLE
feat(reference): provenance for reference-sourced cells

### DIFF
--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -41,6 +41,7 @@ Rules:
 - After edit_observation_unit or schema definition changes (edit_column, add_column, delete_column), existing table values may be stale. Offer reextract to refresh values from documents, or run_schematiq / continue_discovery when the user wants schema rediscovery.
 - Manual update_cell edits do not require re-extraction unless the user asks to repopulate from documents.
 - When a question may depend on information not in the source documents (e.g. external attributes of an entity), call list_reference_sources to see if the user attached a relevant reference document, then read_reference_source to consult it. You may also combine it with your own knowledge. If a reference document contains an attribute that is not yet a column and looks useful, you may suggest add_column for it. To fill or update an existing column from a reference document, write the values with update_cell per row — do NOT use reextract or reprocess, which only re-run extraction from the source documents.
+- When you fill a cell with a value taken from a reference document (via update_cell), pass that reference's reference_id so the cell is marked as sourced from it and attributed correctly. Do not pass reference_id for values you did not take from a reference.
 - Cheap tools run immediately. Expensive tools (reextract, reprocess, continue_discovery, run_schematiq) require user confirmation.
 - Reply concisely in plain English after completing the requested work.
 """

--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -491,8 +491,21 @@ class ToolExecutor:
       column = args["column"]
       value = args["value"]
       source_document = await self._resolve_source_document(session_id, row_name)
+      # If the value came from a reference document, resolve its filename so the
+      # cell can be attributed to it.
+      reference_source = None
+      reference_id = (args.get("reference_id") or "").strip()
+      if reference_id:
+          session = session_manager.get_session(session_id)
+          if session:
+              from app.services import reference_document_service as refsvc
+
+              ref = refsvc.get_reference_document(session, reference_id)
+              if ref:
+                  reference_source = ref.filename
       return await data_editor.update_cell(
-          session_id, row_name, column, value, source_document=source_document
+          session_id, row_name, column, value, source_document=source_document,
+          reference_source=reference_source,
       )
 
   async def _resolve_source_document(self, session_id: str, row_name: str) -> Optional[str]:

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -243,6 +243,15 @@ def _all_tools() -> list[ToolSpec]:
                     "row": {"type": "string", "description": "Row name / observation unit name."},
                     "column": {"type": "string", "description": "Column name."},
                     "value": {"type": "string", "description": "New cell value."},
+                    "reference_id": {
+                        "type": "string",
+                        "description": (
+                            "Optional. If this value was taken from an attached "
+                            "reference document, pass that reference's id (from "
+                            "list_reference_sources) so the cell is marked as sourced "
+                            "from it. Omit for normal manual edits."
+                        ),
+                    },
                 },
                 "required": ["row", "column", "value"],
             },

--- a/backend/app/services/data_editor.py
+++ b/backend/app/services/data_editor.py
@@ -55,7 +55,7 @@ class DataEditor:
     async def update_cell(
         self, session_id: str, row_name: str, column: str, value: Any,
         restore: Any = None, source_document: str = None,
-        row_index: Optional[int] = None,
+        row_index: Optional[int] = None, reference_source: Optional[str] = None,
     ) -> dict:
         """
         Update a specific cell value in the session's data file.
@@ -160,6 +160,12 @@ class DataEditor:
                 raise ValueError(f"Row at index {row_index} not found")
             raise ValueError(f"Row with row_name '{row_name}' not found")
 
+        # Provenance: when the value came from an attached reference document, mark
+        # the cell as externally sourced and attribute it to that reference, so the
+        # table shows where it came from (reuses the existing external_source style).
+        if reference_source and restore is None:
+            self._mark_external_source(row, column, reference_source)
+
         # Write back all rows
         with open(data_file, "w", encoding="utf-8") as f:
             for row in rows:
@@ -175,6 +181,28 @@ class DataEditor:
             "value": value,
             "previous_value": previous_value,
         }
+
+    @staticmethod
+    def _mark_external_source(row: dict, column: str, source_name: str) -> None:
+        """Flag a cell as sourced from an external reference document.
+
+        Sets ``_cell_status[column] = "external_source"`` (rendered distinctly in
+        the table) and, when the cell holds an answer/excerpts object, attaches an
+        excerpt attributing the value to ``source_name`` so the source is shown.
+        """
+        if "data" in row and isinstance(row["data"], dict):
+            cell = row["data"].get(column)
+        else:
+            cell = row.get(column)
+        if isinstance(cell, dict):
+            cell["excerpts"] = [
+                {
+                    "text": f"Value taken from reference document '{source_name}'.",
+                    "source": source_name,
+                }
+            ]
+        status = row.setdefault("_cell_status", {})
+        status[column] = "external_source"
 
     async def rename_column(
         self, session_id: str, old_name: str, new_name: str

--- a/backend/tests/test_reference_provenance.py
+++ b/backend/tests/test_reference_provenance.py
@@ -1,0 +1,105 @@
+"""Tests for external-reference provenance marking on cell updates."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services.data_editor import DataEditor
+from app.storage.factory import reset_storage
+from app.storage.local_backend import LocalStorageBackend
+
+
+@pytest.fixture
+def session_dirs(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    work_dir = tmp_path / "schematiq_work"
+    data_dir = tmp_path / "data"
+    work_dir.mkdir(parents=True)
+    data_dir.mkdir(parents=True)
+    return work_dir, data_dir
+
+
+@pytest.fixture
+def local_storage(session_dirs, tmp_path, monkeypatch):
+    work_dir, data_dir = session_dirs
+    reset_storage()
+    backend = LocalStorageBackend(
+        sessions_dir=str(tmp_path / "sessions"),
+        data_dir=str(data_dir),
+        schematiq_work_dir=str(work_dir),
+    )
+    monkeypatch.setattr("app.storage.factory.get_storage", lambda: backend)
+    monkeypatch.setattr("app.storage.get_storage", lambda: backend)
+    yield backend
+    reset_storage()
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def _read_row(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.loads(f.readline())
+
+
+@pytest.mark.asyncio
+async def test_reference_source_marks_cell_external(session_dirs, local_storage):
+    work_dir, data_dir = session_dirs
+    session_id = "prov-nested"
+    editor = DataEditor(work_dir=str(work_dir), data_dir=str(data_dir))
+    data_file = data_dir / session_id / "data.jsonl"
+    _write_jsonl(
+        data_file,
+        [{"row_name": "Acker", "data": {"president": {"answer": "", "excerpts": []}}}],
+    )
+
+    await editor.update_cell(
+        session_id, "Acker", "president", "Ronald Reagan", reference_source="FJC.xlsx"
+    )
+
+    row = _read_row(data_file)
+    assert row["_cell_status"]["president"] == "external_source"
+    cell = row["data"]["president"]
+    assert cell["answer"] == "Ronald Reagan"
+    assert cell["excerpts"] and cell["excerpts"][0]["source"] == "FJC.xlsx"
+
+
+@pytest.mark.asyncio
+async def test_reference_source_marks_flat_format(session_dirs, local_storage):
+    work_dir, data_dir = session_dirs
+    session_id = "prov-flat"
+    editor = DataEditor(work_dir=str(work_dir), data_dir=str(data_dir))
+    data_file = data_dir / session_id / "data.jsonl"
+    _write_jsonl(data_file, [{"row_name": "Acker", "president": {"answer": "", "excerpts": []}}])
+
+    await editor.update_cell(
+        session_id, "Acker", "president", "Ronald Reagan", reference_source="FJC.xlsx"
+    )
+
+    row = _read_row(data_file)
+    assert row["_cell_status"]["president"] == "external_source"
+    assert row["president"]["excerpts"][0]["source"] == "FJC.xlsx"
+
+
+@pytest.mark.asyncio
+async def test_no_reference_source_leaves_plain_manual_edit(session_dirs, local_storage):
+    work_dir, data_dir = session_dirs
+    session_id = "prov-plain"
+    editor = DataEditor(work_dir=str(work_dir), data_dir=str(data_dir))
+    data_file = data_dir / session_id / "data.jsonl"
+    _write_jsonl(
+        data_file,
+        [{"row_name": "Acker", "data": {"president": {"answer": "", "excerpts": []}}}],
+    )
+
+    await editor.update_cell(session_id, "Acker", "president", "Ronald Reagan")
+
+    row = _read_row(data_file)
+    assert "_cell_status" not in row
+    assert row["data"]["president"]["excerpts"] == []
+    assert row["data"]["president"]["manually_edited"] is True


### PR DESCRIPTION
update_cell accepts reference_id; reference-sourced cells are marked _cell_status=external_source and attributed to the reference filename, reusing existing table rendering. Backend only. 3 tests.