### PR TITLE
fix: count re-extraction and continue-discovery LLM calls toward global quota

### DIFF
--- a/backend/app/services/continue_discovery_service.py
+++ b/backend/app/services/continue_discovery_service.py
@@ -950,6 +950,10 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
         # Set session context for logging
         set_session_context(operation.session_id)
         LLMCallTracker.get_instance().set_stage("continue_discovery")
+        # Snapshot the shared tracker's stage counter so we record only this run's
+        # calls (same pattern as _run_reextraction; the singleton may hold counts
+        # from an earlier run). The delta is recorded in the ``finally`` below.
+        llm_calls_before = LLMCallTracker.get_instance().get_counts().get("continue_discovery", 0)
 
         logger.info(f"_run_continue_discovery started for operation {operation_id}")
 
@@ -1345,6 +1349,23 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                 }
             )
         finally:
+            # Record this run's LLM calls toward the global quota. Continue-
+            # discovery is not part of the main pipeline, so without this its
+            # calls never reach the persistent usage store and never count
+            # against LLM_CALL_GLOBAL_LIMIT. The deferred import breaks the
+            # module-load cycle (chat.deps imports this service) and reuses the
+            # single shared runner instance.
+            try:
+                llm_calls_after = LLMCallTracker.get_instance().get_counts().get("continue_discovery", 0)
+                delta = max(0, llm_calls_after - llm_calls_before)
+                if delta > 0:
+                    from app.services.chat.deps import schematiq_runner
+                    record_id = f"continue_discovery-{operation.session_id[:8]}-{int(datetime.now().timestamp())}"
+                    await asyncio.to_thread(
+                        schematiq_runner.record_external_usage, record_id, {"continue_discovery": delta}
+                    )
+            except Exception as exc:
+                logger.debug("Could not record continue-discovery LLM usage: %s", exc)
             await concurrency_limiter.release(operation.session_id)
             # Only cleanup on stopped — failed operations persist for polling,
             # successful operations persist for the confirm/extraction step.

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -1119,6 +1119,11 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
         set_session_context(operation.session_id)
         LLMCallTracker.get_instance().set_stage("reextraction")
+        # Snapshot the shared tracker's stage counter so we record only the calls
+        # this run makes. The tracker is a process-global singleton and may
+        # already hold counts from an earlier run; the delta is recorded in the
+        # ``finally`` block below.
+        llm_calls_before = LLMCallTracker.get_instance().get_counts().get("reextraction", 0)
         logger.debug(f"_run_reextraction started for operation {operation_id}")
 
         try:
@@ -1432,6 +1437,24 @@ class ReextractionService(WebSocketBroadcasterMixin):
             )
             raise
         finally:
+            # Record this run's LLM calls toward the global quota. Re-extraction
+            # sets the tracker stage but is not part of the main pipeline, so
+            # without this its calls never reach the persistent usage store and
+            # never count against LLM_CALL_GLOBAL_LIMIT. Chat and reference-fill
+            # already record their own out-of-pipeline calls the same way. The
+            # deferred import breaks the module-load cycle (chat.deps imports this
+            # service) and reuses the single shared runner instance.
+            try:
+                llm_calls_after = LLMCallTracker.get_instance().get_counts().get("reextraction", 0)
+                delta = max(0, llm_calls_after - llm_calls_before)
+                if delta > 0:
+                    from app.services.chat.deps import schematiq_runner
+                    record_id = f"reextraction-{operation.session_id[:8]}-{int(datetime.now().timestamp())}"
+                    await asyncio.to_thread(
+                        schematiq_runner.record_external_usage, record_id, {"reextraction": delta}
+                    )
+            except Exception as exc:
+                logger.debug("Could not record re-extraction LLM usage: %s", exc)
             await concurrency_limiter.release(operation.session_id)
             self._cleanup_operation(operation_id)
 


### PR DESCRIPTION
## Problem
Re-extraction and continue-discovery each call `LLMCallTracker.set_stage(...)` but never persist their usage. Only the main pipeline (`schematiq_runner`), chat, and reference-fill call `record_external_usage`. The tracker is a process-global singleton that the main pipeline resets at the start of every run, so these services' calls are discarded before ever reaching `global_llm_usage.json` or Google Sheets. Result: their LLM calls never count against `LLM_CALL_GLOBAL_LIMIT`, and the global quota can be exceeded silently.

## Solution
Snapshot the tracker's per-stage counter at the start of each run and record the delta via the shared runner's `record_external_usage` in the existing `finally` block. The delta is clamped at zero, so it is strictly better than today's zero even in the rare case where a concurrent full-pipeline run resets the singleton mid-run. A fully race-free count would require per-call local counters threaded through every LLM call site (as reference-fill does) and is out of scope. The runner is imported lazily inside the method to avoid the module-load cycle (`chat.deps` imports both services) and to reuse the single shared runner instance.

## Verify
- `git apply --ignore-whitespace --check` passes on a clean clone
- `python -m py_compile` passes for both changed files
- Manual: run a re-extraction, then GET /api/usage — the cumulative total now increases by the number of extraction LLM calls; same for continue-discovery