### PR TITLE
chore: centralize LOG_LEVEL and LLM_USAGE_SYNC_TTL_SECONDS in config

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -42,6 +42,7 @@ API_VERSION = "1.0.0"
 # Server Configuration
 DEFAULT_HOST = os.environ.get("HOST", "0.0.0.0")
 DEFAULT_PORT = int(os.environ.get("PORT", 8000))
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
 
 # CORS Configuration - supports comma-separated origins via ALLOWED_ORIGINS env var
 _default_origins = [
@@ -138,6 +139,7 @@ LLM_CALL_GLOBAL_LIMIT = int(os.environ.get("LLM_CALL_GLOBAL_LIMIT", "1000"))
 # When > 0, only LLM calls recorded within the last N days count toward
 # LLM_CALL_GLOBAL_LIMIT, so the quota recovers as old usage ages out.
 LLM_CALL_LIMIT_WINDOW_DAYS = int(os.environ.get("LLM_CALL_LIMIT_WINDOW_DAYS", "0"))
+LLM_USAGE_SYNC_TTL_SECONDS = float(os.environ.get("LLM_USAGE_SYNC_TTL_SECONDS", "300"))
 
 # ── Quota Alert Email ────────────────────────────────────────────
 # Send an email when the LLM quota is exceeded.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,12 +9,18 @@ from pathlib import Path
 from dotenv import load_dotenv
 load_dotenv(Path(__file__).parent.parent / ".env")
 
+# Add schematiq-lib to Python path (sibling directory to backend)
+_SCHEMATIQ_LIB_PATH = Path(__file__).parent.parent.parent / "schematiq-lib"
+if _SCHEMATIQ_LIB_PATH.exists() and str(_SCHEMATIQ_LIB_PATH) not in sys.path:
+    sys.path.insert(0, str(_SCHEMATIQ_LIB_PATH))
+
 # Configure logging to show in container logs
 # Set LOG_LEVEL=DEBUG to see detailed schema column tracking
 # Format includes [session_id] for Railway log filtering per session
+from app.core.config import LOG_LEVEL
 from app.core.logging_utils import SessionFilter
 
-log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+log_level = LOG_LEVEL.upper()
 logging.basicConfig(
     level=getattr(logging, log_level, logging.INFO),
     format='%(levelname)s:%(name)s:[%(session_id)s] %(message)s',
@@ -27,11 +33,6 @@ for _handler in logging.root.handlers:
 
 # Suppress noisy uvicorn access logs (frontend polling every ~3s floods Railway logs)
 logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
-
-# Add schematiq-lib to Python path (sibling directory to backend)
-_SCHEMATIQ_LIB_PATH = Path(__file__).parent.parent.parent / "schematiq-lib"
-if _SCHEMATIQ_LIB_PATH.exists() and str(_SCHEMATIQ_LIB_PATH) not in sys.path:
-    sys.path.insert(0, str(_SCHEMATIQ_LIB_PATH))
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware

--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -11,7 +11,10 @@ from typing import Dict, Any, Optional, List, Tuple
 from pathlib import Path
 from datetime import datetime
 
-from app.core.config import MAX_DOCUMENTS, DEVELOPER_MODE, LLM_CALL_GLOBAL_LIMIT, LLM_CALL_LIMIT_WINDOW_DAYS
+from app.core.config import (
+    MAX_DOCUMENTS, DEVELOPER_MODE, LLM_CALL_GLOBAL_LIMIT, LLM_CALL_LIMIT_WINDOW_DAYS,
+    LLM_USAGE_SYNC_TTL_SECONDS,
+)
 from app.core.logging_utils import set_session_context
 from app.services import schematiq_thread_pool, concurrency_limiter
 
@@ -74,7 +77,7 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         # file already reflects everything recorded by this process (pipeline
         # and chat), so the external total only guards against redeploys and
         # is allowed to be a few minutes stale.
-        self._usage_sync_ttl = float(os.environ.get("LLM_USAGE_SYNC_TTL_SECONDS", "300"))
+        self._usage_sync_ttl = LLM_USAGE_SYNC_TTL_SECONDS
         self._usage_sync_lock = threading.Lock()
         self._last_sheets_sync = 0.0
         self._external_window_cache: Dict[int, Tuple[float, int]] = {}


### PR DESCRIPTION
## Summary
- Add `LOG_LEVEL` and `LLM_USAGE_SYNC_TTL_SECONDS` to `backend/app/core/config.py` as the single source of truth for these env vars
- Update `main.py` and `schematiq_runner.py` to import the constants instead of reading `os.environ` directly
- Move `schematiq-lib` path setup earlier in `main.py` so `config` can import before logging init (same logic, no behavior change)

## Test plan
- [x] `python -m py_compile app/core/config.py app/main.py app/services/schematiq_runner.py`
- [x] `LLM_CALL_GLOBAL_LIMIT=0 python -m pytest -q` (136 passed, 1 skipped)
- [x] `python -c "from app.main import app"`
- [x] Grep confirms no scattered `os.environ` reads for moved vars outside `config.py`


Made with [Cursor](https://cursor.com)