### PR TITLE
feat: grounding display for reference-sourced values

### DIFF
--- a/backend/app/api/routes/reference.py
+++ b/backend/app/api/routes/reference.py
@@ -11,6 +11,7 @@ import logging
 from typing import List
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 
 from app.services import session_manager, websocket_manager
@@ -70,6 +71,26 @@ async def list_reference_documents(session_id: str) -> ReferenceDocumentList:
         session_id=session_id,
         reference_documents=[_to_info(r) for r in refsvc.list_reference_documents(session)],
     )
+
+
+@router.get("/{session_id}/{reference_id}/content", response_class=PlainTextResponse)
+async def get_reference_document_content(
+    session_id: str, reference_id: str
+) -> PlainTextResponse:
+    """Return a reference document's extracted plain text.
+
+    Used by the source panel to render a reference document inline and highlight
+    the passage a reference-sourced cell was filled from. The text is loaded from
+    the storage backend (or inline ``content`` for legacy documents).
+    """
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    ref = refsvc.get_reference_document(session, reference_id)
+    if not ref:
+        raise HTTPException(status_code=404, detail="Reference document not found")
+    text = await refsvc.load_reference_text(session_id, ref)
+    return PlainTextResponse(content=text or "")
 
 
 @router.post("/{session_id}/upload", response_model=ReferenceDocumentInfo)

--- a/frontend/src/components/DocumentViewer/DocumentPreview.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentPreview.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FileText, ExternalLink, Download, FileX, Upload } from 'lucide-react';
 
-import { unitsAPI } from '../../services/api';
+import { referenceAPI, unitsAPI } from '../../services/api';
 import { findHighlightRanges } from './highlightUtils';
 
 /** Extensions the browser can render inline in an <iframe>. */
@@ -63,6 +63,14 @@ interface DocumentPreviewProps {
    * document away and clicked the same cell again).
    */
   scrollNonce?: number;
+  /**
+   * When set, the panel renders this attached reference document instead of the
+   * source document `documentName` — used when the selected cell's value was
+   * filled from a reference. Reference text is fetched by id from the reference
+   * content endpoint and rendered with the same highlight-capable text renderer,
+   * so `highlightTexts` grounds the passage inside the reference.
+   */
+  referenceDoc?: { id: string; filename: string } | null;
 }
 
 /**
@@ -91,13 +99,25 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
   onRequestUpload,
   highlightTexts,
   scrollNonce,
+  referenceDoc,
 }) => {
+  // A reference document, when set, takes precedence over the row's source
+  // document: the selected cell's value came from the reference, so we render
+  // and highlight inside it. The display name drives extension detection.
+  const isReference = Boolean(referenceDoc);
+  const displayName = referenceDoc?.filename ?? documentName;
+
   const contentUrl = useMemo(() => {
-    if (!sessionId || !documentName) return null;
+    if (!sessionId) return null;
+    if (referenceDoc) {
+      // Reference content has no cache-staleness concern (immutable per id).
+      return referenceAPI.getContentUrl(sessionId, referenceDoc.id);
+    }
+    if (!documentName) return null;
     const base = unitsAPI.getDocumentContentUrl(sessionId, documentName);
     // Cache-bust so a freshly uploaded file isn't masked by a cached 404/response.
     return reloadToken ? `${base}&_t=${reloadToken}` : base;
-  }, [sessionId, documentName, reloadToken]);
+  }, [sessionId, documentName, reloadToken, referenceDoc]);
 
   const [availability, setAvailability] = useState<Availability>('idle');
 
@@ -120,15 +140,17 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
     };
   }, [contentUrl]);
 
-  const ext = documentName ? extensionOf(documentName) : '';
+  const ext = displayName ? extensionOf(displayName) : '';
   const canRenderInline = ext === '' || INLINE_EXTENSIONS.has(ext);
   const needsSandbox = SANDBOX_EXTENSIONS.has(ext);
   const showOpenFull = Boolean(contentUrl) && availability === 'ok';
 
   // Highlight mode is opt-in (the prop is present) and only applies to text
-  // formats we can render and annotate ourselves.
+  // formats we can render and annotate ourselves. Reference documents are always
+  // stored as extracted text, so they are text-renderable regardless of the
+  // original upload's extension (e.g. a .xlsx reference stored as .txt).
   const highlightEnabled = highlightTexts !== undefined;
-  const isTextRenderable = ext === '' || TEXT_EXTENSIONS.has(ext);
+  const isTextRenderable = isReference || ext === '' || TEXT_EXTENSIONS.has(ext);
   const useInlineText = highlightEnabled && isTextRenderable;
 
   const [text, setText] = useState<string | null>(null);
@@ -140,7 +162,7 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
   const [contentIsBinary, setContentIsBinary] = useState(false);
 
   useEffect(() => {
-    if (!useInlineText || !sessionId || !documentName || availability !== 'ok') {
+    if (!useInlineText || !sessionId || !displayName || availability !== 'ok') {
       setText(null);
       setTextError(false);
       setContentIsBinary(false);
@@ -150,8 +172,10 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
     setText(null);
     setTextError(false);
     setContentIsBinary(false);
-    unitsAPI
-      .getDocumentContentText(sessionId, documentName)
+    const fetchText = referenceDoc
+      ? referenceAPI.getContentText(sessionId, referenceDoc.id)
+      : unitsAPI.getDocumentContentText(sessionId, documentName as string);
+    fetchText
       .then((content) => {
         if (cancelled) return;
         if (content.startsWith('%PDF-') || content.indexOf('\u0000') !== -1) {
@@ -166,7 +190,7 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [useInlineText, sessionId, documentName, availability, reloadToken]);
+  }, [useInlineText, sessionId, documentName, displayName, availability, reloadToken, referenceDoc]);
 
   const highlightRanges = useMemo(
     () => (useInlineText ? findHighlightRanges(text, highlightTexts) : []),
@@ -247,10 +271,12 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
         <div className="h-full flex flex-col items-center justify-center gap-2 text-sm text-muted-foreground text-center px-6">
           <FileX className="h-8 w-8 opacity-40" />
           <span>This document isn&apos;t available to preview.</span>
-          <span className="text-xs">
-            Imported projects don&apos;t include the original files. Upload them to enable preview.
-          </span>
-          {onRequestUpload && (
+          {!isReference && (
+            <span className="text-xs">
+              Imported projects don&apos;t include the original files. Upload them to enable preview.
+            </span>
+          )}
+          {!isReference && onRequestUpload && (
             <button
               type="button"
               onClick={onRequestUpload}
@@ -271,7 +297,7 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
         <iframe
           key={contentUrl}
           src={contentUrl}
-          title={documentName || 'Document preview'}
+          title={displayName || 'Document preview'}
           className="w-full h-full border-0"
           {...(needsSandbox ? { sandbox: '' } : {})}
         />
@@ -305,8 +331,13 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
   return (
     <div className="flex-1 min-w-0 h-full flex flex-col">
       <div className="flex items-center gap-2 px-3 py-2 border-b border-border text-xs">
-        <span className="truncate text-muted-foreground" title={documentName || ''}>
-          {documentName || 'No document selected'}
+        {isReference && (
+          <span className="shrink-0 rounded bg-purple-100 px-1.5 py-0.5 font-medium text-purple-700 dark:bg-purple-950/40 dark:text-purple-300">
+            Reference
+          </span>
+        )}
+        <span className="truncate text-muted-foreground" title={displayName || ''}>
+          {displayName || 'No document selected'}
         </span>
         <span className="flex-1" />
         {showOpenFull && (

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -70,8 +70,11 @@ export function SpreadsheetSurface({
   hotTableRef: MutableRefObject<HotTableClass | null>;
   onSelectionChange: (selection: SheetSelection) => void;
   // Reports all grounding excerpts of the newly selected data cell (or null when
-  // the cell has no grounding), so the source panel can highlight them.
-  onGroundingHighlight?: (texts: string[] | null) => void;
+  // the cell has no grounding), so the source panel can highlight them. The
+  // second argument is the excerpt source (a reference filename when the value
+  // came from an attached reference document, else the source-document name), so
+  // the panel can decide which document to open and highlight in.
+  onGroundingHighlight?: (texts: string[] | null, source?: string | null) => void;
   // Fires on each mouse click of a grounded data cell, so the source panel can
   // re-scroll to the highlight even when the same cell is clicked again.
   onGroundingScrollRequest?: () => void;
@@ -927,7 +930,7 @@ export function SpreadsheetSurface({
         afterSelectionEnd={(row: number, col: number, row2: number, col2: number) => {
           if (row < 0 || col < 0 || row2 < 0 || col2 < 0) {
             onSelectionChange(null);
-            onGroundingHighlight?.(null);
+            onGroundingHighlight?.(null, null);
             return;
           }
           const fromRow = Math.min(row, row2);
@@ -945,6 +948,7 @@ export function SpreadsheetSurface({
           // first is scrolled into view).
           if (onGroundingHighlight) {
             let excerptTexts: string[] | null = null;
+            let excerptSource: string | null = null;
             if (activeSheet === 'data') {
               const column = sheet.columns[fromCol];
               const hot = hotTableRef.current?.hotInstance;
@@ -953,12 +957,16 @@ export function SpreadsheetSurface({
                 column && physicalRow != null && physicalRow >= 0
                   ? dataGrounding[physicalRow]?.[column.key]
                   : null;
-              const texts = (grounding?.excerpts ?? [])
+              const excerpts = grounding?.excerpts ?? [];
+              const texts = excerpts
                 .map((e) => e.text)
                 .filter((t): t is string => Boolean(t && t.trim()));
               excerptTexts = texts.length > 0 ? texts : null;
+              // Source of the first excerpt with one; the panel matches it
+              // against attached reference filenames to route highlighting.
+              excerptSource = excerpts.find((e) => e.source)?.source ?? null;
             }
-            onGroundingHighlight(excerptTexts);
+            onGroundingHighlight(excerptTexts, excerptSource);
           }
         }}
         afterOnCellMouseDown={(event, coords) => {

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -45,7 +45,7 @@ import SkippedDocumentsBanner from '@/components/DataTable/SkippedDocumentsBanne
 import { ViewModeToggle } from '@/components/ViewMode/ViewModeToggle';
 import MissingDocumentsSection from '@/components/SchemaEditor/MissingDocumentsSection';
 import TableFeedbackWidget from '@/components/TableFeedbackWidget/TableFeedbackWidget';
-import api, { configAPI, loadAPI, schematiqAPI, unitsAPI } from '@/services/api';
+import api, { configAPI, loadAPI, referenceAPI, schematiqAPI, unitsAPI, type ReferenceDocumentInfo } from '@/services/api';
 import type {
   CostEstimate,
   DataRow,
@@ -159,6 +159,13 @@ function Workspace() {
   // Grounding excerpts of the currently selected data cell, highlighted in the
   // source panel so the user can see every place the value came from.
   const [groundingHighlights, setGroundingHighlights] = useState<string[] | null>(null);
+  // Source (filename) of the selected cell's grounding excerpts. When it matches
+  // an attached reference document, the source panel opens that reference and
+  // highlights the passage there instead of the row's source document.
+  const [groundingSource, setGroundingSource] = useState<string | null>(null);
+  // Reference documents attached to this session, used to route grounding: an
+  // excerpt whose source matches one of these opens the reference in the panel.
+  const [referenceDocuments, setReferenceDocuments] = useState<ReferenceDocumentInfo[]>([]);
   // Bumped on each grounded-cell click so the source panel re-scrolls to the
   // highlight even when the excerpt set is unchanged (same cell clicked again).
   const [groundingScrollNonce, setGroundingScrollNonce] = useState(0);
@@ -510,6 +517,28 @@ function Workspace() {
     refresh();
   }, [refresh, sessionId]);
 
+  // Keep the attached-reference list current so grounding can route a cell whose
+  // excerpt source is a reference filename to the reference viewer. Cheap (metadata
+  // only); refreshed when the source panel opens and after source-file re-attach.
+  useEffect(() => {
+    if (!sessionId) {
+      setReferenceDocuments([]);
+      return;
+    }
+    let cancelled = false;
+    referenceAPI
+      .list(sessionId)
+      .then((refs) => {
+        if (!cancelled) setReferenceDocuments(refs);
+      })
+      .catch(() => {
+        if (!cancelled) setReferenceDocuments([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, showSourcePanel, sourceDocReloadToken]);
+
   const estimateCurrentCost = useCallback(async () => {
     if (!sessionId) return;
     if (sessionMode === 'load') {
@@ -537,7 +566,8 @@ function Workspace() {
   // Dedupe like updateSheetSelection: HotTable re-emits afterSelectionEnd on
   // every re-render, so returning the previous value for an unchanged excerpt
   // set is required to avoid an infinite render loop.
-  const handleGroundingHighlight = useCallback((texts: string[] | null) => {
+  const handleGroundingHighlight = useCallback((texts: string[] | null, source?: string | null) => {
+    setGroundingSource((current) => (current === (source ?? null) ? current : source ?? null));
     setGroundingHighlights((current) => {
       if (current === texts) return current;
       if (!current || !texts) return texts;
@@ -751,6 +781,21 @@ function Workspace() {
       (Array.isArray(row.papers) ? row.papers[0] : undefined);
     return raw ? String(raw).trim() : null;
   }, [activeSheet, sheetSelection, alignedDocData, alignedUnitData, dataView]);
+
+  // When the selected cell's grounding excerpt is sourced from an attached
+  // reference document (rather than the row's source document), resolve that
+  // reference so the panel can open and highlight the passage inside it. Matches
+  // by filename (the source stamped on the excerpt) with a basename fallback.
+  const selectedReferenceDoc = useMemo<ReferenceDocumentInfo | null>(() => {
+    if (!groundingSource || referenceDocuments.length === 0) return null;
+    const target = groundingSource.trim();
+    const basename = (name: string) => name.split(/[\\/]/).pop() ?? name;
+    return (
+      referenceDocuments.find((r) => r.filename === target) ??
+      referenceDocuments.find((r) => basename(r.filename) === basename(target)) ??
+      null
+    );
+  }, [groundingSource, referenceDocuments]);
 
   const handleAttachSourceDocs = useCallback(
     async (e: ChangeEvent<HTMLInputElement>) => {
@@ -992,6 +1037,7 @@ function Workspace() {
                   <DocumentPreview
                     sessionId={sessionId}
                     documentName={selectedSourceDoc}
+                    referenceDoc={selectedReferenceDoc}
                     emptyHint="Select a row to see its source document."
                     reloadToken={sourceDocReloadToken}
                     highlightTexts={groundingHighlights}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1094,6 +1094,23 @@ export const referenceAPI = {
   remove: async (sessionId: string, referenceId: string): Promise<void> => {
     await api.delete(`/reference/${sessionId}/${referenceId}`);
   },
+
+  /** URL of a reference document's raw text (used by the highlight-capable preview). */
+  getContentUrl: (sessionId: string, referenceId: string): string =>
+    `${API_BASE}/reference/${encodeURIComponent(sessionId)}/${encodeURIComponent(referenceId)}/content`,
+
+  /**
+   * Fetch a reference document's extracted plain text via the shared axios
+   * instance, so the source panel can render it in a DOM we control and
+   * highlight the passage a reference-sourced cell was filled from.
+   */
+  getContentText: async (sessionId: string, referenceId: string): Promise<string> => {
+    const response = await api.get<string>(
+      `/reference/${encodeURIComponent(sessionId)}/${encodeURIComponent(referenceId)}/content`,
+      { responseType: 'text', transformResponse: [(d) => d] },
+    );
+    return typeof response.data === 'string' ? response.data : String(response.data ?? '');
+  },
 };
 
 export async function downloadBlob(path: string, fallbackFilename: string): Promise<void> {

--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -45,6 +45,7 @@ from ..config.prompts import (
 )
 from ..utils.schema_builder import build_extraction_response_schema
 from ..utils.reference_retrieval import ReferenceRetriever
+from ..utils.reference_grounder import ReferenceGrounder
 from ..utils.excerpt_grounder import ExcerptGrounder
 
 # Type alias for warning callback: (paper_title, warning_type, message) -> None
@@ -107,6 +108,10 @@ class PaperProcessor:
         self.json_parser = JSONResponseParser()
         self.unit_parser = UnitIdentificationParser()
         self.text_processor = TextProcessor()
+        # Grounder that re-attributes reference-derived excerpts to the reference
+        # document they came from (built from the full blob, before the small/large
+        # split below reassigns reference_context). Inactive when no reference.
+        self.reference_grounder = ReferenceGrounder(reference_context)
         # Small reference -> inject whole (cheap, no retrieval). Large reference ->
         # index once and retrieve per unit so we never blow the context window.
         reference_retriever = None
@@ -363,6 +368,12 @@ class PaperProcessor:
                     )
                     for exc in excerpts
                 ]
+        # Excerpts pulled from the external reference are stamped above with the
+        # source-document filename; re-attribute those to the reference document
+        # they actually came from (and narrow tabular matches to a single row) so
+        # they highlight in the reference viewer rather than failing to match the
+        # source document. No-op when no reference is attached.
+        self.reference_grounder.reattribute(data)
         return data
 
     def _should_skip_truncation(self) -> bool:

--- a/schematiq-lib/schematiq/value_extraction/utils/reference_grounder.py
+++ b/schematiq-lib/schematiq/value_extraction/utils/reference_grounder.py
@@ -1,0 +1,209 @@
+"""Attribute extraction excerpts that came from an external reference document.
+
+During value extraction the model is given the source document *and* — when the
+user attached one — an external reference document (supplementary lookup material,
+e.g. a table mapping each judge to the president who appointed them). The model
+returns excerpts as verbatim quotes supporting each value, but it does not tell us
+*which document* a given excerpt came from.
+
+The default excerpt attribution stamps every excerpt with the source-document
+filename (see ``PaperProcessor._attach_source_to_excerpts``). That is wrong for a
+value the model pulled from the reference: the excerpt text lives in the reference,
+not the source document, so highlighting it against the source document would fail.
+
+This module re-attributes such excerpts. Given the combined reference-context blob
+(the same text injected into the extraction prompt, whose per-document sections are
+labelled ``--- Reference document: <filename> ---``), it:
+
+- locates each excerpt in the reference text (exact/case-insensitive/normalised),
+- when found, sets the excerpt's ``source`` to the owning reference filename, and
+- for tabular references, narrows the excerpt ``text`` to the single matching row
+  (keeping the header line) so the highlight in the reference viewer is precise.
+
+It is deliberately conservative: an excerpt that cannot be located in the reference
+text is left untouched, so source-document excerpts keep their existing attribution.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+# Section header emitted by ``build_reference_context`` for each attached
+# reference document. Kept in sync with backend reference_context.py.
+_SECTION_RE = re.compile(r"^--- Reference document: (?P<name>.+?) ---$")
+
+
+def _fold(text: str) -> str:
+    """Normalise whitespace and common unicode punctuation for robust matching.
+
+    Mirrors the spirit of the frontend highlight folding (unicode quotes/dashes,
+    collapsed whitespace) so an excerpt located here matches what the viewer can
+    later highlight. Deliberately lossy: used only for locating, never stored.
+    """
+    if not text:
+        return ""
+    folded = (
+        text.replace("\u2018", "'").replace("\u2019", "'")
+        .replace("\u201c", '"').replace("\u201d", '"')
+        .replace("\u2013", "-").replace("\u2014", "-")
+        .replace("\u00a0", " ")
+    )
+    return re.sub(r"\s+", " ", folded).strip().lower()
+
+
+@dataclass
+class _ReferenceSection:
+    """One attached reference document's text, plus tabular metadata."""
+
+    filename: str
+    text: str
+    folded: str = ""
+    is_tabular: bool = False
+    header_line: str = ""
+    # Physical lines of the section body (for single-row narrowing), with their
+    # folded form precomputed.
+    lines: List[str] = field(default_factory=list)
+    folded_lines: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.folded = _fold(self.text)
+        raw_lines = [ln for ln in self.text.splitlines()]
+        self.lines = raw_lines
+        self.folded_lines = [_fold(ln) for ln in raw_lines]
+        self._detect_tabular()
+
+    def _detect_tabular(self) -> None:
+        non_empty = [ln for ln in self.lines if ln.strip()]
+        if len(non_empty) < 3:
+            return
+        for delim in (",", "\t", "|"):
+            counts = [ln.count(delim) for ln in non_empty[:20]]
+            if counts and counts[0] >= 1 and sum(
+                c == counts[0] for c in counts
+            ) >= max(3, int(0.7 * len(counts))):
+                self.is_tabular = True
+                self.header_line = non_empty[0].strip()
+                return
+
+
+def _parse_sections(reference_context: str) -> List[_ReferenceSection]:
+    """Split the combined reference blob into per-document sections.
+
+    ``build_reference_context`` joins documents as::
+
+        --- Reference document: a.csv ---
+        <text of a>
+
+        --- Reference document: b.txt ---
+        <text of b>
+
+    If no headers are present (unexpected, but be defensive) the whole blob is
+    treated as a single unnamed section.
+    """
+    if not reference_context or not reference_context.strip():
+        return []
+
+    sections: List[Tuple[str, List[str]]] = []
+    current_name: Optional[str] = None
+    current_lines: List[str] = []
+    for line in reference_context.splitlines():
+        m = _SECTION_RE.match(line.strip())
+        if m:
+            if current_name is not None or current_lines:
+                sections.append((current_name or "reference", current_lines))
+            current_name = m.group("name").strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+    if current_name is not None or current_lines:
+        sections.append((current_name or "reference", current_lines))
+
+    result: List[_ReferenceSection] = []
+    for name, lines in sections:
+        text = "\n".join(lines).strip()
+        if text:
+            result.append(_ReferenceSection(filename=name, text=text))
+    return result
+
+
+class ReferenceGrounder:
+    """Re-attributes reference-derived excerpts to the reference they came from.
+
+    Build once from the combined reference-context blob, then call
+    :meth:`reattribute` on each extraction result to fix up its excerpts in place.
+    Cheap to build; matching is string search over the (small, per-document)
+    reference text.
+    """
+
+    def __init__(self, reference_context: Optional[str]):
+        self._sections = _parse_sections(reference_context or "")
+
+    @property
+    def active(self) -> bool:
+        return bool(self._sections)
+
+    def _match_row(self, section: _ReferenceSection, folded_excerpt: str) -> Optional[str]:
+        """Return the single tabular row (header + row) containing the excerpt.
+
+        Returns None if the excerpt does not map cleanly to one row, so the caller
+        keeps the model's original excerpt text.
+        """
+        if not section.is_tabular or not folded_excerpt:
+            return None
+        for raw, folded in zip(section.lines, section.folded_lines):
+            if not folded or folded == _fold(section.header_line):
+                continue
+            if folded_excerpt in folded or folded in folded_excerpt:
+                row = raw.strip()
+                if section.header_line and section.header_line != row:
+                    return f"{section.header_line}\n{row}"
+                return row
+        return None
+
+    def _locate(self, excerpt_text: str) -> Optional[Tuple[_ReferenceSection, Optional[str]]]:
+        """Find the reference section an excerpt came from.
+
+        Returns ``(section, narrowed_text_or_None)`` or None if the excerpt is not
+        found in any reference (i.e. it came from the source document).
+        """
+        folded = _fold(excerpt_text)
+        if not folded:
+            return None
+        for section in self._sections:
+            if folded in section.folded:
+                return section, self._match_row(section, folded)
+        return None
+
+    def reattribute(self, extraction_result: Dict[str, Any]) -> None:
+        """Fix excerpt attribution in an extraction result, in place.
+
+        For each excerpt whose text is located in a reference document, set its
+        ``source`` to that reference's filename and, for tabular references,
+        narrow its ``text`` to the matching row. Excerpts not found in any
+        reference are left untouched (they belong to the source document).
+        """
+        if not self._sections:
+            return
+        for col_name, col_value in extraction_result.items():
+            if col_name.startswith("_"):
+                continue
+            if not isinstance(col_value, dict):
+                continue
+            excerpts = col_value.get("excerpts")
+            if not isinstance(excerpts, list):
+                continue
+            for exc in excerpts:
+                if not isinstance(exc, dict):
+                    continue
+                text = exc.get("text")
+                if not isinstance(text, str) or not text.strip():
+                    continue
+                located = self._locate(text)
+                if located is None:
+                    continue
+                section, narrowed = located
+                exc["source"] = section.filename
+                if narrowed:
+                    exc["text"] = narrowed

--- a/schematiq-lib/tests/test_reference_grounder.py
+++ b/schematiq-lib/tests/test_reference_grounder.py
@@ -1,0 +1,117 @@
+"""Tests for reference excerpt re-attribution (ReferenceGrounder).
+
+Loaded directly from its module path so the test does not import the heavy
+schematiq package (which pulls sentence-transformers at import time).
+"""
+
+import importlib.util
+import os
+import sys
+
+_MODULE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "schematiq",
+    "value_extraction",
+    "utils",
+    "reference_grounder.py",
+)
+_spec = importlib.util.spec_from_file_location("reference_grounder", _MODULE_PATH)
+reference_grounder = importlib.util.module_from_spec(_spec)
+sys.modules["reference_grounder"] = reference_grounder
+_spec.loader.exec_module(reference_grounder)
+
+ReferenceGrounder = reference_grounder.ReferenceGrounder
+
+
+TABULAR_BLOB = (
+    "--- Reference document: judges.csv ---\n"
+    "name,appointing_president\n"
+    "William Acker,Nixon\n"
+    "Jane Doe,Reagan\n"
+    "\n"
+    "--- Reference document: notes.txt ---\n"
+    "Some prose about the case that is not tabular at all here."
+)
+
+
+def test_no_reference_is_noop():
+    g = ReferenceGrounder(None)
+    assert g.active is False
+    data = {"col": {"excerpts": [{"text": "x", "source": "ruling.pdf"}]}}
+    g.reattribute(data)
+    assert data["col"]["excerpts"][0]["source"] == "ruling.pdf"
+
+
+def test_tabular_excerpt_reattributed_and_narrowed_to_single_row():
+    g = ReferenceGrounder(TABULAR_BLOB)
+    assert g.active is True
+    data = {
+        "appointing_president": {
+            "answer": "Nixon",
+            "excerpts": [{"text": "William Acker,Nixon", "source": "ruling.pdf"}],
+        }
+    }
+    g.reattribute(data)
+    exc = data["appointing_president"]["excerpts"][0]
+    assert exc["source"] == "judges.csv"
+    # Header is kept and only the matching row is included (not Jane Doe).
+    assert "name,appointing_president" in exc["text"]
+    assert "William Acker,Nixon" in exc["text"]
+    assert "Jane Doe" not in exc["text"]
+
+
+def test_source_document_excerpt_is_left_untouched():
+    g = ReferenceGrounder(TABULAR_BLOB)
+    data = {
+        "summary": {
+            "answer": "x",
+            "excerpts": [
+                {"text": "This quote is only in the source document.", "source": "ruling.pdf"}
+            ],
+        }
+    }
+    g.reattribute(data)
+    assert data["summary"]["excerpts"][0]["source"] == "ruling.pdf"
+
+
+def test_prose_reference_excerpt_reattributed_without_narrowing():
+    g = ReferenceGrounder(TABULAR_BLOB)
+    data = {
+        "note": {
+            "answer": "y",
+            "excerpts": [{"text": "prose about the case", "source": "ruling.pdf"}],
+        }
+    }
+    g.reattribute(data)
+    exc = data["note"]["excerpts"][0]
+    assert exc["source"] == "notes.txt"
+    # Prose is not narrowed; the model's excerpt text is preserved.
+    assert exc["text"] == "prose about the case"
+
+
+def test_matching_is_whitespace_and_quote_insensitive():
+    blob = (
+        "--- Reference document: r.txt ---\n"
+        "The court held that \u201cthe statute applies\u201d in full."
+    )
+    g = ReferenceGrounder(blob)
+    data = {
+        "c": {
+            "answer": "z",
+            # Straight quotes and collapsed spacing vs. curly quotes in the source.
+            "excerpts": [{"text": 'the  statute   applies', "source": "doc.pdf"}],
+        }
+    }
+    g.reattribute(data)
+    assert data["c"]["excerpts"][0]["source"] == "r.txt"
+
+
+def test_ignores_underscore_columns_and_string_excerpts():
+    g = ReferenceGrounder(TABULAR_BLOB)
+    data = {
+        "_cell_status": {"appointing_president": "external_source"},
+        "col": {"answer": "a", "excerpts": ["William Acker,Nixon"]},  # not a dict excerpt
+    }
+    # Should not raise, and string excerpts are skipped (only dict excerpts fixed).
+    g.reattribute(data)
+    assert data["col"]["excerpts"] == ["William Acker,Nixon"]


### PR DESCRIPTION
## Problem
Values filled from an attached reference document were attributed only to a filename, with a placeholder excerpt. There was no real grounding: the actual reference passage was not captured, reference documents were not viewable in the source panel, and clicking a reference-sourced cell highlighted nothing.

## Solution
Implements all three pieces of `01-next-grounding-display.md` (RAG/extraction path; single-row granularity for tabular references).

1. **Capture the real passage** — new `schematiq-lib/.../utils/reference_grounder.py`. `ReferenceGrounder` parses the combined reference blob by its `--- Reference document: <filename> ---` headers, locates each extraction excerpt in the reference text (whitespace/unicode-folded matching), re-stamps `source` to the owning reference filename, and narrows tabular matches to header + the single matching row. Wired into `PaperProcessor`: built in `__init__` from the original blob (before the small/large split nulls it) and invoked at the end of `_attach_source_to_excerpts`, so it covers every extraction path. Excerpts not found in any reference are left untouched (source-document grounding is unchanged).

2. **Viewable reference** — new `GET /api/reference/{session_id}/{reference_id}/content` returning the stored text via `load_reference_text`; `referenceAPI.getContentUrl`/`getContentText` clients. `DocumentPreview` gains a `referenceDoc` prop that takes precedence over `documentName`, fetches reference text by id, forces the highlight-capable text renderer (reference docs are stored as extracted text), and shows a "Reference" badge.

3. **Source-based routing** — `SpreadsheetSurface` now passes the selected excerpt's `source` alongside the highlight texts. `Workspace` loads the attached reference list and resolves the selected reference (filename match with basename fallback); when the excerpt source matches an attached reference, the panel opens that reference and highlights the passage there instead of the row's source document.

## Verify
- `git apply --ignore-whitespace --check` on a clean main clone: OK
- `( cd frontend && npx tsc --noEmit )`: clean
- `python -m py_compile` on changed backend/lib files: OK
- `python -m pytest tests/test_reference_grounder.py`: 6 passed (no-reference no-op, tabular re-attribution + single-row narrowing, source-doc excerpt untouched, prose re-attribution, quote/whitespace-insensitive matching, underscore-column/string-excerpt safety)

Manual: fill a column from a tabular reference via extraction, click the cell with the source panel open. Expected: the reference opens (purple "Reference" badge), the matching row is highlighted in yellow. Source-document values still highlight in their source document (no regression).