### PR TITLE
refactor: dedup directory-path defaults via config constants

### DIFF
--- a/backend/app/services/chat/deps.py
+++ b/backend/app/services/chat/deps.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from app.core.config import RELEASE_CONFIG
+from app.core.config import DEFAULT_SCHEMATIQ_WORK_DIR, RELEASE_CONFIG
 from app.services import (
     session_manager,
     websocket_manager,
@@ -57,7 +57,7 @@ reference_fill_service = ReferenceFillService(
 )
 
 CHAT_MODEL = "gemini-3.5-flash"
-WORK_DIR = Path("./schematiq_work")
+WORK_DIR = Path(DEFAULT_SCHEMATIQ_WORK_DIR)
 
 
 def get_default_llm_config() -> dict[str, Any]:

--- a/backend/app/services/data_editor.py
+++ b/backend/app/services/data_editor.py
@@ -9,6 +9,7 @@ import logging
 from pathlib import Path
 from typing import Any, Optional
 
+from app.core.config import DEFAULT_DATA_DIR, DEFAULT_SCHEMATIQ_WORK_DIR
 from app.services.data_utils import (
     resolve_session_data_files,
     persist_session_data_file,
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 class DataEditor:
     """Handles cell-level data updates in JSONL data files."""
 
-    def __init__(self, work_dir: str = "./schematiq_work", data_dir: str = "./data"):
+    def __init__(self, work_dir: str = DEFAULT_SCHEMATIQ_WORK_DIR, data_dir: str = DEFAULT_DATA_DIR):
         self.work_dir = Path(work_dir)
         self.data_dir = Path(data_dir)
 

--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 from app.core.config import (
     MAX_DOCUMENTS, DEVELOPER_MODE, LLM_CALL_GLOBAL_LIMIT, LLM_CALL_LIMIT_WINDOW_DAYS,
-    LLM_USAGE_SYNC_TTL_SECONDS, LLM_CALL_WARN_THRESHOLD,
+    LLM_USAGE_SYNC_TTL_SECONDS, LLM_CALL_WARN_THRESHOLD, DEFAULT_SCHEMATIQ_WORK_DIR,
 )
 from app.core.logging_utils import set_session_context
 from app.services import schematiq_thread_pool, concurrency_limiter
@@ -49,7 +49,7 @@ from app.services.websocket_mixin import WebSocketBroadcasterMixin
 class ScheMatiQRunner(WebSocketBroadcasterMixin):
     """Handles ScheMatiQ execution and integration."""
 
-    def __init__(self, work_dir: str = "./schematiq_work", websocket_manager=None, session_manager=None,
+    def __init__(self, work_dir: str = DEFAULT_SCHEMATIQ_WORK_DIR, websocket_manager=None, session_manager=None,
                  data_collection_service=None, pubmed_enrichment_service=None,
                  uniprot_enrichment_service=None):
         if websocket_manager is not None:

--- a/backend/app/storage/local_backend.py
+++ b/backend/app/storage/local_backend.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 import aiofiles
 import aiofiles.os
 
+from app.core.config import DEFAULT_DATA_DIR, DEFAULT_SCHEMATIQ_WORK_DIR, DEFAULT_SESSIONS_DIR
 from app.storage.interface import StorageInterface, DatasetInfo, FileInfo, TemplateInfo, InitialSchemaInfo
 
 logger = logging.getLogger(__name__)
@@ -27,9 +28,9 @@ class LocalStorageBackend(StorageInterface):
 
     def __init__(
         self,
-        sessions_dir: str = "./sessions",
-        data_dir: str = "./data",
-        schematiq_work_dir: str = "./schematiq_work",
+        sessions_dir: str = DEFAULT_SESSIONS_DIR,
+        data_dir: str = DEFAULT_DATA_DIR,
+        schematiq_work_dir: str = DEFAULT_SCHEMATIQ_WORK_DIR,
         datasets_dir: str = "../research/data",
         templates_dir: str = "./templates",
         initial_schemas_dir: str = "./initial_schemas"


### PR DESCRIPTION
## Problem
The directory defaults `./sessions`, `./data`, and `./schematiq_work` were hardcoded as parameter defaults in `chat/deps.py`, `data_editor.py`, `schematiq_runner.py`, and `local_backend.py`, duplicating `DEFAULT_SESSIONS_DIR` / `DEFAULT_DATA_DIR` / `DEFAULT_SCHEMATIQ_WORK_DIR` in `app.core.config`. `storage/factory.py` already imports and passes those constants, so the backend defaults were stale copies.

## Solution
Reference the `app.core.config` constants in all four modules. Values are unchanged, so behavior is preserved; the directory defaults now have a single source of truth. No import cycle: `config` imports only `os` and `schematiq.core.model_specs`.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone: passes
- `python -m py_compile` on all four files: passes