### PR TITLE
chore(reference-fill): polish + live-stream chat cell writes

### DIFF
--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -533,10 +533,21 @@ class ToolExecutor:
               ref = refsvc.get_reference_document(session, reference_id)
               if ref:
                   reference_source = ref.filename
-      return await data_editor.update_cell(
+      result = await data_editor.update_cell(
           session_id, row_name, column, value, source_document=source_document,
           reference_source=reference_source,
       )
+      # Stream the write so the cell appears in the table as it is written, rather
+      # than only after the whole chat turn completes (the workspace refreshes on
+      # cell_extracted). Best-effort — a streaming hiccup must never fail the write.
+      try:
+          await websocket_manager.broadcast_to_session(
+              session_id,
+              {"type": "cell_extracted", "data": {"row": row_name, "column": column}},
+          )
+      except Exception:  # streaming is best-effort
+          pass
+      return result
 
   async def _resolve_source_document(self, session_id: str, row_name: str) -> Optional[str]:
       data_file = None

--- a/backend/app/services/reference_fill_service.py
+++ b/backend/app/services/reference_fill_service.py
@@ -21,7 +21,7 @@ import re
 import threading
 import time
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Optional
 
 from app.core.config import LLM_CALL_GLOBAL_LIMIT
@@ -53,15 +53,14 @@ REFERENCE_RAG_MAX_CHUNKS = int(os.getenv("REFERENCE_RAG_MAX_CHUNKS", "4000"))
 # outcomes, so use a capable chat-class model (not the lite per-row extractor).
 REFERENCE_SUMMARY_MODEL = os.getenv("REFERENCE_SUMMARY_MODEL", "gemini-3.5-flash")
 # How many per-row model calls may be in flight at once. The rows are independent,
-# so we fan them out instead of awaiting one at a time. Bounded to stay within API
-# rate limits and to keep quota over-run (past the global limit) small.
-# Bounded so we stay within API rate limits — and low by default because other
-# jobs/users may be calling the same API concurrently and share that limit.
+# so we fan them out instead of awaiting one at a time. Low by default because other
+# jobs/users may share the same API rate limit, and it also keeps any over-run past
+# the global quota small.
 REFERENCE_FILL_CONCURRENCY = int(os.getenv("REFERENCE_FILL_CONCURRENCY", "4"))
 # Retries per row on a transient model-call error (rate limit / 5xx / timeout),
 # with exponential backoff + jitter. Prevents a concurrency burst from silently
 # dropping rows that a retry would have filled.
-REFERENCE_FILL_MAX_RETRIES = int(os.getenv("REFERENCE_FILL_MAX_RETRIES", "4"))
+REFERENCE_FILL_MAX_RETRIES = max(1, int(os.getenv("REFERENCE_FILL_MAX_RETRIES", "4")))
 # Base backoff in seconds; a rate limit needs a real pause (several seconds),
 # especially when other jobs share the quota. Grows exponentially, capped at 30s.
 REFERENCE_FILL_RETRY_BASE_SECONDS = float(
@@ -354,7 +353,8 @@ class ReferenceFillService:
                         "reference fill %s row %d/%d unit=%r -> model answered %r",
                         op.fill_id, index + 1, op.total, unit, answer,
                     )
-                    if answer and answer.upper() not in _NO_VALUE_SENTINELS:
+                    valid = bool(answer) and answer.upper() not in _NO_VALUE_SENTINELS
+                    if valid:
                         try:
                             # Write every row sharing this unit's name (update_all), not
                             # just the first match — a reference lookup is a property of
@@ -367,10 +367,10 @@ class ReferenceFillService:
                             await self._broadcast_cell(op.session_id, unit, op.column, answer)
                         except Exception as exc:  # one row's write must not abort the run
                             logger.warning("reference fill write for %r failed: %s", unit, exc)
-                            answer = ""
+                            valid = False
                     records[index] = {
                         "unit": unit,
-                        "answer": answer if (answer and answer.upper() not in _NO_VALUE_SENTINELS) else None,
+                        "answer": answer if valid else None,
                         "found_in_context": found,
                     }
 


### PR DESCRIPTION
Two small, independent follow-ups to the reference-fill feature (#308), each in its
own commit.

## 1. refactor(reference-fill): cleanup
- Drop the unused `field` import from `dataclasses`.
- Collapse a duplicated comment block on `REFERENCE_FILL_CONCURRENCY`.
- Guard `REFERENCE_FILL_MAX_RETRIES` with `max(1, ...)` so the retry loop always
  runs at least once and never `raise`s `None` if the env var is set to 0.
- Compute the "is this a real value" sentinel check once (`valid`) instead of
  twice.

No behavior change.

## 2. feat(chat): stream update_cell writes
- The chat `update_cell` tool now broadcasts a best-effort `cell_extracted` event
  after a successful write, so cells written by the agent appear in the table live
  instead of only after the turn completes (the workspace already refreshes on
  `cell_extracted`).
- Chat-path only — separate from the reference-fill job, which already streams via
  its own broadcast, so there is no double-broadcast.
- Adopts the one useful idea from #304 without its destructive changes; #304 is
  being closed as superseded by #308.