### PR TITLE
fix: stop leaking ping intervals on WebSocket reconnect

### DIFF
--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -20,6 +20,7 @@ function getWebSocketBaseUrl(): string {
 class WebSocketService {
   private socket: WebSocket | null = null;
   private reconnectTimeout: NodeJS.Timeout | null = null;
+  private pingInterval: NodeJS.Timeout | null = null;
   private messageHandlers: MessageHandler[] = [];
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 5;
@@ -140,13 +141,24 @@ class WebSocketService {
   }
 
   private startPingInterval() {
-    const pingInterval = setInterval(() => {
+    // Clear any interval left over from a previous connection so reconnects do
+    // not leak timers. Each open starts exactly one ping loop, tracked on the
+    // instance so it can also be cleared from closeSocket().
+    this.clearPingInterval();
+    this.pingInterval = setInterval(() => {
       if (this.socket && this.socket.readyState === WebSocket.OPEN) {
         this.socket.send(JSON.stringify({ type: 'ping' }));
       } else {
-        clearInterval(pingInterval);
+        this.clearPingInterval();
       }
     }, 15000); // Ping every 15 seconds (reduced from 30s to help keep connection alive)
+  }
+
+  private clearPingInterval() {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+      this.pingInterval = null;
+    }
   }
 
   private scheduleReconnect() {
@@ -188,6 +200,8 @@ class WebSocketService {
   }
 
   private closeSocket() {
+    this.clearPingInterval();
+
     if (this.reconnectTimeout) {
       clearTimeout(this.reconnectTimeout);
       this.reconnectTimeout = null;


### PR DESCRIPTION
## Problem
`startPingInterval` stored its timer in a local variable and ran on every `onopen`. On reconnect a new interval was created while the old one kept firing (its self-clear guard sees the new open socket and never triggers), so every reconnect leaked another 15s ping loop. `closeSocket` could not clear it either, since no reference was kept.

## Solution
Track the interval on the instance (`this.pingInterval`), clear any stale interval at the start of `startPingInterval`, and clear it in `closeSocket`. Each open now runs exactly one ping loop.

## Verify
- `( cd frontend && npx tsc --noEmit )` passes
- Manual: drop and restore the backend several times; only one ping fires every 15s (Network tab), and pings stop after the last holder disconnects