### PR TITLE
fix(workspace): restore reliable in-session cell editing

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -55,7 +55,8 @@ export function SpreadsheetSurface({
   onGroundingHighlight,
   onGroundingScrollRequest,
   onRefresh,
-  onLocalEdit,
+  onRefreshData,
+  onOptimisticCellEdit,
   onEditFollowUp,
   onEditEnd,
   layoutRevision,
@@ -76,10 +77,15 @@ export function SpreadsheetSurface({
   // re-scroll to the highlight even when the same cell is clicked again.
   onGroundingScrollRequest?: () => void;
   onRefresh: () => void;
-  // Fired synchronously the instant a local grid edit is made, before its PUT
-  // resolves. Lets the parent invalidate in-flight/deferred background
-  // refreshes so a stale payload cannot flash the pre-edit value back in.
-  onLocalEdit: () => void;
+  // Row-data-only refresh after a Data-sheet cell edit (no status/schema churn).
+  onRefreshData: () => void;
+  // Apply the edited value to React state immediately so the grid does not
+  // revert when a background refresh re-renders before the PUT completes.
+  onOptimisticCellEdit: (
+    identity: { rowName: string; sourceDocument?: string; rowIndex?: number },
+    column: string,
+    value: string,
+  ) => void;
   onEditFollowUp: (kind: PendingRerunKind, columns?: string[]) => void;
   onEditEnd: () => void;
   layoutRevision: string;
@@ -582,39 +588,40 @@ export function SpreadsheetSurface({
       if (oldValue === newValue || prop == null) continue;
       const key = String(prop);
 
-      // Signal the edit before any async persistence so the parent can drop
-      // background refreshes that were fetched pre-edit. Without this a clear
-      // (or any edit) briefly reverts when a stale silent refresh lands, then
-      // re-applies once the edit's own refresh resolves.
-      onLocalEdit();
-
       if (activeSheet === 'data') {
         if (key.startsWith('_')) continue;
         const sourceRow: DataRow | undefined = data.rows[rowIndex];
         const rowName = sourceRow?.row_name || sourceRow?._unit_name || '';
         const rowIndexId = sourceRow?._row_index;
+        const sourceDocument = sourceRow?._source_document || sourceRow?._parent_document;
         if (!rowName && rowIndexId == null) {
           toast({
             title: 'Cell update failed',
             description: 'Could not identify which row to update.',
             variant: 'destructive',
           });
-          onRefresh();
+          onRefreshData();
           continue;
         }
+
+        onOptimisticCellEdit(
+          { rowName, sourceDocument, rowIndex: rowIndexId },
+          key,
+          String(newValue ?? ''),
+        );
 
         schematiqAPI.updateCell(
           sessionId,
           rowName,
           key,
           String(newValue ?? ''),
-          sourceRow?._source_document || sourceRow?._parent_document,
+          sourceDocument,
           rowIndexId
         )
           .then(() => {
             const rowLabel = rowName || (rowIndexId != null ? `Row ${rowIndexId + 1}` : 'Row');
             toast({ title: 'Cell updated', description: `${rowLabel} / ${key}` });
-            onRefresh();
+            onRefreshData();
           })
           .catch((err: any) => {
             toast({
@@ -622,7 +629,7 @@ export function SpreadsheetSurface({
               description: err?.response?.data?.detail || err?.message || 'Could not update cell',
               variant: 'destructive',
             });
-            onRefresh();
+            onRefreshData();
           });
       }
 
@@ -743,7 +750,7 @@ export function SpreadsheetSurface({
           });
       }
     }
-  }, [activeSheet, data.rows, observationUnitRows, onEditFollowUp, onLocalEdit, onRefresh, schemaColumns, sessionId, toast]);
+  }, [activeSheet, data.rows, observationUnitRows, onEditFollowUp, onOptimisticCellEdit, onRefresh, onRefreshData, schemaColumns, sessionId, toast]);
 
   const handleBeforeRemoveRow = useCallback(
     (_index: number, _amount: number, physicalRows: number[], _source?: string): boolean | void => {

--- a/frontend/src/pages/Workspace/helpers.ts
+++ b/frontend/src/pages/Workspace/helpers.ts
@@ -7,6 +7,7 @@ import type {
   ChatToolInfo,
   ChatTurnMessage,
   CostEstimate,
+  DataRow,
   PaginatedData,
   ScheMatiQConfig,
   ScheMatiQStatus,
@@ -133,6 +134,51 @@ export function buildExportFilename(question: string, ext: string, sessionId?: s
   const stem = slug || (sessionId ? sessionId.slice(0, 8) : 'project');
   return `schematiq_${stem}_${date}.${ext}`;
 }
+/** Apply a single cell edit to a copy of the paginated data (optimistic UI). */
+export function patchDataCell(
+  data: PaginatedData,
+  identity: { rowName: string; sourceDocument?: string; rowIndex?: number },
+  column: string,
+  value: string,
+): PaginatedData {
+  let changed = false;
+  const rows = data.rows.map((row, idx) => {
+    if (!rowMatchesEditIdentity(row, identity, idx)) return row;
+    changed = true;
+    return patchRowCellValue(row, column, value);
+  });
+  if (!changed) return data;
+  return { ...data, rows };
+}
+
+function rowMatchesEditIdentity(
+  row: DataRow,
+  identity: { rowName: string; sourceDocument?: string; rowIndex?: number },
+  _index: number,
+): boolean {
+  if (!identity.rowName && identity.rowIndex != null) {
+    return row._row_index === identity.rowIndex;
+  }
+  const name = row.row_name || row._unit_name || '';
+  if (name !== identity.rowName) return false;
+  if (identity.sourceDocument) {
+    const src = row._source_document || row._parent_document || '';
+    if (src && src !== identity.sourceDocument) return false;
+  }
+  return true;
+}
+
+function patchRowCellValue(row: DataRow, column: string, value: string): DataRow {
+  const next = { ...row };
+  const cell = { answer: value, excerpts: [] as unknown[], manually_edited: true };
+  if (next.data && typeof next.data === 'object') {
+    next.data = { ...next.data, [column]: cell };
+  } else {
+    next.data = { [column]: cell };
+  }
+  return next;
+}
+
 export function dataEquals(a: PaginatedData, b: PaginatedData): boolean {
   if (a === b) return true;
   if (

--- a/frontend/src/pages/Workspace/hooks/useWorkspaceSocket.ts
+++ b/frontend/src/pages/Workspace/hooks/useWorkspaceSocket.ts
@@ -128,13 +128,19 @@ export function useWorkspaceSocket({
       if (
         message.type === 'progress' ||
         message.type === 'completed' ||
-        message.type === 'schema_completed' ||
-        message.type === 'schema_updated' ||
         message.type === 'cell_extracted' ||
         message.type === 'row_completed' ||
-        message.type === 'schema_progress' ||
         message.type === 'reprocessing_progress' ||
-        message.type === 'reprocessing_completed' ||
+        message.type === 'reprocessing_completed'
+      ) {
+        void refreshSilent();
+        return;
+      }
+
+      if (
+        message.type === 'schema_completed' ||
+        message.type === 'schema_updated' ||
+        message.type === 'schema_progress' ||
         message.type === 'observation_unit_definition_updated'
       ) {
         void refresh({ silent: true });

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -64,6 +64,7 @@ import {
   buildExportFilename,
   dataEquals,
   documentDisplayName,
+  patchDataCell,
   schemaFromLoadSession,
   selectionArea,
   selectionsEqual,
@@ -175,33 +176,11 @@ function Workspace() {
   } = useWorkspaceLayout();
 
   const deferredDataRef = useRef<PaginatedData | null>(null);
-  // Monotonic edit epoch. Bumped the instant a local grid edit begins (e.g.
-  // clearing a cell). A silent refresh whose network fetch started before the
-  // current epoch is stale: its payload predates the edit and would flash the
-  // pre-edit value back in for a frame before the edit's own authoritative
-  // refresh lands. Such stale payloads are dropped (not applied, not deferred).
-  const editEpochRef = useRef(0);
-  // Tracks the in-flight silent refresh so concurrent silent refreshes coalesce
-  // (declared here so a local edit can invalidate it — see notifyLocalEdit).
-  const inFlightSilentRef = useRef<Promise<void> | null>(null);
   const cancelChatPendingRef = useRef<(() => Promise<boolean>) | null>(null);
 
   const cancelChatPendingIfAny = useCallback(async (): Promise<boolean> => {
     if (!cancelChatPendingRef.current) return true;
     return cancelChatPendingRef.current();
-  }, []);
-
-  // Called synchronously when a local grid edit begins. Bumps the epoch so any
-  // refresh already in flight is treated as stale, discards any snapshot
-  // deferred while the editor was open (it too predates the edit), and drops
-  // the in-flight silent-refresh handle so the edit's own post-PUT refresh
-  // starts a *fresh* fetch (at the new epoch) instead of coalescing into the
-  // stale one — which would be rejected by the epoch guard, leaving the edit
-  // (e.g. a cell clear) never applied to state.
-  const notifyLocalEdit = useCallback(() => {
-    editEpochRef.current += 1;
-    deferredDataRef.current = null;
-    inFlightSilentRef.current = null;
   }, []);
 
   const isCellEditorOpen = useCallback(() => {
@@ -210,12 +189,11 @@ function Workspace() {
   }, []);
 
   const applyData = useCallback(
-    (nextData: PaginatedData, opts?: { silent?: boolean; epoch?: number }) => {
-      // Drop a silent refresh whose fetch predates the latest local edit.
-      if (opts?.silent && opts.epoch != null && opts.epoch < editEpochRef.current) {
-        return;
-      }
-      if (opts?.silent && isCellEditorOpen()) {
+    (nextData: PaginatedData, opts?: { silent?: boolean; force?: boolean }) => {
+      // Background polls defer while the inline editor is open so a mid-edit
+      // fetch cannot clobber what the user is typing. Post-edit refreshes pass
+      // force so the persisted value is always applied.
+      if (opts?.silent && !opts?.force && isCellEditorOpen()) {
         deferredDataRef.current = nextData;
         return;
       }
@@ -232,12 +210,36 @@ function Workspace() {
     setData((current) => (dataEquals(current, pending) ? current : pending));
   }, []);
 
+  // Fetch row data only — no status/schema/session churn. Used after cell edits
+  // and for background polls so a refresh cannot re-render the grid from stale
+  // React state while the network round-trip is still in flight.
+  const refreshData = useCallback(async (options?: { silent?: boolean; force?: boolean }) => {
+    if (!sessionId) return;
+    const fetchData = sessionMode === 'load'
+      ? () => loadAPI.getData(sessionId, 0, 500)
+      : () => schematiqAPI.getData(sessionId, 0, 500);
+    const nextData = await fetchData().catch(() => emptyData);
+    applyData(nextData, options);
+  }, [applyData, sessionId, sessionMode]);
+
+  const refreshAfterEdit = useCallback(() => refreshData({ silent: true, force: true }), [refreshData]);
+
+  const refreshSilent = useCallback(() => refreshData({ silent: true }), [refreshData]);
+
+  const applyOptimisticCellEdit = useCallback((
+    identity: { rowName: string; sourceDocument?: string; rowIndex?: number },
+    column: string,
+    value: string,
+  ) => {
+    deferredDataRef.current = null;
+    const patch = (current: PaginatedData) => patchDataCell(current, identity, column, value);
+    setData(patch);
+    setUnitData(patch);
+  }, []);
+
   const refresh = useCallback(async (options?: { silent?: boolean }) => {
     if (!sessionId) return;
     const silent = Boolean(options?.silent);
-    // Snapshot the edit epoch at fetch start so applyData can drop this payload
-    // if a local edit happens (or already happened) while it was in flight.
-    const startEpoch = editEpochRef.current;
     if (!silent) {
       setLoading(true);
     }
@@ -258,7 +260,7 @@ function Workspace() {
           fetchData().catch(() => emptyData),
           fetchDocuments().catch(() => null),
         ]);
-        applyData(nextData, { ...options, epoch: startEpoch });
+        applyData(nextData, options);
         setDocuments(nextDocuments);
       } finally {
         if (!silent) setDataLoading(false);
@@ -316,17 +318,6 @@ function Workspace() {
       }
     }
   }, [applyData, sessionId, sessionMode]);
-
-  const refreshSilent = useCallback(() => {
-    if (inFlightSilentRef.current) return inFlightSilentRef.current;
-    const run = refresh({ silent: true }).finally(() => {
-      // Only clear if this run is still the tracked one; a local edit (or a
-      // newer refresh) may have replaced the handle while we were in flight.
-      if (inFlightSilentRef.current === run) inFlightSilentRef.current = null;
-    });
-    inFlightSilentRef.current = run;
-    return run;
-  }, [refresh]);
 
   const {
     addDocsFiles,
@@ -802,8 +793,9 @@ function Workspace() {
         onSelectionChange={updateSheetSelection}
         onGroundingHighlight={handleGroundingHighlight}
         onGroundingScrollRequest={() => setGroundingScrollNonce((n) => n + 1)}
-        onRefresh={refreshSilent}
-        onLocalEdit={notifyLocalEdit}
+        onRefresh={() => void refresh({ silent: true })}
+        onRefreshData={refreshAfterEdit}
+        onOptimisticCellEdit={applyOptimisticCellEdit}
         onEditFollowUp={notifyEditFollowUp}
         onEditEnd={flushDeferredData}
         layoutRevision={gridLayoutRevision}


### PR DESCRIPTION
## Summary

- Removes the epoch/pending/authoritative refresh machinery from #288/#290 that blocked or deferred post-edit refreshes, leaving React row state stale until a full page reload.
- Adds optimistic `patchDataCell` updates (both `data` and `unitData`) so the grid reflects edits immediately.
- Introduces `refreshData()` — row fetch only, no status/schema/session churn — for post-edit sync and background polls; schema/unit edits still use a full silent refresh.
- WebSocket row-progress events now use data-only refresh; schema events keep full refresh.

Backend #292 (multi-file cell writes) is unchanged and remains the correct persistence fix.

## Test plan

- [x] `(cd frontend && npx tsc --noEmit)` passes
- [ ] Edit a data cell → value sticks without page refresh
- [ ] Clear a data cell → stays cleared; no flash of old value on next click
- [ ] Repeat in **By Document** and **By Unit** views
- [ ] Schema column edit still updates the Schema sheet after save


Made with [Cursor](https://cursor.com)