### PR TITLE
fix: quiet broadcast_to_session logging when no clients are connected

### DIFF
--- a/backend/app/services/websocket_manager.py
+++ b/backend/app/services/websocket_manager.py
@@ -198,8 +198,11 @@ class WebSocketManager:
         async with self._lock:
             ws_set = self.connections.get(session_id)
             if not ws_set:
-                logger.warning(f"No connections for session {session_id}")
-                logger.warning(f"Active sessions: {list(self.connections.keys())}")
+                # No active client for this session (e.g. the user navigated away
+                # while the pipeline keeps broadcasting). This is normal, so log
+                # at debug to avoid flooding production logs. The sibling
+                # broadcast_* methods already return silently in this case.
+                logger.debug(f"No connections for session {session_id}")
                 return
             snapshot = list(ws_set)
 


### PR DESCRIPTION
## Problem
`broadcast_to_session` logged two WARNING lines (including a dump of all active session keys) whenever it was called with no active connection. This is a normal state (user navigated away while the pipeline keeps broadcasting), and it floods production logs. The sibling broadcast_* methods already return silently in the same case.

## Solution
Downgrade to a single debug line and drop the active-sessions dump, matching the otherDowngrade to a single debug line and dropy_Downgrade to a sapDowngrade to a singt_Downgrade to a single debug line and drop the active client attached; no WARNING spam, one debug line per broadcast