### PR TITLE
fix(chat): slightly reduce attach and send button heights to 32px

### DIFF
--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -533,6 +533,7 @@ export function ChatPanel({
             type="button"
             size="sm"
             variant="outline"
+            className="h-8 px-3"
             onClick={handleAttachClick}
             disabled={!sessionId || uploadingReference}
             title="Attach an external reference document (e.g. a lookup spreadsheet). It is not treated as a source document."
@@ -549,7 +550,7 @@ export function ChatPanel({
             size="icon"
             onClick={ask}
             disabled={busy || !input.trim()}
-            className="ml-auto h-9 w-9 rounded-lg"
+            className="ml-auto h-8 w-8 rounded-lg"
             aria-label="Send message"
             title="Send message (Enter)"
           >


### PR DESCRIPTION
## Problem
The Attach reference and send buttons (both 36px) felt a touch large in the chat input footer.

## Solution
Reduce both to 32px: Attach reference gets h-8 px-3, the send button gets h-8 w-8. Kept them aligned in height.

## Verify
- git apply --check on fresh main: OK
- cd frontend && npx tsc --noEmit: OK