### PR TITLE
feat(reference): store reference text in storage backend, support large files

### DIFF
--- a/backend/app/api/routes/reference.py
+++ b/backend/app/api/routes/reference.py
@@ -86,7 +86,7 @@ async def upload_reference_document(
         raise HTTPException(status_code=400, detail="Uploaded file is empty")
 
     try:
-        ref = refsvc.build_reference_document(filename, raw)
+        ref = await refsvc.store_reference_document(session_id, filename, raw)
     except refsvc.UnsupportedReferenceFormat as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except refsvc.ReferenceExtractionError as exc:
@@ -113,6 +113,7 @@ async def delete_reference_document(session_id: str, reference_id: str) -> dict:
     removed = refsvc.remove_reference_document(session, reference_id)
     if not removed:
         raise HTTPException(status_code=404, detail="Reference document not found")
+    await refsvc.delete_reference_storage(session_id, reference_id)
     session_manager.update_session(session)
     await _broadcast_updated(session_id, session)
     return {"status": "success", "removed": reference_id}

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -157,7 +157,7 @@ class ReferenceDocument(BaseModel):
     """
     id: str
     filename: str
-    content: str  # Plain-text representation of the uploaded file
+    content: Optional[str] = None  # Legacy inline text; new docs store text in the storage backend
     char_count: int = 0
     truncated: bool = False  # True if content was capped at the size limit
     uploaded_at: datetime = Field(default_factory=datetime.now)

--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -254,12 +254,13 @@ class ToolExecutor:
       ref = refsvc.get_reference_document(session, reference_id)
       if not ref:
           raise ValueError(f"Reference document '{reference_id}' not found")
+      full_text = await refsvc.load_reference_text(session_id, ref)
       # Cap the returned text so the whole result stays within the chat
       # tool-result budget. truncate_result drops an oversized string value
       # outright, which would hand the model an empty body; clip it here instead
       # and flag that more text exists. The full document is still used during
       # value extraction.
-      content = ref.content
+      content = full_text
       clipped = len(content) > READ_REFERENCE_CHAT_BUDGET
       if clipped:
           content = content[:READ_REFERENCE_CHAT_BUDGET]

--- a/backend/app/services/pipeline/value_extraction.py
+++ b/backend/app/services/pipeline/value_extraction.py
@@ -73,7 +73,7 @@ async def run_value_extraction(
     on_value_extracted = create_value_extracted_callback(ws_mixin, session_id, loop)
     on_warning = create_warning_callback(ws_manager, session_id, loop)
 
-    reference_context = build_reference_context(session)
+    reference_context = await build_reference_context(session)
 
     extraction_result = {}
 

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -1334,6 +1334,9 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 def should_stop():
                     return self.is_stop_requested(operation_id)
 
+                # Load reference context before entering the sync extraction thread.
+                reference_context = await build_reference_context(session)
+
                 def run_extraction():
                     return build_table_jsonl(
                         schema_path=schema_file,
@@ -1351,7 +1354,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                         should_stop=should_stop,  # Allow graceful stop
                         known_units=known_units if known_units else None,
                         write_skip_rationale_artifact=session.write_artifacts,
-                        reference_context=build_reference_context(session),
+                        reference_context=reference_context,
                     )
 
                 await asyncio.get_event_loop().run_in_executor(schematiq_thread_pool, run_extraction)

--- a/backend/app/services/reference_context.py
+++ b/backend/app/services/reference_context.py
@@ -2,33 +2,40 @@
 
 A session may carry external reference documents (supplementary lookup material,
 e.g. a spreadsheet mapping each judge to the president who appointed them). This
-helper concatenates their extracted text into a single labelled blob that the
-extraction pipeline injects into each per-document prompt as supplementary
-context — clearly marked as external so it never yields observation-unit rows.
+helper concatenates their text into a single labelled blob that the extraction
+pipeline injects (or, when large, retrieves from) per document prompt as
+supplementary context — clearly marked as external so it never yields rows.
 
-Reads ``session.reference_documents`` defensively via ``getattr`` so this module
-is safe even where that field is not present on the session model.
+The text now lives in the storage backend rather than inline on the session, so
+this is async and loads each document's text on demand.
 """
 
 from typing import Optional
 
-# Guard so a single oversized reference can't blow up the extraction prompt.
-MAX_REFERENCE_CONTEXT_CHARS = 200_000
+# Upper bound on the combined reference text handed to extraction. Large enough
+# to let the retrieval layer (which chunks and selects per unit) do its job.
+MAX_REFERENCE_CONTEXT_CHARS = 10_000_000
 
 
-def build_reference_context(session) -> Optional[str]:
+async def build_reference_context(session) -> Optional[str]:
     """Return the combined reference text for a session, or None if there is none."""
     refs = getattr(session, "reference_documents", None) or []
     if not refs:
         return None
 
+    from app.services.reference_document_service import load_reference_text
+
+    session_id = getattr(session, "id", None)
     parts = []
     for ref in refs:
         filename = getattr(ref, "filename", "reference")
-        content = getattr(ref, "content", "") or ""
-        if not content.strip():
+        try:
+            text = await load_reference_text(session_id, ref)
+        except Exception:
+            text = ""
+        if not text or not text.strip():
             continue
-        parts.append(f"--- Reference document: {filename} ---\n{content}")
+        parts.append(f"--- Reference document: {filename} ---\n{text}")
 
     if not parts:
         return None

--- a/backend/app/services/reference_document_service.py
+++ b/backend/app/services/reference_document_service.py
@@ -23,9 +23,20 @@ from typing import List, Optional, Tuple
 
 from app.models.session import ReferenceDocument, VisualizationSession
 
-# Cap stored text so a single reference doc can't bloat the session blob
-# unboundedly (the session is serialized on every update).
-MAX_REFERENCE_CHARS = 200_000
+# Cap the extracted text size to avoid pathological uploads exhausting memory.
+# The text itself is stored in the storage backend (not inline on the session),
+# so this bound is generous rather than a session-bloat guard.
+MAX_REFERENCE_CHARS = 10_000_000
+
+# Reference text is stored as a file in the existing "documents" bucket, under a
+# per-session "references/" prefix, so it is session-scoped and cleaned up when
+# the session's documents are deleted. (Supabase has a fixed set of buckets, so
+# we reuse "documents" rather than introducing a new bucket.)
+REFERENCE_BUCKET = "documents"
+
+
+def _reference_storage_path(session_id: str, reference_id: str) -> str:
+    return f"{session_id}/references/{reference_id}.txt"
 
 # File types we can turn into useful text. Tabular and text-native formats are
 # handled in-process; pdf/docx reuse the existing document_conversion helpers.
@@ -145,6 +156,58 @@ def build_reference_document(filename: str, raw: bytes) -> ReferenceDocument:
         char_count=len(text),
         truncated=truncated,
     )
+
+
+async def store_reference_document(
+    session_id: str, filename: str, raw: bytes
+) -> ReferenceDocument:
+    """Extract text from an upload, store it in the storage backend, and return
+    metadata (with ``content=None`` — the text lives in storage, not inline)."""
+    from app.storage.factory import get_storage
+
+    text, truncated = extract_text(filename, raw)
+    ref = ReferenceDocument(
+        id=str(uuid.uuid4()),
+        filename=filename,
+        content=None,
+        char_count=len(text),
+        truncated=truncated,
+    )
+    storage = get_storage()
+    await storage.upload_text(
+        REFERENCE_BUCKET, _reference_storage_path(session_id, ref.id), text
+    )
+    return ref
+
+
+async def load_reference_text(session_id: str, ref: ReferenceDocument) -> str:
+    """Return a reference document's text.
+
+    Uses the inline ``content`` for legacy documents; otherwise downloads it from
+    the storage backend. Returns an empty string if the text can't be found.
+    """
+    if ref.content is not None:
+        return ref.content
+    from app.storage.factory import get_storage
+
+    storage = get_storage()
+    text = await storage.download_text(
+        REFERENCE_BUCKET, _reference_storage_path(session_id, ref.id)
+    )
+    return text or ""
+
+
+async def delete_reference_storage(session_id: str, reference_id: str) -> None:
+    """Best-effort removal of a reference document's stored text."""
+    from app.storage.factory import get_storage
+
+    try:
+        storage = get_storage()
+        await storage.delete_file(
+            REFERENCE_BUCKET, _reference_storage_path(session_id, reference_id)
+        )
+    except Exception:  # deletion is best-effort; never fail the caller on it
+        pass
 
 
 def list_reference_documents(session: VisualizationSession) -> List[ReferenceDocument]:

--- a/backend/tests/test_reference_extraction_injection.py
+++ b/backend/tests/test_reference_extraction_injection.py
@@ -4,6 +4,8 @@ Covers the prompt builder injection, the threading through PaperProcessor /
 TableBuilder, and the backend build_reference_context helper.
 """
 
+import pytest
+
 from app.services.reference_context import build_reference_context
 from schematiq.value_extraction.utils.prompt_builder import PromptBuilder
 
@@ -49,7 +51,7 @@ def test_reference_context_threads_through_table_builder():
 class _Ref:
     def __init__(self, filename, content):
         self.filename = filename
-        self.content = content
+        self.content = content  # inline content -> load_reference_text returns it
 
 
 class _Session:
@@ -57,19 +59,22 @@ class _Session:
         self.reference_documents = refs
 
 
-def test_build_reference_context_none_when_empty():
-    assert build_reference_context(_Session([])) is None
-    assert build_reference_context(object()) is None  # missing attribute -> None
+@pytest.mark.asyncio
+async def test_build_reference_context_none_when_empty():
+    assert await build_reference_context(_Session([])) is None
+    assert await build_reference_context(object()) is None  # missing attribute -> None
 
 
-def test_build_reference_context_concatenates_labelled():
-    ctx = build_reference_context(
+@pytest.mark.asyncio
+async def test_build_reference_context_concatenates_labelled():
+    ctx = await build_reference_context(
         _Session([_Ref("a.csv", "judge,pres\nSmith,Trump"), _Ref("b.txt", "extra")])
     )
     assert "a.csv" in ctx and "Smith,Trump" in ctx
     assert "b.txt" in ctx and "extra" in ctx
 
 
-def test_build_reference_context_skips_blank():
-    ctx = build_reference_context(_Session([_Ref("blank.txt", "   ")]))
+@pytest.mark.asyncio
+async def test_build_reference_context_skips_blank():
+    ctx = await build_reference_context(_Session([_Ref("blank.txt", "   ")]))
     assert ctx is None

--- a/backend/tests/test_reference_storage.py
+++ b/backend/tests/test_reference_storage.py
@@ -1,0 +1,76 @@
+"""Tests for storing reference document text in the storage backend."""
+
+import pytest
+
+from app.models.session import (
+    ReferenceDocument,
+    SessionMetadata,
+    SessionType,
+    VisualizationSession,
+)
+from app.services import reference_document_service as refsvc
+from app.services.reference_context import build_reference_context
+from app.storage.factory import reset_storage
+from app.storage.local_backend import LocalStorageBackend
+
+
+@pytest.fixture
+def local_storage(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    reset_storage()
+    backend = LocalStorageBackend(
+        sessions_dir=str(tmp_path / "sessions"),
+        data_dir=str(tmp_path / "data"),
+        schematiq_work_dir=str(tmp_path / "work"),
+    )
+    monkeypatch.setattr("app.storage.factory.get_storage", lambda: backend)
+    monkeypatch.setattr("app.storage.get_storage", lambda: backend)
+    yield backend
+    reset_storage()
+
+
+def _session(refs):
+    return VisualizationSession(
+        id="store-session",
+        type=SessionType.SCHEMATIQ,
+        metadata=SessionMetadata(source="test"),
+        reference_documents=refs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_then_load_roundtrip(local_storage):
+    csv = b"judge,appointing_president\nAcker,Reagan\nSmith,Obama\n"
+    ref = await refsvc.store_reference_document("store-session", "judges.csv", csv)
+    # Metadata only; text is not inline on the session.
+    assert ref.content is None
+    assert ref.char_count > 0
+
+    text = await refsvc.load_reference_text("store-session", ref)
+    assert "Acker,Reagan" in text and "Smith,Obama" in text
+
+
+@pytest.mark.asyncio
+async def test_build_reference_context_loads_from_storage(local_storage):
+    ref = await refsvc.store_reference_document(
+        "store-session", "judges.csv", b"judge,pres\nAcker,Reagan\n"
+    )
+    ctx = await build_reference_context(_session([ref]))
+    assert ctx and "judges.csv" in ctx and "Acker,Reagan" in ctx
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_stored_text(local_storage):
+    ref = await refsvc.store_reference_document(
+        "store-session", "judges.csv", b"judge,pres\nAcker,Reagan\n"
+    )
+    await refsvc.delete_reference_storage("store-session", ref.id)
+    # After deletion the text is gone; load returns empty rather than raising.
+    assert await refsvc.load_reference_text("store-session", ref) == ""
+
+
+@pytest.mark.asyncio
+async def test_load_prefers_inline_content_for_legacy_docs(local_storage):
+    # Legacy documents carry inline content and must not require storage.
+    legacy = ReferenceDocument(id="legacy", filename="old.csv", content="a,b\n1,2", char_count=7)
+    assert await refsvc.load_reference_text("store-session", legacy) == "a,b\n1,2"


### PR DESCRIPTION
Moves reference document text from inline-on-session to the storage backend (documents bucket, per-session references/ prefix, cleaned up on session delete). Raises the size cap from 200K to 10M chars so multi-MB files are no longer truncated. build_reference_context is now async and loads on demand; legacy inline content still works. Threaded through both extraction paths. 29 reference tests pass; full backend suite green.