### PR TITLE
fix(chat): email alert when chat trips the LLM quota

### DIFF
--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -135,7 +135,12 @@ class ChatAgentService:
                 "messages": outbound_messages,
                 "pending_action": result.get("pending_action"),
             }
-        except QuotaExceededError:
+        except QuotaExceededError as exc:
+            # Chat trips the quota independently of the extraction routes, so the
+            # alert must be sent here too (one-time per process, handled inside).
+            from app.core.email_alerts import send_quota_exceeded_alert
+
+            send_quota_exceeded_alert(total_used=exc.used)
             outbound_messages.append(self._text_message(QUOTA_EXCEEDED_CHAT_MESSAGE))
             return {
                 "chat_id": state.chat_id,
@@ -173,7 +178,10 @@ class ChatAgentService:
         # confirmation can be retried once the quota is restored.
         try:
             await self._ensure_quota_available()
-        except QuotaExceededError:
+        except QuotaExceededError as exc:
+            from app.core.email_alerts import send_quota_exceeded_alert
+
+            send_quota_exceeded_alert(total_used=exc.used)
             return {
                 "chat_id": chat_id,
                 "status": "complete",

--- a/backend/tests/test_chat_agent_safety.py
+++ b/backend/tests/test_chat_agent_safety.py
@@ -464,6 +464,12 @@ def _pending_reextract(state):
 @pytest.mark.asyncio
 async def test_quota_exhausted_blocks_confirm(monkeypatch):
     agent, executor = _agent_with_quota(monkeypatch, exhausted=True)
+    import app.core.email_alerts as email_alerts
+
+    alerts: list[int] = []
+    monkeypatch.setattr(
+        email_alerts, "send_quota_exceeded_alert", lambda total_used: alerts.append(total_used)
+    )
     state = _make_state(FakeChat([FakeResponse(text="unreachable")]))
     _pending_reextract(state)
 
@@ -472,6 +478,7 @@ async def test_quota_exhausted_blocks_confirm(monkeypatch):
     assert result["status"] == "complete"
     assert QUOTA_EXCEEDED_CHAT_MESSAGE in str(result["messages"])
     assert executor.executed == []  # blocked: the pending action did not run
+    assert alerts == [999999]  # the quota alert was sent from the chat path
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The quota-exceeded email alert was only sent from the extraction routes; the chat path caught the quota error and returned the message without alerting. Since chat trips the quota independently, quota exhaustion via chat produced no email. Chat now sends the alert (once per process, same as extraction) from both send_message and confirm_pending. Test asserts the alert fires. Requires ALERT_EMAIL_TO set and the OAuth creds to include the gmail.send scope.