### PR TITLE
fix(chat): size send button to match attach reference height

### DIFF
--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -549,7 +549,7 @@ export function ChatPanel({
             size="icon"
             onClick={ask}
             disabled={busy || !input.trim()}
-            className="ml-auto rounded-lg"
+            className="ml-auto h-9 w-9 rounded-lg"
             aria-label="Send message"
             title="Send message (Enter)"
           >


### PR DESCRIPTION
## Problem
The chat send button used size=icon (40x40), one step taller than the 36px Attach reference button next to it, so the row looked uneven.

## Solution
Constrain the send button to h-9 w-9 (36x36) so it aligns with Attach reference.

## Verify
- git apply --check on fresh main: OK
- cd frontend && npx tsc --noEmit: OK