### PR TITLE
feat(quota): approaching-limit warning email

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -141,6 +141,10 @@ LLM_CALL_GLOBAL_LIMIT = int(os.environ.get("LLM_CALL_GLOBAL_LIMIT", "1000"))
 LLM_CALL_LIMIT_WINDOW_DAYS = int(os.environ.get("LLM_CALL_LIMIT_WINDOW_DAYS", "0"))
 LLM_USAGE_SYNC_TTL_SECONDS = float(os.environ.get("LLM_USAGE_SYNC_TTL_SECONDS", "300"))
 
+# Fraction of LLM_CALL_GLOBAL_LIMIT at which to send a one-time "approaching
+# limit" warning email (e.g. 0.8 = warn at 80%). Set to 0 to disable the warning.
+LLM_CALL_WARN_THRESHOLD = float(os.environ.get("LLM_CALL_WARN_THRESHOLD", "0.8"))
+
 # ── Quota Alert Email ────────────────────────────────────────────
 # Send an email when the LLM quota is exceeded.
 # Uses the same Google OAuth credentials as Google Sheets (no extra passwords).

--- a/backend/app/core/email_alerts.py
+++ b/backend/app/core/email_alerts.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 # Track whether we already sent the quota alert (avoid spamming)
 _quota_alert_sent = False
+_quota_warning_sent = False
 _lock = threading.Lock()
 
 
@@ -138,6 +139,51 @@ def send_quota_exceeded_alert(total_used: int) -> None:
         <p style="color: #666; font-size: 14px;">
             To resume service, either increase <code>LLM_CALL_GLOBAL_LIMIT</code> in Railway
             environment variables, or reset the usage counter.
+        </p>
+    </div>
+    """
+    _send_email(subject, html_body)
+
+
+def send_quota_warning_alert(used: int, limit: int) -> None:
+    """Send a one-time email when LLM usage approaches the quota.
+
+    Fires before the limit is reached (see LLM_CALL_WARN_THRESHOLD) so service
+    can be extended before it blocks. Sent once per process lifetime.
+    """
+    global _quota_warning_sent
+    with _lock:
+        if _quota_warning_sent:
+            return
+        _quota_warning_sent = True
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    pct = int(round(100 * used / limit)) if limit else 0
+    subject = "ScheMatiQ — LLM Usage Approaching Limit"
+    html_body = f"""
+    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <h2 style="color: #e67e22;">LLM Usage Approaching Limit</h2>
+        <p>ScheMatiQ has used <strong>{pct}%</strong> of its API call quota.
+           Service is still running, but will stop accepting new work once the
+           limit is reached.</p>
+        <table style="border-collapse: collapse; margin: 16px 0;">
+            <tr>
+                <td style="padding: 8px 16px; border: 1px solid #ddd; font-weight: bold;">Calls Used</td>
+                <td style="padding: 8px 16px; border: 1px solid #ddd;">{used:,}</td>
+            </tr>
+            <tr>
+                <td style="padding: 8px 16px; border: 1px solid #ddd; font-weight: bold;">Limit</td>
+                <td style="padding: 8px 16px; border: 1px solid #ddd;">{limit:,}</td>
+            </tr>
+            <tr>
+                <td style="padding: 8px 16px; border: 1px solid #ddd; font-weight: bold;">Time</td>
+                <td style="padding: 8px 16px; border: 1px solid #ddd;">{now}</td>
+            </tr>
+        </table>
+        <p style="color: #666; font-size: 14px;">
+            To avoid interruption, raise <code>LLM_CALL_GLOBAL_LIMIT</code> in Railway
+            environment variables, or set a rolling window via
+            <code>LLM_CALL_LIMIT_WINDOW_DAYS</code>.
         </p>
     </div>
     """

--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 from app.core.config import (
     MAX_DOCUMENTS, DEVELOPER_MODE, LLM_CALL_GLOBAL_LIMIT, LLM_CALL_LIMIT_WINDOW_DAYS,
-    LLM_USAGE_SYNC_TTL_SECONDS,
+    LLM_USAGE_SYNC_TTL_SECONDS, LLM_CALL_WARN_THRESHOLD,
 )
 from app.core.logging_utils import set_session_context
 from app.services import schematiq_thread_pool, concurrency_limiter
@@ -180,16 +180,23 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
         if limit <= 0:
             return
         usage = self.get_quota_usage(limit)
-        if usage["used"] >= limit:
+        used = usage["used"]
+        if used >= limit:
             # Visible on the uvicorn terminal even when logging is minimal
             print(
-                f"[LLM quota] blocked: used={usage['used']} quota_limit={limit} "
+                f"[LLM quota] blocked: used={used} quota_limit={limit} "
                 f"window_days={usage['window_days']} "
                 f"(raise LLM_CALL_GLOBAL_LIMIT, set a rolling window via "
                 f"LLM_CALL_LIMIT_WINDOW_DAYS, or LLM_CALL_GLOBAL_LIMIT=0 to disable)",
                 flush=True,
             )
-            raise QuotaExceededError(used=usage["used"], limit=limit)
+            raise QuotaExceededError(used=used, limit=limit)
+
+        # Approaching the limit: send a one-time heads-up email before it blocks.
+        if LLM_CALL_WARN_THRESHOLD > 0 and used >= LLM_CALL_WARN_THRESHOLD * limit:
+            from app.core.email_alerts import send_quota_warning_alert
+
+            send_quota_warning_alert(used=used, limit=limit)
 
     def get_usage_report(self) -> Dict[str, Any]:
         """Full quota usage report for the ``/api/usage`` endpoint.

--- a/backend/tests/test_quota_warning.py
+++ b/backend/tests/test_quota_warning.py
@@ -1,0 +1,68 @@
+"""Tests for the approaching-limit quota warning email.
+
+check_global_quota should send a one-time warning when usage crosses the
+threshold (but is still under the limit), block when at/over the limit, and do
+nothing when well under.
+"""
+
+import pytest
+
+import app.core.email_alerts as email_alerts
+import app.services.schematiq_runner as sr
+from app.services.schematiq_runner import ScheMatiQRunner
+from schematiq.core.llm_call_tracker import QuotaExceededError
+
+
+class _FakeUsage:
+    """Duck-typed stand-in exposing only get_quota_usage."""
+
+    def __init__(self, used: int):
+        self._used = used
+
+    def get_quota_usage(self, limit: int):
+        return {"used": self._used, "limit": limit, "window_days": 0,
+                "remaining": max(limit - self._used, 0)}
+
+
+@pytest.fixture
+def captured_alerts(monkeypatch):
+    warns: list[tuple[int, int]] = []
+    monkeypatch.setattr(email_alerts, "send_quota_warning_alert",
+                        lambda used, limit: warns.append((used, limit)))
+    monkeypatch.setattr(sr, "LLM_CALL_WARN_THRESHOLD", 0.8)
+    return warns
+
+
+def test_warning_fires_when_crossing_threshold(captured_alerts, monkeypatch):
+    # 850 / 1000 = 85% -> warn, not blocked
+    ScheMatiQRunner.check_global_quota(_FakeUsage(850), 1000)
+    assert captured_alerts == [(850, 1000)]
+
+
+def test_no_warning_below_threshold(captured_alerts):
+    # 500 / 1000 = 50% -> nothing
+    ScheMatiQRunner.check_global_quota(_FakeUsage(500), 1000)
+    assert captured_alerts == []
+
+
+def test_at_limit_blocks_and_does_not_warn(captured_alerts):
+    with pytest.raises(QuotaExceededError):
+        ScheMatiQRunner.check_global_quota(_FakeUsage(1000), 1000)
+    assert captured_alerts == []  # blocked path does not send the warning
+
+
+def test_threshold_zero_disables_warning(captured_alerts, monkeypatch):
+    monkeypatch.setattr(sr, "LLM_CALL_WARN_THRESHOLD", 0.0)
+    ScheMatiQRunner.check_global_quota(_FakeUsage(999), 1000)
+    assert captured_alerts == []
+
+
+def test_warning_email_sent_once(monkeypatch):
+    # The one-time guard means repeated crossings send a single email.
+    email_alerts._quota_warning_sent = False
+    sent: list[str] = []
+    monkeypatch.setattr(email_alerts, "_send_email", lambda subject, body: sent.append(subject))
+    email_alerts.send_quota_warning_alert(used=850, limit=1000)
+    email_alerts.send_quota_warning_alert(used=900, limit=1000)
+    assert len(sent) == 1
+    email_alerts._quota_warning_sent = False  # reset for other tests


### PR DESCRIPTION
Sends a one-time email when LLM usage crosses LLM_CALL_WARN_THRESHOLD (default 80%) of the global quota, before it blocks, so the limit can be raised in time. The check lives in check_global_quota (the single enforcement gate all paths pass through), so it covers chat and extraction. Threshold is configurable; 0 disables. Requires ALERT_EMAIL_TO and the gmail.send OAuth scope, same as the exceeded alert. 5 tests; full backend suite green.