### PR TITLE
feat: use Gemini 3.5 Flash (not Lite) for chat

### DIFF
--- a/backend/app/services/chat/deps.py
+++ b/backend/app/services/chat/deps.py
@@ -47,7 +47,7 @@ schematiq_runner = ScheMatiQRunner(
     uniprot_enrichment_service=uniprot_enrichment_service,
 )
 
-CHAT_MODEL = "gemini-3.5-flash-lite"
+CHAT_MODEL = "gemini-3.5-flash"
 WORK_DIR = Path("./schematiq_work")
 
 

--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -414,7 +414,7 @@ export function ChatPanel({
           Chat
         </div>
         <div className="flex items-center gap-2">
-          <Badge variant="outline">gemini-3.5-flash-lite</Badge>
+          <Badge variant="outline">gemini-3.5-flash</Badge>
           <Button size="sm" variant="outline" onClick={showToolsList} disabled={busy}>
             Tools
           </Button>


### PR DESCRIPTION
## Problem
Chat used `gemini-3.5-flash-lite` (hardcoded), per #274.

## Solution
Set `CHAT_MODEL` to `gemini-3.5-flash` and update the chat header badge to match. The `gemini-3.5-flash` entry already exists in `llmModels.ts` (with `isDefault: true`), so no constants changes were needed this time.

## Notes
`DEFAULT_EXTRACTION_MODEL` / `DEFAULT_RELEASE_EXTRACTION_MODEL` are for extraction, not chat, and are left untouched.

## Verify
- `python -m py_compile backend/app/services/chat/deps.py`
- `( cd frontend && npx tsc --noEmit )` — clean
- Patch applies cleanly on current main