### PR TITLE
fix: By Document/By Unit grouping badge disappears after leaving the Data tab

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -366,10 +366,24 @@ export function SpreadsheetSurface({
   // renderer and merge builder both index this by physical row, so they stay
   // in sync with each other and survive column sorting/filtering (which only
   // changes the visual<->physical mapping, not this array).
+  //
+  // Derived from the raw `data.rows` prop rather than `dataRows` (the sheet
+  // rows handed to Handsontable) on purpose: Handsontable's mergeCells plugin
+  // writes back into its bound source data, blanking the grouping column on
+  // every row it covers with a merge. `dataRows` is that same bound array, so
+  // reading it here would pick up those blanks — correct right after the
+  // first merge, but wrong on every subsequent recompute (e.g. leaving the
+  // Data sheet and coming back), since by then the covered rows' values have
+  // already been zeroed out and no longer match their group's key.
   const groupKeys = useMemo<string[]>(() => {
     if (activeSheet !== 'data') return [];
-    return dataRows.map((row) => String((row as Record<string, string>)[groupColKey] ?? '').trim().toLowerCase());
-  }, [activeSheet, dataRows, groupColKey]);
+    return data.rows.map((row) => {
+      const raw = groupColKey === '_row_name'
+        ? (row.row_name || row._unit_name || '')
+        : documentDisplayName(row._source_document || row._parent_document || row.papers?.[0]);
+      return String(raw ?? '').trim().toLowerCase();
+    });
+  }, [activeSheet, data.rows, groupColKey]);
 
   // Resolve the group key shown at a given *visual* row (accounting for sort).
   const groupKeyAtVisual = useCallback(


### PR DESCRIPTION
## Problem
When the Data sheet groups rows (By Document or By Unit) and a group spans multiple rows, switching to another tab (Schema, Observation Unit, ...) and back to Data silently drops the merge and its count badge (e.g. "3 observations"). The grouped rows' first-column cells go blank instead.

## Root cause
Handsontable's `mergeCells` plugin mutates its *bound* source data in place, nulling the grouping column for every row a merge covers. `groupKeys` was derived from `dataRows`, the very array handed to Handsontable as `data` — so it read those nulled values on any later recompute (its `useMemo` re-runs whenever `activeSheet` changes). With the covered rows' keys now blank, they no longer matched their group, so no merge range was computed and the badge disappeared.

Verified in a real Chromium session (not just static reading): `hot.getSourceData()` showed the grouping column nulled for covered rows immediately after the very first merge, before ever touching another tab.

## Solution
Compute `groupKeys` from the raw `data.rows` prop, which Handsontable never touches, instead of from `dataRows`.

## Verify
- `git apply --ignore-whitespace --check` on current main
- `npx tsc --noEmit` — clean
- Manual repro in a real browser harness: badge now survives 5 consecutive round trips through Schema/Observation Unit and back to Data