### PR TITLE
refactor: dedup dev.sh instance-dir discovery logic

### DIFF
--- a/backend/app/services/data_utils.py
+++ b/backend/app/services/data_utils.py
@@ -98,22 +98,34 @@ _APP_DIR = _MODULE_DIR.parent              # app/
 _BACKEND_DIR = _APP_DIR.parent             # backend/
 
 
+def dev_instance_dirs(subdir: str) -> List[Path]:
+    """dev.sh isolation dirs: ``.dev-data/instance-*/<subdir>`` (sorted, deduped).
+
+    Returns an empty list when there is no ``.dev-data`` root (Docker / prod).
+    """
+    dev_root = _BACKEND_DIR.parent / ".dev-data"
+    if not dev_root.is_dir():
+        return []
+    seen: set[Path] = set()
+    dirs: List[Path] = []
+    for instance_dir in sorted(dev_root.glob(f"instance-*/{subdir}")):
+        resolved = instance_dir.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            dirs.append(instance_dir)
+    return dirs
+
+
 def candidate_work_dirs() -> List[Path]:
     """Search order for schematiq_work — CWD first (dev.sh / Docker), then fallbacks."""
     seen: set[Path] = set()
     dirs: List[Path] = []
-    for raw in (Path.cwd() / "schematiq_work", _BACKEND_DIR / "schematiq_work"):
+    for raw in (Path.cwd() / "schematiq_work", _BACKEND_DIR / "schematiq_work",
+                *dev_instance_dirs("schematiq_work")):
         resolved = raw.resolve()
         if resolved not in seen:
             seen.add(resolved)
             dirs.append(raw)
-    dev_root = _BACKEND_DIR.parent / ".dev-data"
-    if dev_root.is_dir():
-        for instance_work in sorted(dev_root.glob("instance-*/schematiq_work")):
-            resolved = instance_work.resolve()
-            if resolved not in seen:
-                seen.add(resolved)
-                dirs.append(instance_work)
     return dirs
 
 
@@ -121,18 +133,12 @@ def candidate_data_dirs() -> List[Path]:
     """Search order for session data/ — CWD first (dev.sh / Docker), then fallbacks."""
     seen: set[Path] = set()
     dirs: List[Path] = []
-    for raw in (Path.cwd() / "data", _BACKEND_DIR / "data", _APP_DIR / "data"):
+    for raw in (Path.cwd() / "data", _BACKEND_DIR / "data", _APP_DIR / "data",
+                *dev_instance_dirs("data")):
         resolved = raw.resolve()
         if resolved not in seen:
             seen.add(resolved)
             dirs.append(raw)
-    dev_root = _BACKEND_DIR.parent / ".dev-data"
-    if dev_root.is_dir():
-        for instance_data in sorted(dev_root.glob("instance-*/data")):
-            resolved = instance_data.resolve()
-            if resolved not in seen:
-                seen.add(resolved)
-                dirs.append(instance_data)
     return dirs
 
 

--- a/backend/app/services/unit_view_service.py
+++ b/backend/app/services/unit_view_service.py
@@ -36,20 +36,9 @@ class UnitViewService:
 
     def _dev_instance_work_dirs(self) -> List[Path]:
         """schematiq_work dirs from dev.sh isolation (.dev-data/instance-N/)."""
-        from app.services.data_utils import _BACKEND_DIR
+        from app.services.data_utils import dev_instance_dirs
 
-        dev_root = _BACKEND_DIR.parent / ".dev-data"
-        if not dev_root.is_dir():
-            return []
-
-        seen: set[Path] = set()
-        dirs: List[Path] = []
-        for instance_work in sorted(dev_root.glob("instance-*/schematiq_work")):
-            resolved = instance_work.resolve()
-            if resolved not in seen:
-                seen.add(resolved)
-                dirs.append(instance_work)
-        return dirs
+        return dev_instance_dirs("schematiq_work")
 
     def _candidate_work_dirs(self) -> List[Path]:
         """Work dirs to search — CWD-relative, module-relative, and dev.sh instances."""
@@ -66,20 +55,9 @@ class UnitViewService:
 
     def _dev_instance_data_dirs(self) -> List[Path]:
         """data dirs from dev.sh isolation (.dev-data/instance-N/data)."""
-        from app.services.data_utils import _BACKEND_DIR
+        from app.services.data_utils import dev_instance_dirs
 
-        dev_root = _BACKEND_DIR.parent / ".dev-data"
-        if not dev_root.is_dir():
-            return []
-
-        seen: set[Path] = set()
-        dirs: List[Path] = []
-        for instance_data in sorted(dev_root.glob("instance-*/data")):
-            resolved = instance_data.resolve()
-            if resolved not in seen:
-                seen.add(resolved)
-                dirs.append(instance_data)
-        return dirs
+        return dev_instance_dirs("data")
 
     def _candidate_data_dirs(self) -> List[Path]:
         """Data dirs to search — CWD-relative, module-relative, and dev.sh instances."""


### PR DESCRIPTION
## Problem
The `.dev-data/instance-*/<subdir>` glob-and-dedup logic was copy-pasted in four places: inline in `data_utils.candidate_work_dirs`/`candidate_data_dirs`, and as `UnitViewService._dev_instance_work_dirs`/`_dev_instance_data_dirs`.

## Solution
Extract a single `dev_instance_dirs(subdir)` helper in `data_utils` and call it from all four sites. Ordering and dedup semantics are preserved exactly. Net -16 lines.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone: passes
- `python -m py_compile backend/app/services/data_utils.py backend/app/services/unit_view_service.py`: passes