### PR TITLE
fix: disable sorting while a By Unit/By Document group is merged

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -364,8 +364,8 @@ export function SpreadsheetSurface({
 
   // One normalized group key per data row, in displayed (physical) order. The
   // renderer and merge builder both index this by physical row, so they stay
-  // in sync with each other and survive column sorting/filtering (which only
-  // changes the visual<->physical mapping, not this array).
+  // in sync with each other and survive column filtering (which only changes
+  // the visual<->physical mapping, not this array).
   //
   // Derived from the raw `data.rows` prop rather than `dataRows` (the sheet
   // rows handed to Handsontable) on purpose: Handsontable's mergeCells plugin
@@ -384,6 +384,20 @@ export function SpreadsheetSurface({
       return String(raw ?? '').trim().toLowerCase();
     });
   }, [activeSheet, data.rows, groupColKey]);
+
+  // Whether the current grouped view actually has any group spanning more
+  // than one row (i.e. a merge will be drawn). Handsontable's mergeCells
+  // plugin is not compatible with columnSorting: sorting while a merge is
+  // active reads already-blanked cells as sort keys, scrambles the row order,
+  // and applies the resulting (wrong) merge ranges — corrupting the grouping
+  // column's values on unrelated rows. See handsontable/handsontable#7509.
+  // Since sorting would also scatter a group's rows apart even if that bug
+  // didn't exist, the two features are mutually exclusive here: sorting is
+  // only offered when there's nothing merged to break.
+  const hasMultiRowGroup = useMemo<boolean>(
+    () => groupKeys.some((key, i) => i > 0 && key !== '' && key === groupKeys[i - 1]),
+    [groupKeys],
+  );
 
   // Resolve the group key shown at a given *visual* row (accounting for sort).
   const groupKeyAtVisual = useCallback(
@@ -927,7 +941,7 @@ export function SpreadsheetSurface({
         contextMenu
         filters
         dropdownMenu
-        columnSorting
+        columnSorting={!hasMultiRowGroup}
         copyPaste
         undo
         minSpareRows={sheet.minSpareRows || 0}


### PR DESCRIPTION
## Problem
Switching grouping mode (By Unit ↔ By Document) and then sorting a column while a multi-row group is merged corrupts the merge: wrong rowspans get applied, and the grouping column's display value (Source Document / unit_name) is blanked on unrelated rows. Confirmed via a real mouse click on the column header in a live browser session, not just the plugin API — and confirmed the corruption never reaches real extracted schema data, only the internal grouping-display fields.

## Root cause
Handsontable's mergeCells plugin is a documented-incompatible combination with columnSorting (see [handsontable/handsontable#7509](https://github.com/handsontable/handsontable/issues/7509)): while a merge is active, the sort reads the merge's blanked cells as comparison keys, which scrambles the resulting row order and therefore the merge ranges computed from it.

## Solution
Added `hasMultiRowGroup`, a small pure check for whether the current view has any group spanning more than one row, and gate `columnSorting` on it. Sorting continues to work normally in the (more common) case where every unit/document has exactly one row.

## Verify
- `git apply --ignore-whitespace --check` on current main
- `npx tsc --noEmit` — clean
- Manual browser verification: 10 scenarios (both grouping modes, multiple groups, repeated tab round trips, real header-click sort attempts while grouped, and confirming normal sort still works when ungrouped) all pass