### PR TITLE
feat: auto-recover WebSocket when connectivity returns or tab is refocused

### DIFF
--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -32,6 +32,39 @@ class WebSocketService {
   private activeSessionId: string | null = null;
   private activeEndpoint: 'progress' | 'logs' = 'progress';
 
+  constructor() {
+    // Auto-recover after the reconnect budget is exhausted. Once the browser
+    // regains connectivity or the tab is foregrounded, a still-needed session
+    // reconnects instead of staying dead until a page reload. The singleton
+    // lives for the page lifetime, so these listeners are never removed.
+    if (typeof window !== 'undefined') {
+      window.addEventListener('online', this.handleConnectivityRestored);
+    }
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', this.handleConnectivityRestored);
+    }
+  }
+
+  private handleConnectivityRestored = () => {
+    // Only act when a holder still needs the socket and it is fully down.
+    if (this.refCount <= 0 || !this.activeSessionId || this.socket) {
+      return;
+    }
+    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+      return;
+    }
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+      return;
+    }
+    // Reset the backoff and cancel any pending timer so recovery is immediate.
+    this.reconnectAttempts = 0;
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = null;
+    }
+    this.openSocket(this.activeSessionId, this.activeEndpoint);
+  };
+
   connect(sessionId: string, endpoint: 'progress' | 'logs' = 'progress') {
     const key = `${endpoint}/${sessionId}`;
 


### PR DESCRIPTION
## Problem
The shared webSocketService stops reconnecting after maxReconnectAttempts (5). Once exhausted it stays dead until a full page reload, even if the network comes back. The disconnected polling fallback keeps table data fresh, but live updates (cell animations, progress) are lost until reload. This affects every consumer of the shared service (Workspace, ScheMatiQMonitor).

## Solution
Listen for the browser `online` event and `visibilitychange`. When a holder still needs the socket and it is fully down, reset the backoff and reconnect immediately (skipping the remaining wait). Guarded by refCount, an active session id, visibility, and navigator.onLine so it never opens a redundant or futile socket. The singleton lives for the page lifetime, so the listeners are never removed.

## Out of scope
Visualize.tsx has its own inline WebSocket logic and is not covered here.

## Verify
- `( cd frontend && npx tsc --noEmit )` passes
- Manual: disconnect the backend until the client gives up (5 attempts), then restore it and either refocus the tab or restore the network. The socket reconnects without a page reload and live updates resume