### PR TITLE
feat: grounding display for reference-sourced values

### DIFF
--- a/backend/app/api/routes/reference.py
+++ b/backend/app/api/routes/reference.py
@@ -11,6 +11,7 @@ import logging
 from typing import List
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 
 from app.services import session_manager, websocket_manager
@@ -70,6 +71,26 @@ async def list_reference_documents(session_id: str) -> ReferenceDocumentList:
         session_id=session_id,
         reference_documents=[_to_info(r) for r in refsvc.list_reference_documents(session)],
     )
+
+
+@router.get("/{session_id}/{reference_id}/content", response_class=PlainTextResponse)
+async def get_reference_document_content(
+    session_id: str, reference_id: str
+) -> PlainTextResponse:
+    """Return a reference document's extracted plain text.
+
+    Used by the source panel to render a reference document inline and highlight
+    the passage a reference-sourced cell was filled from. The text is loaded from
+    the storage backend (or inline ``content`` for legacy documents).
+    """
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    ref = refsvc.get_reference_document(session, reference_id)
+    if not ref:
+        raise HTTPException(status_code=404, detail="Reference document not found")
+    text = await refsvc.load_reference_text(session_id, ref)
+    return PlainTextResponse(content=text or "")
 
 
 @router.post("/{session_id}/upload", response_model=ReferenceDocumentInfo)

--- a/frontend/src/components/DocumentViewer/DocumentPreview.reference.test.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentPreview.reference.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot, Root } from 'react-dom/client';
+
+import DocumentPreview from './DocumentPreview';
+
+// Mock the api module so we don't pull axios/env config, and can assert which
+// endpoint the reference path calls. NOTE: CRA's jest config sets resetMocks:true,
+// which strips jest.fn(impl) factory implementations before every test — so the
+// URL builders' implementations are (re)assigned in beforeEach, not here.
+const mockGetContentText = jest.fn();
+const mockGetContentUrl = jest.fn();
+const mockGetDocumentContentText = jest.fn();
+const mockGetDocumentContentUrl = jest.fn();
+
+jest.mock('../../services/api', () => ({
+  referenceAPI: {
+    getContentText: (...args: [string, string]) => mockGetContentText(...args),
+    getContentUrl: (...args: [string, string]) => mockGetContentUrl(...args),
+  },
+  unitsAPI: {
+    getDocumentContentText: (...args: [string, string]) => mockGetDocumentContentText(...args),
+    getDocumentContentUrl: (...args: [string, string]) => mockGetDocumentContentUrl(...args),
+  },
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  // Re-establish implementations after resetMocks wipes them.
+  mockGetContentUrl.mockImplementation(
+    (sessionId: string, referenceId: string) =>
+      `http://test/reference/${sessionId}/${referenceId}/content`,
+  );
+  mockGetDocumentContentUrl.mockImplementation(
+    (sessionId: string, name: string) => `http://test/units/doc/${sessionId}?name=${name}`,
+  );
+  // Availability probe uses fetch HEAD; make it succeed.
+  (global as unknown as { fetch: jest.Mock }).fetch = jest.fn(() =>
+    Promise.resolve({ ok: true } as Response),
+  );
+  // scrollIntoView isn't implemented in jsdom.
+  (window.HTMLElement.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView =
+    jest.fn();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+// Two async hops happen in sequence: the HEAD availability probe resolves and
+// sets state, then a re-render fires the text-fetch effect. Yield to the macrotask
+// queue a few times, each inside act(), so both settle and React flushes.
+const flush = async () => {
+  for (let i = 0; i < 5; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+};
+
+test('reference mode fetches reference text, renders it, and highlights the passage', async () => {
+  const refText =
+    'name,appointing_president\nWilliam Acker,Nixon\nJane Doe,Reagan';
+  mockGetContentText.mockResolvedValue(refText);
+
+  await act(async () => {
+    root.render(
+      <DocumentPreview
+        sessionId="s1"
+        documentName="ruling.pdf"
+        referenceDoc={{ id: 'ref-123', filename: 'judges.csv' }}
+        highlightTexts={['name,appointing_president\nWilliam Acker,Nixon']}
+      />,
+    );
+  });
+  await flush();
+
+  // It fetched the REFERENCE, not the source document.
+  expect(mockGetContentText).toHaveBeenCalledWith('s1', 'ref-123');
+  expect(mockGetDocumentContentText).not.toHaveBeenCalled();
+
+  // The reference text is on screen.
+  expect(container.textContent).toContain('William Acker,Nixon');
+
+  // The "Reference" badge is shown.
+  expect(container.textContent).toContain('Reference');
+  // The reference filename is shown in the header (not the source doc name).
+  expect(container.textContent).toContain('judges.csv');
+
+  // The passage is highlighted in a <mark>.
+  const marks = container.querySelectorAll('mark');
+  expect(marks.length).toBeGreaterThan(0);
+  const marked = Array.from(marks).map((m) => m.textContent).join(' ');
+  expect(marked).toContain('William Acker,Nixon');
+  // The non-matching row is NOT inside a mark.
+  expect(marked).not.toContain('Jane Doe');
+});
+
+test('without referenceDoc it uses the source-document text path', async () => {
+  mockGetDocumentContentText.mockResolvedValue('Some source document text here.');
+
+  await act(async () => {
+    root.render(
+      <DocumentPreview
+        sessionId="s1"
+        documentName="ruling.txt"
+        highlightTexts={['source document text']}
+      />,
+    );
+  });
+  await flush();
+
+  expect(mockGetDocumentContentText).toHaveBeenCalledWith('s1', 'ruling.txt');
+  expect(mockGetContentText).not.toHaveBeenCalled();
+  expect(container.textContent).toContain('Some source document text');
+  // No reference badge in source mode.
+  expect(container.querySelector('mark')?.textContent).toContain('source document text');
+});
+
+test('reference load failure shows an error, not a crash', async () => {
+  mockGetContentText.mockRejectedValue(new Error('boom'));
+
+  await act(async () => {
+    root.render(
+      <DocumentPreview
+        sessionId="s1"
+        documentName="ruling.pdf"
+        referenceDoc={{ id: 'ref-err', filename: 'judges.csv' }}
+        highlightTexts={['anything']}
+      />,
+    );
+  });
+  await flush();
+
+  expect(container.textContent).toContain('Could not load');
+});

--- a/frontend/src/components/DocumentViewer/DocumentPreview.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentPreview.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FileText, ExternalLink, Download, FileX, Upload } from 'lucide-react';
 
-import { unitsAPI } from '../../services/api';
+import { referenceAPI, unitsAPI } from '../../services/api';
 import { findHighlightRanges } from './highlightUtils';
 
 /** Extensions the browser can render inline in an <iframe>. */
@@ -63,6 +63,14 @@ interface DocumentPreviewProps {
    * document away and clicked the same cell again).
    */
   scrollNonce?: number;
+  /**
+   * When set, the panel renders this attached reference document instead of the
+   * source document `documentName` — used when the selected cell's value was
+   * filled from a reference. Reference text is fetched by id from the reference
+   * content endpoint and rendered with the same highlight-capable text renderer,
+   * so `highlightTexts` grounds the passage inside the reference.
+   */
+  referenceDoc?: { id: string; filename: string } | null;
 }
 
 /**
@@ -91,13 +99,25 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
   onRequestUpload,
   highlightTexts,
   scrollNonce,
+  referenceDoc,
 }) => {
+  // A reference document, when set, takes precedence over the row's source
+  // document: the selected cell's value came from the reference, so we render
+  // and highlight inside it. The display name drives extension detection.
+  const isReference = Boolean(referenceDoc);
+  const displayName = referenceDoc?.filename ?? documentName;
+
   const contentUrl = useMemo(() => {
-    if (!sessionId || !documentName) return null;
+    if (!sessionId) return null;
+    if (referenceDoc) {
+      // Reference content has no cache-staleness concern (immutable per id).
+      return referenceAPI.getContentUrl(sessionId, referenceDoc.id);
+    }
+    if (!documentName) return null;
     const base = unitsAPI.getDocumentContentUrl(sessionId, documentName);
     // Cache-bust so a freshly uploaded file isn't masked by a cached 404/response.
     return reloadToken ? `${base}&_t=${reloadToken}` : base;
-  }, [sessionId, documentName, reloadToken]);
+  }, [sessionId, documentName, reloadToken, referenceDoc]);
 
   const [availability, setAvailability] = useState<Availability>('idle');
 
@@ -120,15 +140,17 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
     };
   }, [contentUrl]);
 
-  const ext = documentName ? extensionOf(documentName) : '';
+  const ext = displayName ? extensionOf(displayName) : '';
   const canRenderInline = ext === '' || INLINE_EXTENSIONS.has(ext);
   const needsSandbox = SANDBOX_EXTENSIONS.has(ext);
   const showOpenFull = Boolean(contentUrl) && availability === 'ok';
 
   // Highlight mode is opt-in (the prop is present) and only applies to text
-  // formats we can render and annotate ourselves.
+  // formats we can render and annotate ourselves. Reference documents are always
+  // stored as extracted text, so they are text-renderable regardless of the
+  // original upload's extension (e.g. a .xlsx reference stored as .txt).
   const highlightEnabled = highlightTexts !== undefined;
-  const isTextRenderable = ext === '' || TEXT_EXTENSIONS.has(ext);
+  const isTextRenderable = isReference || ext === '' || TEXT_EXTENSIONS.has(ext);
   const useInlineText = highlightEnabled && isTextRenderable;
 
   const [text, setText] = useState<string | null>(null);
@@ -140,7 +162,7 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
   const [contentIsBinary, setContentIsBinary] = useState(false);
 
   useEffect(() => {
-    if (!useInlineText || !sessionId || !documentName || availability !== 'ok') {
+    if (!useInlineText || !sessionId || !displayName || availability !== 'ok') {
       setText(null);
       setTextError(false);
       setContentIsBinary(false);
@@ -150,8 +172,10 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
     setText(null);
     setTextError(false);
     setContentIsBinary(false);
-    unitsAPI
-      .getDocumentContentText(sessionId, documentName)
+    const fetchText = referenceDoc
+      ? referenceAPI.getContentText(sessionId, referenceDoc.id)
+      : unitsAPI.getDocumentContentText(sessionId, documentName as string);
+    fetchText
       .then((content) => {
         if (cancelled) return;
         if (content.startsWith('%PDF-') || content.indexOf('\u0000') !== -1) {
@@ -166,7 +190,7 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [useInlineText, sessionId, documentName, availability, reloadToken]);
+  }, [useInlineText, sessionId, documentName, displayName, availability, reloadToken, referenceDoc]);
 
   const highlightRanges = useMemo(
     () => (useInlineText ? findHighlightRanges(text, highlightTexts) : []),
@@ -247,10 +271,12 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
         <div className="h-full flex flex-col items-center justify-center gap-2 text-sm text-muted-foreground text-center px-6">
           <FileX className="h-8 w-8 opacity-40" />
           <span>This document isn&apos;t available to preview.</span>
-          <span className="text-xs">
-            Imported projects don&apos;t include the original files. Upload them to enable preview.
-          </span>
-          {onRequestUpload && (
+          {!isReference && (
+            <span className="text-xs">
+              Imported projects don&apos;t include the original files. Upload them to enable preview.
+            </span>
+          )}
+          {!isReference && onRequestUpload && (
             <button
               type="button"
               onClick={onRequestUpload}
@@ -271,7 +297,7 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
         <iframe
           key={contentUrl}
           src={contentUrl}
-          title={documentName || 'Document preview'}
+          title={displayName || 'Document preview'}
           className="w-full h-full border-0"
           {...(needsSandbox ? { sandbox: '' } : {})}
         />
@@ -305,8 +331,13 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
   return (
     <div className="flex-1 min-w-0 h-full flex flex-col">
       <div className="flex items-center gap-2 px-3 py-2 border-b border-border text-xs">
-        <span className="truncate text-muted-foreground" title={documentName || ''}>
-          {documentName || 'No document selected'}
+        {isReference && (
+          <span className="shrink-0 rounded bg-purple-100 px-1.5 py-0.5 font-medium text-purple-700 dark:bg-purple-950/40 dark:text-purple-300">
+            Reference
+          </span>
+        )}
+        <span className="truncate text-muted-foreground" title={displayName || ''}>
+          {displayName || 'No document selected'}
         </span>
         <span className="flex-1" />
         {showOpenFull && (

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -71,8 +71,11 @@ export function SpreadsheetSurface({
   hotTableRef: MutableRefObject<HotTableClass | null>;
   onSelectionChange: (selection: SheetSelection) => void;
   // Reports all grounding excerpts of the newly selected data cell (or null when
-  // the cell has no grounding), so the source panel can highlight them.
-  onGroundingHighlight?: (texts: string[] | null) => void;
+  // the cell has no grounding), so the source panel can highlight them. The
+  // second argument lists the distinct excerpt sources (reference filenames
+  // and/or the source-document name); the panel prefers a source that matches an
+  // attached reference so a reference-sourced value highlights inside it.
+  onGroundingHighlight?: (texts: string[] | null, sources?: string[]) => void;
   // Fires on each mouse click of a grounded data cell, so the source panel can
   // re-scroll to the highlight even when the same cell is clicked again.
   onGroundingScrollRequest?: () => void;
@@ -962,7 +965,7 @@ export function SpreadsheetSurface({
         afterSelectionEnd={(row: number, col: number, row2: number, col2: number) => {
           if (row < 0 || col < 0 || row2 < 0 || col2 < 0) {
             onSelectionChange(null);
-            onGroundingHighlight?.(null);
+            onGroundingHighlight?.(null, []);
             return;
           }
           const fromRow = Math.min(row, row2);
@@ -980,6 +983,7 @@ export function SpreadsheetSurface({
           // first is scrolled into view).
           if (onGroundingHighlight) {
             let excerptTexts: string[] | null = null;
+            let excerptSources: string[] = [];
             if (activeSheet === 'data') {
               const column = sheet.columns[fromCol];
               const hot = hotTableRef.current?.hotInstance;
@@ -988,12 +992,22 @@ export function SpreadsheetSurface({
                 column && physicalRow != null && physicalRow >= 0
                   ? dataGrounding[physicalRow]?.[column.key]
                   : null;
-              const texts = (grounding?.excerpts ?? [])
+              const excerpts = grounding?.excerpts ?? [];
+              const texts = excerpts
                 .map((e) => e.text)
                 .filter((t): t is string => Boolean(t && t.trim()));
               excerptTexts = texts.length > 0 ? texts : null;
+              // Distinct sources, order-preserving; the panel matches these
+              // against attached reference filenames to route highlighting.
+              excerptSources = Array.from(
+                new Set(
+                  excerpts
+                    .map((e) => e.source)
+                    .filter((s): s is string => Boolean(s && s.trim())),
+                ),
+              );
             }
-            onGroundingHighlight(excerptTexts);
+            onGroundingHighlight(excerptTexts, excerptSources);
           }
         }}
         afterOnCellMouseDown={(event, coords) => {

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -45,7 +45,7 @@ import SkippedDocumentsBanner from '@/components/DataTable/SkippedDocumentsBanne
 import { ViewModeToggle } from '@/components/ViewMode/ViewModeToggle';
 import MissingDocumentsSection from '@/components/SchemaEditor/MissingDocumentsSection';
 import TableFeedbackWidget from '@/components/TableFeedbackWidget/TableFeedbackWidget';
-import api, { configAPI, loadAPI, schematiqAPI, unitsAPI } from '@/services/api';
+import api, { configAPI, loadAPI, referenceAPI, schematiqAPI, unitsAPI, type ReferenceDocumentInfo } from '@/services/api';
 import type {
   CostEstimate,
   DataRow,
@@ -160,6 +160,13 @@ function Workspace() {
   // Grounding excerpts of the currently selected data cell, highlighted in the
   // source panel so the user can see every place the value came from.
   const [groundingHighlights, setGroundingHighlights] = useState<string[] | null>(null);
+  // Distinct sources of the selected cell's grounding excerpts. When one matches
+  // an attached reference document, the source panel opens that reference and
+  // highlights the passage there instead of the row's source document.
+  const [groundingSources, setGroundingSources] = useState<string[]>([]);
+  // Reference documents attached to this session, used to route grounding: an
+  // excerpt whose source matches one of these opens the reference in the panel.
+  const [referenceDocuments, setReferenceDocuments] = useState<ReferenceDocumentInfo[]>([]);
   // Bumped on each grounded-cell click so the source panel re-scrolls to the
   // highlight even when the excerpt set is unchanged (same cell clicked again).
   const [groundingScrollNonce, setGroundingScrollNonce] = useState(0);
@@ -510,6 +517,28 @@ function Workspace() {
     refresh();
   }, [refresh, sessionId]);
 
+  // Keep the attached-reference list current so grounding can route a cell whose
+  // excerpt source is a reference filename to the reference viewer. Cheap (metadata
+  // only); refreshed when the source panel opens and after source-file re-attach.
+  useEffect(() => {
+    if (!sessionId) {
+      setReferenceDocuments([]);
+      return;
+    }
+    let cancelled = false;
+    referenceAPI
+      .list(sessionId)
+      .then((refs) => {
+        if (!cancelled) setReferenceDocuments(refs);
+      })
+      .catch(() => {
+        if (!cancelled) setReferenceDocuments([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, showSourcePanel, sourceDocReloadToken]);
+
   const estimateCurrentCost = useCallback(async () => {
     if (!sessionId) return;
     if (sessionMode === 'load') {
@@ -537,7 +566,15 @@ function Workspace() {
   // Dedupe like updateSheetSelection: HotTable re-emits afterSelectionEnd on
   // every re-render, so returning the previous value for an unchanged excerpt
   // set is required to avoid an infinite render loop.
-  const handleGroundingHighlight = useCallback((texts: string[] | null) => {
+  const handleGroundingHighlight = useCallback((texts: string[] | null, sources?: string[]) => {
+    const nextSources = sources ?? [];
+    setGroundingSources((current) => {
+      if (current.length === nextSources.length
+        && current.every((s, i) => s === nextSources[i])) {
+        return current;
+      }
+      return nextSources;
+    });
     setGroundingHighlights((current) => {
       if (current === texts) return current;
       if (!current || !texts) return texts;
@@ -751,6 +788,26 @@ function Workspace() {
       (Array.isArray(row.papers) ? row.papers[0] : undefined);
     return raw ? String(raw).trim() : null;
   }, [activeSheet, sheetSelection, alignedDocData, alignedUnitData, dataView]);
+
+  // When any of the selected cell's grounding sources is an attached reference
+  // document (rather than the row's source document), resolve that reference so
+  // the panel can open and highlight the passage inside it. A reference match is
+  // preferred over the source document because verifying reference-filled values
+  // in the reference is the whole point of this view. Matches by filename with a
+  // basename fallback.
+  const selectedReferenceDoc = useMemo<ReferenceDocumentInfo | null>(() => {
+    if (groundingSources.length === 0 || referenceDocuments.length === 0) return null;
+    const basename = (name: string) => name.split(/[\\/]/).pop() ?? name;
+    for (const raw of groundingSources) {
+      const target = raw.trim();
+      if (!target) continue;
+      const match =
+        referenceDocuments.find((r) => r.filename === target) ??
+        referenceDocuments.find((r) => basename(r.filename) === basename(target));
+      if (match) return match;
+    }
+    return null;
+  }, [groundingSources, referenceDocuments]);
 
   const handleAttachSourceDocs = useCallback(
     async (e: ChangeEvent<HTMLInputElement>) => {
@@ -993,6 +1050,7 @@ function Workspace() {
                   <DocumentPreview
                     sessionId={sessionId}
                     documentName={selectedSourceDoc}
+                    referenceDoc={selectedReferenceDoc}
                     emptyHint="Select a row to see its source document."
                     reloadToken={sourceDocReloadToken}
                     highlightTexts={groundingHighlights}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1094,6 +1094,23 @@ export const referenceAPI = {
   remove: async (sessionId: string, referenceId: string): Promise<void> => {
     await api.delete(`/reference/${sessionId}/${referenceId}`);
   },
+
+  /** URL of a reference document's raw text (used by the highlight-capable preview). */
+  getContentUrl: (sessionId: string, referenceId: string): string =>
+    `${API_BASE}/reference/${encodeURIComponent(sessionId)}/${encodeURIComponent(referenceId)}/content`,
+
+  /**
+   * Fetch a reference document's extracted plain text via the shared axios
+   * instance, so the source panel can render it in a DOM we control and
+   * highlight the passage a reference-sourced cell was filled from.
+   */
+  getContentText: async (sessionId: string, referenceId: string): Promise<string> => {
+    const response = await api.get<string>(
+      `/reference/${encodeURIComponent(sessionId)}/${encodeURIComponent(referenceId)}/content`,
+      { responseType: 'text', transformResponse: [(d) => d] },
+    );
+    return typeof response.data === 'string' ? response.data : String(response.data ?? '');
+  },
 };
 
 export async function downloadBlob(path: string, fallbackFilename: string): Promise<void> {

--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -45,6 +45,7 @@ from ..config.prompts import (
 )
 from ..utils.schema_builder import build_extraction_response_schema
 from ..utils.reference_retrieval import ReferenceRetriever
+from ..utils.reference_grounder import ReferenceGrounder
 from ..utils.excerpt_grounder import ExcerptGrounder
 
 # Type alias for warning callback: (paper_title, warning_type, message) -> None
@@ -107,6 +108,10 @@ class PaperProcessor:
         self.json_parser = JSONResponseParser()
         self.unit_parser = UnitIdentificationParser()
         self.text_processor = TextProcessor()
+        # Grounder that re-attributes reference-derived excerpts to the reference
+        # document they came from (built from the full blob, before the small/large
+        # split below reassigns reference_context). Inactive when no reference.
+        self.reference_grounder = ReferenceGrounder(reference_context)
         # Small reference -> inject whole (cheap, no retrieval). Large reference ->
         # index once and retrieve per unit so we never blow the context window.
         reference_retriever = None
@@ -363,6 +368,12 @@ class PaperProcessor:
                     )
                     for exc in excerpts
                 ]
+        # Excerpts pulled from the external reference are stamped above with the
+        # source-document filename; re-attribute those to the reference document
+        # they actually came from (and narrow tabular matches to a single row) so
+        # they highlight in the reference viewer rather than failing to match the
+        # source document. No-op when no reference is attached.
+        self.reference_grounder.reattribute(data)
         return data
 
     def _should_skip_truncation(self) -> bool:

--- a/schematiq-lib/schematiq/value_extraction/utils/reference_grounder.py
+++ b/schematiq-lib/schematiq/value_extraction/utils/reference_grounder.py
@@ -1,0 +1,288 @@
+"""Attribute extraction excerpts that came from an external reference document.
+
+During value extraction the model is given the source document *and* — when the
+user attached one — an external reference document (supplementary lookup material,
+e.g. a table mapping each judge to the president who appointed them). The model
+returns excerpts as verbatim quotes supporting each value, but it does not tell us
+*which document* a given excerpt came from.
+
+The default excerpt attribution stamps every excerpt with the source-document
+filename (see ``PaperProcessor._attach_source_to_excerpts``). That is wrong for a
+value the model pulled from the reference: the excerpt text lives in the reference,
+not the source document, so highlighting it against the source document would fail.
+
+This module re-attributes such excerpts. Given the combined reference-context blob
+(the same text injected into the extraction prompt, whose per-document sections are
+labelled ``--- Reference document: <filename> ---``), it:
+
+- locates each excerpt in the reference text (exact/case-insensitive/normalised),
+- when found, sets the excerpt's ``source`` to the owning reference filename, and
+- for tabular references, narrows the excerpt ``text`` to the single matching row
+  (keeping the header line) so the highlight in the reference viewer is precise.
+
+It is deliberately conservative: an excerpt that cannot be located in the reference
+text is left untouched, so source-document excerpts keep their existing attribution.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+# Section header emitted by ``build_reference_context`` for each attached
+# reference document. Kept in sync with backend reference_context.py.
+_SECTION_RE = re.compile(r"^--- Reference document: (?P<name>.+?) ---$")
+
+# Below this folded length, a free-text excerpt is too generic to safely re-attribute
+# to a reference on a bare substring match (e.g. a single name or number that also
+# appears in the source document). Excerpts that align to a full tabular row are
+# re-attributed regardless of length, because a whole row is distinctive.
+_MIN_FREETEXT_MATCH_CHARS = 12
+
+_NUMERIC_RE = re.compile(r"^[+-]?[\d,.]*\d[\d,.]*\s*%?$")
+
+
+def _looks_numeric(cell: str) -> bool:
+    """True if a table cell is numeric-ish (int/float/percent), ignoring currency."""
+    cell = cell.strip().lstrip("$€£").strip()
+    return bool(cell) and bool(_NUMERIC_RE.match(cell))
+
+
+def _fold(text: str) -> str:
+    """Normalise whitespace and common unicode punctuation for robust matching.
+
+    Mirrors the spirit of the frontend highlight folding (unicode quotes/dashes,
+    collapsed whitespace) so an excerpt located here matches what the viewer can
+    later highlight. Deliberately lossy: used only for locating, never stored.
+    """
+    if not text:
+        return ""
+    folded = (
+        text.replace("\u2018", "'").replace("\u2019", "'")
+        .replace("\u201c", '"').replace("\u201d", '"')
+        .replace("\u2013", "-").replace("\u2014", "-")
+        .replace("\u00a0", " ")
+    )
+    return re.sub(r"\s+", " ", folded).strip().lower()
+
+
+@dataclass
+class _ReferenceSection:
+    """One attached reference document's text, plus tabular metadata."""
+
+    filename: str
+    text: str
+    folded: str = ""
+    is_tabular: bool = False
+    header_line: str = ""
+    # Physical lines of the section body (for single-row narrowing), with their
+    # folded form precomputed. Blank lines are dropped so row matching is stable.
+    lines: List[str] = field(default_factory=list)
+    folded_lines: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.folded = _fold(self.text)
+        raw_lines = [ln for ln in self.text.splitlines() if ln.strip()]
+        self.lines = raw_lines
+        self.folded_lines = [_fold(ln) for ln in raw_lines]
+        self._detect_tabular()
+
+    def _detect_tabular(self) -> None:
+        if len(self.lines) < 3:
+            return
+        for delim in (",", "\t", "|"):
+            counts = [ln.count(delim) for ln in self.lines[:20]]
+            if not counts or counts[0] < 1:
+                continue
+            consistent = sum(c == counts[0] for c in counts)
+            if consistent < max(3, int(0.7 * len(counts))):
+                continue
+            self.is_tabular = True
+            # Treat the first row as a header only if it looks like column labels
+            # (no numeric cells) while a later row has a numeric cell in the same
+            # position. Otherwise the file is headerless and prepending the first
+            # data row would corrupt the highlight.
+            if self._first_row_is_header(delim):
+                self.header_line = self.lines[0].strip()
+            return
+
+    def _first_row_is_header(self, delim: str) -> bool:
+        first = [c.strip() for c in self.lines[0].split(delim)]
+        if not first or any(_looks_numeric(c) for c in first):
+            return False
+        data_rows = [
+            [c.strip() for c in ln.split(delim)] for ln in self.lines[1:30]
+        ]
+        if not data_rows:
+            return False
+        # Signal 1: a data row has a numeric cell while the all-text first row does
+        # not — strong evidence the first row is a label row.
+        for cells in data_rows:
+            if any(_looks_numeric(c) for c in cells):
+                return True
+        # Signal 2: all-text table. Treat the first row as a header only if its
+        # cells do not recur as values in their own column (labels are distinct
+        # from the data below them), which distinguishes a "name,country" header
+        # from a headerless table whose first row is just more data.
+        width = len(first)
+        for col in range(width):
+            column_values = {
+                cells[col] for cells in data_rows if len(cells) > col
+            }
+            if first[col] in column_values:
+                return False
+        return True
+
+
+def _parse_sections(reference_context: str) -> List[_ReferenceSection]:
+    """Split the combined reference blob into per-document sections.
+
+    ``build_reference_context`` joins documents as::
+
+        --- Reference document: a.csv ---
+        <text of a>
+
+        --- Reference document: b.txt ---
+        <text of b>
+
+    If no headers are present (unexpected, but be defensive) the whole blob is
+    treated as a single unnamed section.
+    """
+    if not reference_context or not reference_context.strip():
+        return []
+
+    sections: List[Tuple[str, List[str]]] = []
+    current_name: Optional[str] = None
+    current_lines: List[str] = []
+    for line in reference_context.splitlines():
+        m = _SECTION_RE.match(line.strip())
+        if m:
+            if current_name is not None or current_lines:
+                sections.append((current_name or "reference", current_lines))
+            current_name = m.group("name").strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+    if current_name is not None or current_lines:
+        sections.append((current_name or "reference", current_lines))
+
+    result: List[_ReferenceSection] = []
+    for name, lines in sections:
+        text = "\n".join(lines).strip()
+        if text:
+            result.append(_ReferenceSection(filename=name, text=text))
+    return result
+
+
+class ReferenceGrounder:
+    """Re-attributes reference-derived excerpts to the reference they came from.
+
+    Build once from the combined reference-context blob, then call
+    :meth:`reattribute` on each extraction result to fix up its excerpts in place.
+    Cheap to build; matching is string search over the (small, per-document)
+    reference text.
+    """
+
+    def __init__(self, reference_context: Optional[str]):
+        self._sections = _parse_sections(reference_context or "")
+
+    @property
+    def active(self) -> bool:
+        return bool(self._sections)
+
+    def _match_row(self, section: _ReferenceSection, folded_excerpt: str) -> Optional[str]:
+        """Return the single tabular row (header + row) containing the excerpt.
+
+        Returns None if the excerpt does not map cleanly to one row, so the caller
+        keeps the model's original excerpt text.
+        """
+    def _match_row(self, section: _ReferenceSection, folded_excerpt: str) -> Optional[str]:
+        """Return the single tabular row (header + row) the excerpt maps to.
+
+        A row matches when its folded form is contained in the folded excerpt, or
+        the excerpt is contained in the folded row (the model may quote one cell of
+        a row). Narrowing happens only when *exactly one* data row matches — a
+        multi-row excerpt is left whole so no content is silently dropped.
+        """
+        if not section.is_tabular:
+            return None
+        folded_header = _fold(section.header_line) if section.header_line else ""
+        matches: List[str] = []
+        for raw, folded in zip(section.lines, section.folded_lines):
+            if not folded or (folded_header and folded == folded_header):
+                continue
+            row_in_excerpt = folded in folded_excerpt
+            excerpt_in_row = folded_excerpt in folded
+            # Row fully quoted in the excerpt -> distinctive, always a match.
+            # Excerpt is only a fragment of the row -> require it to be long enough
+            # to be distinctive (a bare cell value likely also occurs in the source
+            # document, so a short fragment must not flip attribution).
+            if row_in_excerpt or (
+                excerpt_in_row and len(folded_excerpt) >= _MIN_FREETEXT_MATCH_CHARS
+            ):
+                matches.append(raw.strip())
+                if len(matches) > 1:
+                    return None  # ambiguous / spans multiple rows -> don't narrow
+        if len(matches) != 1:
+            return None
+        row = matches[0]
+        if section.header_line and section.header_line != row:
+            return f"{section.header_line}\n{row}"
+        return row
+
+    def _locate(self, excerpt_text: str) -> Optional[Tuple[_ReferenceSection, Optional[str]]]:
+        """Find the reference section an excerpt came from.
+
+        Returns ``(section, narrowed_text_or_None)``. Narrowed text is set only for
+        a single-row tabular match. For free text, the excerpt must be locatable in
+        the reference *and* distinctive enough (see ``_MIN_FREETEXT_MATCH_CHARS``)
+        to avoid flipping a short value that also occurs in the source document.
+        Returns None when the excerpt is not confidently from a reference.
+        """
+        folded = _fold(excerpt_text)
+        if not folded:
+            return None
+        for section in self._sections:
+            if folded not in section.folded:
+                continue
+            narrowed = self._match_row(section, folded)
+            if narrowed is not None:
+                return section, narrowed
+            # No single-row narrowing: accept as a free-text reference match only
+            # if the excerpt is long enough to be distinctive.
+            if len(folded) >= _MIN_FREETEXT_MATCH_CHARS:
+                return section, None
+        return None
+
+    def reattribute(self, extraction_result: Dict[str, Any]) -> None:
+        """Fix excerpt attribution in an extraction result, in place.
+
+        For each excerpt whose text is located in a reference document, set its
+        ``source`` to that reference's filename and, for tabular references,
+        narrow its ``text`` to the matching row. Excerpts not found in any
+        reference are left untouched (they belong to the source document).
+        """
+        if not self._sections:
+            return
+        for col_name, col_value in extraction_result.items():
+            if col_name.startswith("_"):
+                continue
+            if not isinstance(col_value, dict):
+                continue
+            excerpts = col_value.get("excerpts")
+            if not isinstance(excerpts, list):
+                continue
+            for exc in excerpts:
+                if not isinstance(exc, dict):
+                    continue
+                text = exc.get("text")
+                if not isinstance(text, str) or not text.strip():
+                    continue
+                located = self._locate(text)
+                if located is None:
+                    continue
+                section, narrowed = located
+                exc["source"] = section.filename
+                if narrowed:
+                    exc["text"] = narrowed

--- a/schematiq-lib/tests/test_reference_grounder.py
+++ b/schematiq-lib/tests/test_reference_grounder.py
@@ -1,0 +1,178 @@
+"""Tests for reference excerpt re-attribution (ReferenceGrounder).
+
+Loaded directly from its module path so the test does not import the heavy
+schematiq package (which pulls sentence-transformers at import time).
+"""
+
+import importlib.util
+import os
+import sys
+
+_MODULE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "schematiq",
+    "value_extraction",
+    "utils",
+    "reference_grounder.py",
+)
+_spec = importlib.util.spec_from_file_location("reference_grounder", _MODULE_PATH)
+reference_grounder = importlib.util.module_from_spec(_spec)
+sys.modules["reference_grounder"] = reference_grounder
+_spec.loader.exec_module(reference_grounder)
+
+ReferenceGrounder = reference_grounder.ReferenceGrounder
+
+
+TABULAR_BLOB = (
+    "--- Reference document: judges.csv ---\n"
+    "name,appointing_president\n"
+    "William Acker,Nixon\n"
+    "Jane Doe,Reagan\n"
+    "\n"
+    "--- Reference document: notes.txt ---\n"
+    "Some prose about the case that is not tabular at all here."
+)
+
+
+def test_no_reference_is_noop():
+    g = ReferenceGrounder(None)
+    assert g.active is False
+    data = {"col": {"excerpts": [{"text": "x", "source": "ruling.pdf"}]}}
+    g.reattribute(data)
+    assert data["col"]["excerpts"][0]["source"] == "ruling.pdf"
+
+
+def test_tabular_excerpt_reattributed_and_narrowed_to_single_row():
+    g = ReferenceGrounder(TABULAR_BLOB)
+    assert g.active is True
+    data = {
+        "appointing_president": {
+            "answer": "Nixon",
+            "excerpts": [{"text": "William Acker,Nixon", "source": "ruling.pdf"}],
+        }
+    }
+    g.reattribute(data)
+    exc = data["appointing_president"]["excerpts"][0]
+    assert exc["source"] == "judges.csv"
+    # Header is kept and only the matching row is included (not Jane Doe).
+    assert "name,appointing_president" in exc["text"]
+    assert "William Acker,Nixon" in exc["text"]
+    assert "Jane Doe" not in exc["text"]
+
+
+def test_source_document_excerpt_is_left_untouched():
+    g = ReferenceGrounder(TABULAR_BLOB)
+    data = {
+        "summary": {
+            "answer": "x",
+            "excerpts": [
+                {"text": "This quote is only in the source document.", "source": "ruling.pdf"}
+            ],
+        }
+    }
+    g.reattribute(data)
+    assert data["summary"]["excerpts"][0]["source"] == "ruling.pdf"
+
+
+def test_prose_reference_excerpt_reattributed_without_narrowing():
+    g = ReferenceGrounder(TABULAR_BLOB)
+    data = {
+        "note": {
+            "answer": "y",
+            "excerpts": [{"text": "prose about the case", "source": "ruling.pdf"}],
+        }
+    }
+    g.reattribute(data)
+    exc = data["note"]["excerpts"][0]
+    assert exc["source"] == "notes.txt"
+    # Prose is not narrowed; the model's excerpt text is preserved.
+    assert exc["text"] == "prose about the case"
+
+
+def test_matching_is_whitespace_and_quote_insensitive():
+    blob = (
+        "--- Reference document: r.txt ---\n"
+        "The court held that \u201cthe statute applies\u201d in full."
+    )
+    g = ReferenceGrounder(blob)
+    data = {
+        "c": {
+            "answer": "z",
+            # Straight quotes and collapsed spacing vs. curly quotes in the source.
+            "excerpts": [{"text": 'the  statute   applies', "source": "doc.pdf"}],
+        }
+    }
+    g.reattribute(data)
+    assert data["c"]["excerpts"][0]["source"] == "r.txt"
+
+
+def test_ignores_underscore_columns_and_string_excerpts():
+    g = ReferenceGrounder(TABULAR_BLOB)
+    data = {
+        "_cell_status": {"appointing_president": "external_source"},
+        "col": {"answer": "a", "excerpts": ["William Acker,Nixon"]},  # not a dict excerpt
+    }
+    # Should not raise, and string excerpts are skipped (only dict excerpts fixed).
+    g.reattribute(data)
+    assert data["col"]["excerpts"] == ["William Acker,Nixon"]
+
+
+def test_short_bare_value_is_not_reattributed():
+    """A short cell value that also plausibly appears in the source document must
+    not flip to the reference on a bare substring match."""
+    g = ReferenceGrounder(TABULAR_BLOB)
+    data = {"c": {"excerpts": [{"text": "Nixon", "source": "ruling.pdf"}]}}
+    g.reattribute(data)
+    assert data["c"]["excerpts"][0]["source"] == "ruling.pdf"
+
+
+def test_multi_row_excerpt_is_attributed_but_not_narrowed():
+    """An excerpt spanning several rows is attributed to the reference but kept
+    whole — narrowing must never silently drop rows."""
+    blob = (
+        "--- Reference document: t.csv ---\n"
+        "a,b\n"
+        "row1x,1\n"
+        "row2y,2"
+    )
+    g = ReferenceGrounder(blob)
+    data = {"c": {"excerpts": [{"text": "row1x,1\nrow2y,2", "source": "x.pdf"}]}}
+    g.reattribute(data)
+    exc = data["c"]["excerpts"][0]
+    assert exc["source"] == "t.csv"
+    assert "row1x,1" in exc["text"] and "row2y,2" in exc["text"]
+
+
+def test_headerless_numeric_table_does_not_prepend_a_row():
+    """A CSV whose first line is data (not labels) must not have that line
+    prepended as a bogus header."""
+    blob = (
+        "--- Reference document: nohdr.csv ---\n"
+        "Acker,Nixon,1990\n"
+        "Doe,Reagan,1985\n"
+        "Roe,Bush,1991"
+    )
+    g = ReferenceGrounder(blob)
+    data = {"c": {"excerpts": [{"text": "Doe,Reagan,1985", "source": "x.pdf"}]}}
+    g.reattribute(data)
+    exc = data["c"]["excerpts"][0]
+    assert exc["source"] == "nohdr.csv"
+    assert exc["text"] == "Doe,Reagan,1985"
+    assert "Acker" not in exc["text"]
+
+
+def test_all_text_table_with_repeating_column_is_headerless():
+    """An all-text table whose first row's values recur in their column is treated
+    as headerless (no false header prepend)."""
+    blob = (
+        "--- Reference document: pairs.csv ---\n"
+        "Nixon,Republican\n"
+        "Reagan,Republican\n"
+        "Carter,Democrat"
+    )
+    g = ReferenceGrounder(blob)
+    data = {"c": {"excerpts": [{"text": "Reagan,Republican", "source": "x.pdf"}]}}
+    g.reattribute(data)
+    exc = data["c"]["excerpts"][0]
+    assert exc["source"] == "pairs.csv"
+    assert exc["text"] == "Reagan,Republican"


### PR DESCRIPTION
## Problem
Values filled from an attached reference document were attributed only to a filename, with a placeholder excerpt. There was no real grounding: the actual reference passage was not captured, reference documents were not viewable in the source panel, and clicking a reference-sourced cell highlighted nothing.

## Solution
Implements all three pieces of `01-next-grounding-display.md` (RAG/extraction path; single-row granularity for tabular references).

1. **Capture the real passage** — new `schematiq-lib/.../utils/reference_grounder.py`. `ReferenceGrounder` parses the combined reference blob by its `--- Reference document: <filename> ---` headers, locates each extraction excerpt in the reference text (whitespace/unicode-folded), re-stamps `source` to the owning reference filename, and narrows tabular matches to header + the single matching row. Wired into `PaperProcessor` (built in `__init__` from the original blob before the small/large split nulls it; invoked at the end of `_attach_source_to_excerpts`, covering every extraction path). Guards against false attribution: short cell fragments that also plausibly occur in the source document are not re-attributed; multi-row excerpts are attributed but never narrowed; headerless tables get no bogus header prepend.

2. **Viewable reference** — new `GET /api/reference/{session_id}/{reference_id}/content` returning stored text via `load_reference_text`; `referenceAPI.getContentUrl`/`getContentText` clients. `DocumentPreview` gains a `referenceDoc` prop that takes precedence over `documentName`, fetches reference text by id, forces the highlight-capable text renderer, shows a purple "Reference" badge, and suppresses the source-file upload prompt in reference mode.

3. **Source-based routing** — `SpreadsheetSurface` passes the selected cell's distinct excerpt sources alongside the highlight texts. `Workspace` loads the attached reference list and resolves the selected reference (preferring a reference source over the source document; filename match with basename fallback); when a reference matches, the panel opens it and highlights the passage there.

## Verify
- `git apply --ignore-whitespace --check` on a clean main clone: OK
- `( cd frontend && npx tsc --noEmit )`: clean
- `python -m py_compile` on changed backend/lib files: OK
- `python -m pytest schematiq-lib/tests/test_reference_grounder.py`: 10 passed (grounding logic incl. short-value/multi-row/headerless edge cases)
- `craco test DocumentPreview.reference`: 3 passed — real jsdom render test of the reference viewer: fetches reference text, renders it, shows the badge, highlights the matching row (and not the non-matching row); source mode highlights in the source doc; fetch failure shows an error, not a crash

Not covered by automated tests: live end-to-end (real extraction producing a reference excerpt, clicking a Handsontable cell, routing against a live backend). Recommend one manual pass: fill a column from a tabular reference, click the cell with the source panel open — expect the reference to open (purple badge) with the matching row highlighted.