### PR TITLE
feat(chat): progressive cell fill via cell_extracted broadcast

### DIFF
--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -508,10 +508,24 @@ class ToolExecutor:
               ref = refsvc.get_reference_document(session, reference_id)
               if ref:
                   reference_source = ref.filename
-      return await data_editor.update_cell(
+      result = await data_editor.update_cell(
           session_id, row_name, column, value, source_document=source_document,
           reference_source=reference_source,
       )
+      # Stream the write to the UI so cells fill in as they are written, rather
+      # than only appearing after the whole turn completes. The workspace refreshes
+      # on cell_extracted events.
+      try:
+          await websocket_manager.broadcast_to_session(
+              session_id,
+              {
+                  "type": "cell_extracted",
+                  "data": {"row_name": row_name, "column": column, "value": value},
+              },
+          )
+      except Exception:  # broadcasting is best-effort; never fail the write on it
+          pass
+      return result
 
   async def _resolve_source_document(self, session_id: str, row_name: str) -> Optional[str]:
       data_file = None

--- a/backend/tests/test_chat_executor.py
+++ b/backend/tests/test_chat_executor.py
@@ -180,3 +180,36 @@ async def test_reprocess_strips_excerpt_from_mixed_column_list(
 
     assert captured["columns"] == ["Title"]
     assert result["columns"] == ["Title"]
+
+
+@pytest.mark.asyncio
+async def test_update_cell_streams_cell_extracted(executor, sample_session, monkeypatch):
+    """Each chat cell write broadcasts a cell_extracted event so the UI fills in
+    progressively rather than only after the whole turn completes."""
+    import app.services.chat.tool_executor as te
+
+    sent: list[dict] = []
+
+    async def fake_update_cell(*a, **k):
+        return {"status": "success"}
+
+    async def fake_resolve(self, session_id, row_name):
+        return None
+
+    async def fake_broadcast(session_id, message):
+        sent.append(message)
+
+    monkeypatch.setattr(te.data_editor, "update_cell", fake_update_cell)
+    monkeypatch.setattr(ToolExecutor, "_resolve_source_document", fake_resolve)
+    monkeypatch.setattr(te.websocket_manager, "broadcast_to_session", fake_broadcast)
+
+    await executor.execute(
+        "update_cell",
+        sample_session.id,
+        "schematiq",
+        {"row": "Acker", "column": "Year", "value": "1982"},
+    )
+
+    assert len(sent) == 1
+    assert sent[0]["type"] == "cell_extracted"
+    assert sent[0]["data"] == {"row_name": "Acker", "column": "Year", "value": "1982"}


### PR DESCRIPTION
update_cell now broadcasts a cell_extracted event after each write, so the workspace fills cells in as they are written instead of only after the whole chat turn completes (the workspace already refreshes on cell_extracted). Best-effort; never fails the write. Test asserts the event is emitted.