### PR TITLE
fix: use relative import for table module in metrics.py

### DIFF
--- a/schematiq-lib/schematiq/evaluation/metrics.py
+++ b/schematiq-lib/schematiq/evaluation/metrics.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 # from bert_score import BERTScorer
 import numpy as np
 
-from table import Table
+from .table import Table
 
 class BaseMetric:
     """Calculates and stores information for evaluation metrics.


### PR DESCRIPTION
## Problem
`schematiq-lib/schematiq/evaluation/metrics.py` used an absolute import (`from table import Table`) instead of a relative one, even though `table.py` lives in the same directory and the sibling `__init__.py` correctly uses `from .table import Table`.

This import only resolves if `evaluation/` itself happens to be on `sys.path` — which never happens under normal usage (importing `schematiq.evaluation`, running `test_evaluation.py` via pytest from repo root, from `schematiq-lib/`, or from `backend/`). Under all realistic import paths it raises `ModuleNotFoundError: No module named 'table'`.

## Solution
Changed the import to `from .table import Table`, matching the working pattern already used in `evaluation/__init__.py`.

## Verify
```
git apply --ignore-whitespace --check fix-metrics-table-import.patch
python -m py_compile schematiq-lib/schematiq/evaluation/metrics.py
( cd frontend && npx tsc --noEmit )
```
Confirmed via direct package-import test: before the fix, importing `schematiq.evaluation.metrics` as a package (the real-world usage pattern) raises `ModuleNotFoundError: No module named 'table'`; after the fix it imports cleanly.