### PR TITLE
fix(pipeline): dedup pending_values across value-extraction runs

### DIFF
--- a/backend/app/services/pipeline/value_extraction.py
+++ b/backend/app/services/pipeline/value_extraction.py
@@ -256,6 +256,8 @@ async def process_suggested_values(
 
         threshold = col.auto_expand_threshold if col.auto_expand_threshold is not None else 2
 
+        existing_pending = {pv.value for pv in (col.pending_values or [])}
+
         auto_added = []
         pending = []
 
@@ -272,7 +274,8 @@ async def process_suggested_values(
                 col.allowed_values.append(value)
                 auto_added.append(value)
                 logger.info("  Auto-added '%s' to %s (appeared in %d docs, threshold=%d)", value, col.name, doc_count, threshold)
-            else:
+            elif value not in existing_pending:
+                existing_pending.add(value)
                 pending.append(PendingValue(
                     value=value,
                     document_count=doc_count,


### PR DESCRIPTION
## Problem
`process_suggested_values` appends to `col.pending_values` via `.extend(pending)` with no check against existing entries. Within a single run the source is a dict keyed by value, so there are no intra-run duplicates. But when value extraction runs again on the same session (e.g. after continue-discovery adds documents), a value that stays below `auto_expand_threshold` is re-added as a duplicate `PendingValue`.

## Solution
Build `existing_pending = {pv.value for pv in (col.pending_values or [])}` once per column before the loop, and only append when the value is not already pending. The set is updated in-loop to stay accurate.

## Verify
- `python -m py_compile backend/app/services/pipeline/value_extraction.py`
- Run value extraction twice on a session with a sub-threshold value: it appears once in `pending_values`, not twice.

## Out of scope
Per-run count semantics: a value seen in one document per run stays pending with a stale count even if the cross-run document total would meet the threshold. Not introduced by this change; a future merge-on-reseen patch could address it.