### PR TITLE
fix(reference): dedupe attached reference docs by filename

### DIFF
--- a/backend/app/services/reference_document_service.py
+++ b/backend/app/services/reference_document_service.py
@@ -163,9 +163,22 @@ def get_reference_document(
 def add_reference_document(
     session: VisualizationSession, ref: ReferenceDocument
 ) -> None:
-    """Append a reference document to the session (in place)."""
+    """Add a reference document to the session (in place).
+
+    Reference documents are session-scoped lookup material that stays active
+    (and is re-sent to the model) until the user removes it. Attaching a file
+    whose name matches one already attached therefore *replaces* the existing
+    entry in place rather than appending a duplicate: re-attaching the same
+    file is a no-op-with-refresh, and uploading an updated version of a
+    same-named lookup swaps in the new content. This prevents the same text
+    from being injected into extraction/chat prompts twice.
+    """
     if session.reference_documents is None:  # defensive; default is a list
         session.reference_documents = []
+    for index, existing in enumerate(session.reference_documents):
+        if existing.filename == ref.filename:
+            session.reference_documents[index] = ref
+            return
     session.reference_documents.append(ref)
 
 

--- a/backend/tests/test_reference_documents.py
+++ b/backend/tests/test_reference_documents.py
@@ -103,6 +103,29 @@ def test_add_list_get_remove_reference():
     assert refsvc.remove_reference_document(session, ref.id) is False
 
 
+def test_add_reference_replaces_same_filename():
+    session = _session("ref-dedup")
+    first = refsvc.build_reference_document("judges.csv", b"judge,president\nSmith,Trump")
+    refsvc.add_reference_document(session, first)
+
+    # Re-attaching the same filename (e.g. accidental double-attach, or an
+    # updated version) replaces the existing entry instead of duplicating it.
+    second = refsvc.build_reference_document(
+        "judges.csv", b"judge,president\nSmith,Trump\nJones,Obama"
+    )
+    refsvc.add_reference_document(session, second)
+
+    refs = refsvc.list_reference_documents(session)
+    assert len(refs) == 1
+    assert refs[0].id == second.id
+    assert refs[0].char_count == second.char_count
+
+    # A different filename still appends as a distinct entry.
+    other = refsvc.build_reference_document("courts.csv", b"court,circuit\nCA9,9")
+    refsvc.add_reference_document(session, other)
+    assert len(refsvc.list_reference_documents(session)) == 2
+
+
 # ---------------------------------------------------------------------------
 # Chat tools
 # ---------------------------------------------------------------------------

--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -137,7 +137,15 @@ export function ChatPanel({
       setReferenceError(null);
       try {
         const created = await referenceAPI.upload(sessionId, file);
-        setReferences((current) => [...current, created]);
+        // The backend dedups by filename (re-attaching the same name replaces
+        // the existing entry), so mirror that here: swap a same-named chip in
+        // place instead of appending a duplicate.
+        setReferences((current) => {
+          const withoutSameName = current.filter(
+            (ref) => ref.filename !== created.filename,
+          );
+          return [...withoutSameName, created];
+        });
       } catch (error) {
         const detail = (error as { response?: { data?: { detail?: unknown } } })?.response?.data
           ?.detail;
@@ -467,6 +475,12 @@ export function ChatPanel({
       <div className="workspace-chat-input">
         {(references.length > 0 || referenceError) && (
           <div className="mb-2 flex flex-col gap-1">
+            {references.length > 0 && (
+              <div className="text-[11px] text-muted-foreground">
+                Stays available to the assistant for this whole conversation
+                until you remove it.
+              </div>
+            )}
             {references.map((ref) => (
               <div
                 key={ref.id}


### PR DESCRIPTION
## Problem
Attaching the same reference file twice created two session entries, so its text was injected into extraction/chat prompts twice and showed as a duplicate chip. Users also had no signal that an attached reference stays active for the whole conversation.

## Solution
- add_reference_document now replaces an existing entry with the same filename instead of appending, so re-attaching (accidental double-attach or an updated lookup) is a refresh, not a duplicate.
- Frontend mirrors this: uploading swaps a same-named chip in place instead of appending.
- Added a one-line hint that a reference stays available until removed. Removal already clears it end-to-end (extraction + chat).

## Verify
- git apply --check on fresh main: OK
- cd frontend && npx tsc --noEmit: OK
- python -m pytest backend/tests/test_reference_documents.py (new test_add_reference_replaces_same_filename)