### PR TITLE
fix(reference): NoneType crash marking reference-sourced cells

### DIFF
--- a/backend/app/services/data_editor.py
+++ b/backend/app/services/data_editor.py
@@ -201,7 +201,13 @@ class DataEditor:
                     "source": source_name,
                 }
             ]
-        status = row.setdefault("_cell_status", {})
+        # Rows may carry an explicit ``_cell_status: null`` (the field defaults to
+        # None on the row model), so setdefault is unsafe here — it would return
+        # None and the item assignment below would raise.
+        status = row.get("_cell_status")
+        if not isinstance(status, dict):
+            status = {}
+            row["_cell_status"] = status
         status[column] = "external_source"
 
     async def rename_column(

--- a/backend/app/services/uniprot_enrichment_service.py
+++ b/backend/app/services/uniprot_enrichment_service.py
@@ -134,7 +134,10 @@ class UniProtEnrichmentService:
 
             for idx in pending_indices:
                 row = rows[idx]
-                status = row.setdefault("_cell_status", {})
+                status = row.get("_cell_status")
+                if not isinstance(status, dict):
+                    status = {}
+                    row["_cell_status"] = status
 
                 protein = extract_value(row.get(pcol)) if pcol else None
                 if not protein:

--- a/backend/tests/test_reference_provenance.py
+++ b/backend/tests/test_reference_provenance.py
@@ -87,6 +87,30 @@ async def test_reference_source_marks_flat_format(session_dirs, local_storage):
 
 
 @pytest.mark.asyncio
+async def test_reference_source_handles_null_cell_status(session_dirs, local_storage):
+    """Rows may serialize _cell_status as null; marking must not crash on it."""
+    work_dir, data_dir = session_dirs
+    session_id = "prov-nullstatus"
+    editor = DataEditor(work_dir=str(work_dir), data_dir=str(data_dir))
+    data_file = data_dir / session_id / "data.jsonl"
+    _write_jsonl(
+        data_file,
+        [{
+            "row_name": "Acker",
+            "_cell_status": None,
+            "data": {"president": {"answer": "", "excerpts": []}},
+        }],
+    )
+
+    await editor.update_cell(
+        session_id, "Acker", "president", "Ronald Reagan", reference_source="FJC.xlsx"
+    )
+
+    row = _read_row(data_file)
+    assert row["_cell_status"]["president"] == "external_source"
+
+
+@pytest.mark.asyncio
 async def test_no_reference_source_leaves_plain_manual_edit(session_dirs, local_storage):
     work_dir, data_dir = session_dirs
     session_id = "prov-plain"


### PR DESCRIPTION
Rows serialize _cell_status as null (field defaults to None), so setdefault returned None and item assignment crashed update_cell when filling from a reference. Treat null/non-dict _cell_status as empty. Same latent bug fixed in uniprot enrichment. Regression test added.