### PR TITLE
fix(workspace): ensure cleared cell is actually applied after edit

### DIFF
--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -181,6 +181,9 @@ function Workspace() {
   // pre-edit value back in for a frame before the edit's own authoritative
   // refresh lands. Such stale payloads are dropped (not applied, not deferred).
   const editEpochRef = useRef(0);
+  // Tracks the in-flight silent refresh so concurrent silent refreshes coalesce
+  // (declared here so a local edit can invalidate it — see notifyLocalEdit).
+  const inFlightSilentRef = useRef<Promise<void> | null>(null);
   const cancelChatPendingRef = useRef<(() => Promise<boolean>) | null>(null);
 
   const cancelChatPendingIfAny = useCallback(async (): Promise<boolean> => {
@@ -189,11 +192,16 @@ function Workspace() {
   }, []);
 
   // Called synchronously when a local grid edit begins. Bumps the epoch so any
-  // refresh already in flight is treated as stale, and discards any snapshot
-  // deferred while the editor was open (it too predates the edit).
+  // refresh already in flight is treated as stale, discards any snapshot
+  // deferred while the editor was open (it too predates the edit), and drops
+  // the in-flight silent-refresh handle so the edit's own post-PUT refresh
+  // starts a *fresh* fetch (at the new epoch) instead of coalescing into the
+  // stale one — which would be rejected by the epoch guard, leaving the edit
+  // (e.g. a cell clear) never applied to state.
   const notifyLocalEdit = useCallback(() => {
     editEpochRef.current += 1;
     deferredDataRef.current = null;
+    inFlightSilentRef.current = null;
   }, []);
 
   const isCellEditorOpen = useCallback(() => {
@@ -309,11 +317,12 @@ function Workspace() {
     }
   }, [applyData, sessionId, sessionMode]);
 
-  const inFlightSilentRef = useRef<Promise<void> | null>(null);
   const refreshSilent = useCallback(() => {
     if (inFlightSilentRef.current) return inFlightSilentRef.current;
     const run = refresh({ silent: true }).finally(() => {
-      inFlightSilentRef.current = null;
+      // Only clear if this run is still the tracked one; a local edit (or a
+      // newer refresh) may have replaced the handle while we were in flight.
+      if (inFlightSilentRef.current === run) inFlightSilentRef.current = null;
     });
     inFlightSilentRef.current = run;
     return run;


### PR DESCRIPTION
## Problem
Follow-up to #288. After the epoch guard landed, clearing a cell (or any local grid edit) no longer took effect at all: the cell kept its old value. The edit's post-updateCell refresh went through refreshSilent, which returns an already in-flight silent refresh when one exists (disconnected poll / WebSocket reload). That in-flight refresh had captured the *previous* epoch, so the guard in applyData correctly dropped it — but because refreshSilent coalesced into it, no fresh refresh ever ran for the edit, and the cleared value was never applied to state.

## Solution
- notifyLocalEdit now also resets inFlightSilentRef, so the edit's own refreshSilent() (fired after the PUT resolves) starts a fresh fetch that captures the current epoch and passes the guard, applying the edit.
- refreshSilent's finally cleanup only clears the handle if it still points at its own run, so it can't clobber a newer refresh (or the reset performed by a local edit).

Single file, frontend only. No backend changes.

## Verify
- git apply --ignore-whitespace --check on a clean clone of main: passes
- ( cd frontend && npx tsc --noEmit ): clean
- Manual: clear a data cell -> it clears and stays cleared; edit a cell -> new value persists and does not revert.