### PR TITLE
feat(workspace): default to split view and trim redundant menu items

### DIFF
--- a/frontend/src/pages/Workspace/hooks/useWorkspaceLayout.ts
+++ b/frontend/src/pages/Workspace/hooks/useWorkspaceLayout.ts
@@ -2,10 +2,23 @@ import { useCallback, useState } from 'react';
 
 // Owns chat-panel width and the pointer-driven divider drag interaction.
 // Parent: Workspace (index.tsx).
+const DEFAULT_CHAT_WIDTH = 380;
+
+// Below this the chat panel is effectively collapsed; above (near the viewport
+// width) the sheet is collapsed. We persist a custom divider width across
+// sessions, but never *restore* a fully collapsed side: reopening a workspace
+// always lands in split view so the user can't get stuck with one pane hidden.
+const MIN_SPLIT_WIDTH = 56;
+
 export function useWorkspaceLayout() {
   const [chatWidth, setChatWidth] = useState(() => {
     const saved = Number(localStorage.getItem('workspace.chatWidth'));
-    return Number.isFinite(saved) ? saved : 380;
+    if (!Number.isFinite(saved)) return DEFAULT_CHAT_WIDTH;
+    const sheetHiddenThreshold = window.innerWidth - 80;
+    if (saved < MIN_SPLIT_WIDTH || saved >= sheetHiddenThreshold) {
+      return DEFAULT_CHAT_WIDTH;
+    }
+    return saved;
   });
   const [isDraggingDivider, setIsDraggingDivider] = useState(false);
 

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -10,7 +10,6 @@ import {
   Loader2,
   MoreVertical,
   PanelLeft,
-  Plus,
   Sparkles,
   Table2,
   X,
@@ -1111,14 +1110,6 @@ function Workspace() {
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-64">
             <DropdownMenuLabel>Project</DropdownMenuLabel>
-            <DropdownMenuItem onClick={() => setProjectDialogOpen(true)}>
-              <Plus className="h-4 w-4" />
-              New Project
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => importInputRef.current?.click()} disabled={importingProject}>
-              {importingProject ? <Loader2 className="h-4 w-4 animate-spin" /> : <FileUp className="h-4 w-4" />}
-              Import Existing Project
-            </DropdownMenuItem>
             {sessionId && (
               <DropdownMenuItem onClick={() => navigate(`/visualize/${sessionId}?mode=${sessionMode}`)}>
                 <Table2 className="h-4 w-4" />


### PR DESCRIPTION
## Problem
Two issues simplifying the workspace chrome:
1. Once a user picked a full-screen layout (Show Sheet / Show Chat Full Screen), the collapsed width was persisted in localStorage and restored on every subsequent project open/load, so they got stuck with one pane hidden.
2. The workspace overflow menu duplicated New Project and Import Existing Project, which already live in the top File menu.

## Solution
- useWorkspaceLayout still persists a custom divider width, but never restores a fully collapsed side (chat-hidden or sheet-hidden). Reopening a workspace always lands in split view.
- Removed New Project and Import Existing Project from the overflow menu (kept Classic Visualizer and Existing Start Page). Cleaned up the now-unused Plus import.

## Verify
- git apply --check on fresh main: OK
- cd frontend && npx tsc --noEmit: OK
- Manual: set chatWidth to 0 via Show Sheet Full Screen, reload -> opens in split (380). Drag divider to 500, reload -> stays 500.