### PR TITLE
fix(workspace): stop cleared cell flickering back before refresh

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -55,6 +55,7 @@ export function SpreadsheetSurface({
   onGroundingHighlight,
   onGroundingScrollRequest,
   onRefresh,
+  onLocalEdit,
   onEditFollowUp,
   onEditEnd,
   layoutRevision,
@@ -75,6 +76,10 @@ export function SpreadsheetSurface({
   // re-scroll to the highlight even when the same cell is clicked again.
   onGroundingScrollRequest?: () => void;
   onRefresh: () => void;
+  // Fired synchronously the instant a local grid edit is made, before its PUT
+  // resolves. Lets the parent invalidate in-flight/deferred background
+  // refreshes so a stale payload cannot flash the pre-edit value back in.
+  onLocalEdit: () => void;
   onEditFollowUp: (kind: PendingRerunKind, columns?: string[]) => void;
   onEditEnd: () => void;
   layoutRevision: string;
@@ -577,6 +582,12 @@ export function SpreadsheetSurface({
       if (oldValue === newValue || prop == null) continue;
       const key = String(prop);
 
+      // Signal the edit before any async persistence so the parent can drop
+      // background refreshes that were fetched pre-edit. Without this a clear
+      // (or any edit) briefly reverts when a stale silent refresh lands, then
+      // re-applies once the edit's own refresh resolves.
+      onLocalEdit();
+
       if (activeSheet === 'data') {
         if (key.startsWith('_')) continue;
         const sourceRow: DataRow | undefined = data.rows[rowIndex];
@@ -732,7 +743,7 @@ export function SpreadsheetSurface({
           });
       }
     }
-  }, [activeSheet, data.rows, observationUnitRows, onEditFollowUp, onRefresh, schemaColumns, sessionId, toast]);
+  }, [activeSheet, data.rows, observationUnitRows, onEditFollowUp, onLocalEdit, onRefresh, schemaColumns, sessionId, toast]);
 
   const handleBeforeRemoveRow = useCallback(
     (_index: number, _amount: number, physicalRows: number[], _source?: string): boolean | void => {

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -175,11 +175,25 @@ function Workspace() {
   } = useWorkspaceLayout();
 
   const deferredDataRef = useRef<PaginatedData | null>(null);
+  // Monotonic edit epoch. Bumped the instant a local grid edit begins (e.g.
+  // clearing a cell). A silent refresh whose network fetch started before the
+  // current epoch is stale: its payload predates the edit and would flash the
+  // pre-edit value back in for a frame before the edit's own authoritative
+  // refresh lands. Such stale payloads are dropped (not applied, not deferred).
+  const editEpochRef = useRef(0);
   const cancelChatPendingRef = useRef<(() => Promise<boolean>) | null>(null);
 
   const cancelChatPendingIfAny = useCallback(async (): Promise<boolean> => {
     if (!cancelChatPendingRef.current) return true;
     return cancelChatPendingRef.current();
+  }, []);
+
+  // Called synchronously when a local grid edit begins. Bumps the epoch so any
+  // refresh already in flight is treated as stale, and discards any snapshot
+  // deferred while the editor was open (it too predates the edit).
+  const notifyLocalEdit = useCallback(() => {
+    editEpochRef.current += 1;
+    deferredDataRef.current = null;
   }, []);
 
   const isCellEditorOpen = useCallback(() => {
@@ -188,7 +202,11 @@ function Workspace() {
   }, []);
 
   const applyData = useCallback(
-    (nextData: PaginatedData, opts?: { silent?: boolean }) => {
+    (nextData: PaginatedData, opts?: { silent?: boolean; epoch?: number }) => {
+      // Drop a silent refresh whose fetch predates the latest local edit.
+      if (opts?.silent && opts.epoch != null && opts.epoch < editEpochRef.current) {
+        return;
+      }
       if (opts?.silent && isCellEditorOpen()) {
         deferredDataRef.current = nextData;
         return;
@@ -209,6 +227,9 @@ function Workspace() {
   const refresh = useCallback(async (options?: { silent?: boolean }) => {
     if (!sessionId) return;
     const silent = Boolean(options?.silent);
+    // Snapshot the edit epoch at fetch start so applyData can drop this payload
+    // if a local edit happens (or already happened) while it was in flight.
+    const startEpoch = editEpochRef.current;
     if (!silent) {
       setLoading(true);
     }
@@ -229,7 +250,7 @@ function Workspace() {
           fetchData().catch(() => emptyData),
           fetchDocuments().catch(() => null),
         ]);
-        applyData(nextData, options);
+        applyData(nextData, { ...options, epoch: startEpoch });
         setDocuments(nextDocuments);
       } finally {
         if (!silent) setDataLoading(false);
@@ -773,6 +794,7 @@ function Workspace() {
         onGroundingHighlight={handleGroundingHighlight}
         onGroundingScrollRequest={() => setGroundingScrollNonce((n) => n + 1)}
         onRefresh={refreshSilent}
+        onLocalEdit={notifyLocalEdit}
         onEditFollowUp={notifyEditFollowUp}
         onEditEnd={flushDeferredData}
         layoutRevision={gridLayoutRevision}


### PR DESCRIPTION
## Problem
Clearing a cell (or any local grid edit) worked, but the old value flashed back for a frame and then disappeared again. The delete was correctly persisted server-side; the flicker was a client race. A silent refresh (disconnected poll or WebSocket-driven reload) whose fetch started *before* the edit persisted carried the pre-edit value. On edit end, flushDeferredData applied that stale snapshot (value reappears), then the edit's own post-updateCell refresh resolved with the cleared value (value vanishes).

## Solution
Added a monotonic edit epoch in Workspace/index.tsx:
- notifyLocalEdit bumps the epoch and clears any deferred snapshot. It is passed to SpreadsheetSurface as onLocalEdit and fired synchronously at the top of handleChanges, before the async PUT.
- refresh() snapshots the epoch at fetch start and passes it to applyData.
- applyData drops a silent payload whose epoch predates the latest local edit, so it is neither applied nor deferred. The edit's own refresh captures the current epoch and always passes, remaining the single source of truth.

No backend changes. Chat-driven refreshes are unaffected (their epoch matches current).

## Verify
- git apply --ignore-whitespace --check on a clean clone: passes
- ( cd frontend && npx tsc --noEmit ): clean
- Manual: clear a data cell; it stays cleared with no flash-back on the next click.