### PR TITLE
fix: remove unused PyPDF2 dependency and suppress SWIG test warnings

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 asyncio_mode = auto
 testpaths = tests
+filterwarnings =
+    ignore:builtin type Swig\w* has no __module__ attribute:DeprecationWarning

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,7 +12,6 @@ numpy>=2.0.0
 
 # PDF processing
 pymupdf4llm>=0.2.8
-PyPDF2>=3.0.0
 python-docx>=1.1.0
 pdfplumber>=0.11.0
 pdf2image>=1.17.0


### PR DESCRIPTION
## Problem
`pytest -q` in backend/ produces two categories of warning noise:
1. `PyPDF2 is deprecated" — but PyPDF2 isn't used anywhere in backend/ (only in schematiq-lib/); it's a stale requirements.txt entry.
2. `SwigPyPacked`/`SwigPyObject`/`swigvarlink` DeprecationWarnings — emitted by pymupdf4llm's SWIG-based C-extension bindings, triggered when app.services.pdf_utils is imported (for monkeypatching) in test_continue_discovery_original_docs.py.

## Solution
- Removed the unused `PyPDF2>=3.0.0` line from `backend/requirements.txt`.
- Added `filterwarnings` to `backend/pytest.ini` to suppress the unavoidable third-party SWIG warnings, since they come from pymupdf4llm's internals and aren't actionable in our code.

## Verify
```
git apply --ignore-whitespace --check fix-backend-test-warnings.patch
( cd frontend && npx tsc --noEmit )
```
Verified functionally with a throwaway test emitting the exact three SWIG warning strings against the patched pytest.ini — all three suppressed, confirmed via the case-insensitive matching behavior of Python's warnings module (not just regex simulation).