### PR TITLE
fix: report correct auto_added_values count in schema_evolution broadcast

### DIFF
--- a/backend/app/services/pipeline/value_extraction.py
+++ b/backend/app/services/pipeline/value_extraction.py
@@ -246,6 +246,9 @@ async def process_suggested_values(
 
     logger.info("Processing %d suggested values for schema evolution", sum(len(vals) for vals in suggested_values.values()))
 
+    # Count values actually auto-added in THIS run (accumulated per column below).
+    total_auto_added = 0
+
     for col in session.columns:
         if col.name not in suggested_values:
             continue
@@ -287,9 +290,9 @@ async def process_suggested_values(
             logger.info("  Added %d pending values to %s for review", len(pending), col.name)
 
         if auto_added:
+            total_auto_added += len(auto_added)
             logger.info("  Auto-expanded %s allowed_values with %d new values", col.name, len(auto_added))
 
-    total_auto_added = sum(1 for col in session.columns if col.allowed_values)
     total_pending = sum(len(col.pending_values or []) for col in session.columns)
 
     if total_auto_added > 0 or total_pending > 0:


### PR DESCRIPTION
## Problem
In `process_suggested_values`, the `auto_added_values` field of the `schema_evolution` WebSocket broadcast was computed as `sum(1 for col in session.columns if col.allowed_values)`. That counts columns that have any allowed_values at all (including ones present before this run), not the number of values auto-added in this run. The frontend received a wrong number.

## Solution
Accumulate a real per-run counter (`total_auto_added += len(auto_added)`) inside the column loop and drop the incorrect post-loop recompute. `total_pending` is intentionally left as-is: it reports the cumulative review backlog across columns, which is a separate, defensible metric and out of scope here.

## Verify
- `git apply --ignore-whitespace --check` passes on a clean clone
- `python -m py_compile` passes
- Manual: a run that auto-adds N values now broadcasts `auto_added_values: N` rather than a column count