### PR TITLE
fix(schema-discovery): persist merged batch on stop-after-merge

### DIFF
--- a/backend/app/services/pipeline/schema_discovery.py
+++ b/backend/app/services/pipeline/schema_discovery.py
@@ -288,6 +288,11 @@ async def run_schema_discovery(
 
         if is_stop_requested(session_id):
             logger.warning("Stop requested after schema merge - saving partial schema")
+            # Promote the just-merged schema and persist it before breaking, so the
+            # returned schema includes this batch and the log message above is truthful.
+            current_schema = merged_schema
+            if work_dir:
+                _save_partial_schema(current_schema, query, work_dir / session_id)
             break
 
         # Identify NEW columns added in this iteration


### PR DESCRIPTION
## Problem
When a stop is requested immediately after a schema merge (`schema_discovery.py:289`), the loop breaks before `current_schema = merged_schema` (line 329) and before `_save_partial_schema` (line 333). Result: the returned schema reflects every batch except the one merged at stop time, and the `Stop requested after schema merge - saving partial schema` log is false — no save happens.

## Solution
Inside the stop-after-merge block, promote `current_schema = merged_schema` and call `_save_partial_schema` (guarded by `work_dir`, matching the existing per-batch save) before breaking. This keeps the just-computed merge and makes the log truthful. The promotion stays out of the convergence path, which still compares the old `current_schema` against `merged_schema`.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone — passes
- `python -m py_compile backend/app/services/pipeline/schema_discovery.py` — passes
- Trigger a stop right after a batch merge; confirm `discovered_schema.json` includes the merged batch's columns.