### PR TITLE
fix(chat): run every batched tool call, not just the first

### DIFF
--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -361,11 +361,23 @@ class ChatAgentService:
         for _ in range(MAX_TOOL_ITERATIONS):
             function_calls = getattr(response, "function_calls", None) or []
             if function_calls:
-                # Handle one tool call per turn. Gemini (AUTO mode) normally returns a
-                # single call; if it ever batches several, take the first and let the model
-                # re-issue the rest next turn, so trailing calls aren't dropped when an
-                # earlier one needs confirmation.
-                for function_call in function_calls[:1]:
+                # Execute every tool call the model issued this turn. The model often
+                # batches several calls (e.g. one update_cell per row); running only the
+                # first would silently drop the rest, and the model — having emitted them
+                # all — would report success for cells that were never written.
+                #
+                # Expensive tools require a per-call confirmation, so if any call in the
+                # batch is expensive we handle a single call this turn and let the model
+                # re-issue the remainder next turn.
+                has_expensive = any(
+                    TOOL_BY_NAME.get(fc.name) is not None
+                    and TOOL_BY_NAME[fc.name].cost_class == "expensive"
+                    for fc in function_calls
+                )
+                batch = function_calls[:1] if has_expensive else function_calls
+
+                response_parts: list[Any] = []
+                for function_call in batch:
                     tool_name = function_call.name
                     args = dict(function_call.args or {})
                     tool = TOOL_BY_NAME.get(tool_name)
@@ -425,11 +437,11 @@ class ChatAgentService:
                                 columns=self._affected_columns(tool_name, args),
                             )
                         )
-                    response = await self._send_function_response(
-                        state,
-                        PendingToolCall(tool_name, args, function_call),
-                        tool_result,
+                    response_parts.append(
+                        self._function_response_part(tool_name, tool_result)
                     )
+
+                response = await self._send_function_response_parts(state, response_parts)
                 continue
 
             text = (getattr(response, "text", None) or "").strip()
@@ -455,15 +467,32 @@ class ChatAgentService:
         pending: PendingToolCall,
         tool_result: dict[str, Any],
     ) -> Any:
-        from google.genai import types
-
-        part = types.Part.from_function_response(
-            name=pending.tool_name,
-            response={"result": tool_result},
-        )
         LLMCallTracker.get_instance().set_stage("chat")
         state.pending_llm_calls += 1
-        return await state.chat.send_message(part)
+        return await state.chat.send_message(
+            self._function_response_part(pending.tool_name, tool_result)
+        )
+
+    @staticmethod
+    def _function_response_part(tool_name: str, tool_result: dict[str, Any]) -> Any:
+        from google.genai import types
+
+        return types.Part.from_function_response(
+            name=tool_name,
+            response={"result": tool_result},
+        )
+
+    async def _send_function_response_parts(
+        self, state: ChatSessionState, parts: list[Any]
+    ) -> Any:
+        """Send one function response per tool call the model issued this turn.
+
+        Gemini expects a response for every function call it emitted; sending all of
+        them together lets a batch of tool calls (e.g. several update_cell) all run.
+        """
+        LLMCallTracker.get_instance().set_stage("chat")
+        state.pending_llm_calls += 1
+        return await state.chat.send_message(parts)
 
     def _text_message(self, content: str) -> dict[str, Any]:
         return {

--- a/backend/tests/test_chat_agent_safety.py
+++ b/backend/tests/test_chat_agent_safety.py
@@ -356,3 +356,58 @@ async def test_excerpt_columns_excluded_from_targets(monkeypatch):
     service = _reextraction_service_with_columns(monkeypatch, ["Age", "Age_excerpt"])
     resolved = await service.resolve_reextraction_columns("s1", scope="all")
     assert resolved == ["Age"]
+
+
+# --- batched tool calls ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_batched_cheap_calls_all_execute(agent_with_fake_executor):
+    """When the model emits several cheap calls in one turn, all run (not just the
+    first). Regression: previously only function_calls[:1] ran, so filling N cells
+    via a batch of update_cell left N-1 cells silently unwritten."""
+    agent, executor = agent_with_fake_executor
+    chat = FakeChat([FakeResponse(text="Filled all rows.")])
+    state = _make_state(chat)
+
+    rows = [
+        ("John C. Coughenour", "Other Republican"),
+        ("Judge Canby", "Democratic"),
+        ("Judge Forrest", "Trump"),
+        ("Judge M. Smith", "Other Republican"),
+        ("Clay D. Land", "Other Republican"),
+    ]
+    calls = [
+        FakeFunctionCall("update_cell", {"row": r, "column": "appointee", "value": v})
+        for r, v in rows
+    ]
+    outbound: list[dict] = []
+    result = await agent._continue_after_tool(state, FakeResponse(function_calls=calls), outbound)
+
+    assert result["status"] == "complete"
+    executed_rows = [args["row"] for name, args in executor.executed if name == "update_cell"]
+    assert executed_rows == [r for r, _ in rows]  # all five, in order
+    # A single combined function-response message carries one part per call.
+    assert len(chat.sent) == 1
+    assert isinstance(chat.sent[0], list) and len(chat.sent[0]) == 5
+
+
+@pytest.mark.asyncio
+async def test_batch_with_expensive_still_pauses(agent_with_fake_executor):
+    """A batch containing an expensive tool must still gate on confirmation and not
+    execute anything inline."""
+    agent, executor = agent_with_fake_executor
+    chat = FakeChat([])
+    state = _make_state(chat)
+
+    calls = [
+        FakeFunctionCall("reextract", {"columns": ["Age"]}),
+        FakeFunctionCall("update_cell", {"row": "x", "column": "c", "value": "v"}),
+    ]
+    outbound: list[dict] = []
+    result = await agent._continue_after_tool(state, FakeResponse(function_calls=calls), outbound)
+
+    assert result["status"] == "pending_confirmation"
+    assert result["pending_action"]["tool_name"] == "reextract"
+    assert executor.executed == []
+    assert state.pending is not None and state.pending.tool_name == "reextract"


### PR DESCRIPTION
The agent loop executed only function_calls[:1] per turn and dropped the rest. When the model batches several cheap calls in one turn (e.g. one update_cell per row), only the first ran; the others were silently dropped and the model reported success for cells never written. The loop now executes all cheap calls in a turn and returns a function response for each; batches containing an expensive tool still gate on confirmation (no safety regression). Reproduced via the agent test harness; 2 new tests; full backend suite green.