### PR TITLE
fix(workspace): preserve definition/rationale/allowed_values when adding a schema column

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -667,10 +667,28 @@ export function SpreadsheetSurface({
         if (!editable.includes(key)) continue;
 
         if (!existing && key === 'name' && String(newValue || '').trim()) {
+          // A brand-new column is created from the spare schema row. Other cells
+          // on that row (definition/rationale/allowed_values) may already hold
+          // values the user typed before the name -- e.g. when filling the row
+          // right-to-left, where the name is entered last. Those edits landed on
+          // a still-non-existing row and were skipped by the `!existing` guard
+          // below, so read them back from the live grid and include them in the
+          // create request. Otherwise the subsequent onRefresh() re-renders from
+          // the backend (name only) and the typed values are lost.
+          const hot = hotTableRef.current?.hotInstance;
+          const readRowCell = (field: string): string =>
+            hot ? String(hot.getDataAtRowProp(rowIndex, field) ?? '') : '';
+          const pendingRationale = readRowCell('rationale').trim();
+          const pendingAllowedValues = parseAllowedValues(readRowCell('allowed_values'));
+
           schemaAPI.addColumn(sessionId, {
             name: String(newValue).trim(),
-            definition: '',
-            rationale: '',
+            definition: readRowCell('definition').trim(),
+            rationale: pendingRationale || undefined,
+            allowed_values:
+              pendingAllowedValues && pendingAllowedValues.length > 0
+                ? pendingAllowedValues
+                : undefined,
           })
             .then(() => {
               toast({ title: 'Schema column added' });


### PR DESCRIPTION
## Problem

When adding a new column via the Schema sheet's spare row, only the name is saved. If the row is filled right-to-left (name entered last, common in Hebrew RTL input), the definition/rationale/allowed_values cells are typed first on a row with no backing column yet.

Each of those edits hits the `if (!existing) continue` guard and is silently dropped. When the name is finally committed, `addColumn` runs with hard-coded empty definition/rationale, and the following `onRefresh()` re-renders from the backend with only the name, wiping the typed values.

Net result: only the name survives.

## Solution

In the new-column branch of `handleChanges` in the Schema sheet, read the sibling cells (`definition`, `rationale`, and `allowed_values`) back from the live Handsontable instance via `getDataAtRowProp` and include them in the `addColumn` request instead of hard-coding them as empty.

Fill order, LTR or RTL, no longer affects what gets persisted.

## Verify

- `( cd frontend && npx tsc --noEmit )` exits successfully.
- Manual: open the Schema sheet and add a new column by filling definition → rationale → name. All fields persist after refresh.
