### PR TITLE
fix: raise chat request timeout so long agent turns are not cut off

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1019,6 +1019,12 @@ export const unitsAPI = {
  * @param path - API path (relative to API_BASE)
  * @param fallbackFilename - Default filename if Content-Disposition header is missing
  */
+// The chat/agent endpoints block until the full agent turn finishes, which can
+// span several LLM round-trips and tool calls. Give them a much larger timeout
+// than the 30s default so long turns are not cut off on the client. Cancel and
+// getTools stay on the default since they return quickly.
+const CHAT_REQUEST_TIMEOUT_MS = 300000; // 5 minutes
+
 export const chatAPI = {
   getTools: async (
     sessionId?: string,
@@ -1041,7 +1047,7 @@ export const chatAPI = {
       pinned_tool?: string;
     },
   ): Promise<ChatMessageResponse> => {
-    const response = await api.post(`/chat/${sessionId}/message`, payload);
+    const response = await api.post(`/chat/${sessionId}/message`, payload, { timeout: CHAT_REQUEST_TIMEOUT_MS });
     return response.data;
   },
 
@@ -1049,7 +1055,7 @@ export const chatAPI = {
     sessionId: string,
     chatId: string,
   ): Promise<ChatMessageResponse> => {
-    const response = await api.post(`/chat/${sessionId}/confirm`, { chat_id: chatId });
+    const response = await api.post(`/chat/${sessionId}/confirm`, { chat_id: chatId }, { timeout: CHAT_REQUEST_TIMEOUT_MS });
     return response.data;
   },
 


### PR DESCRIPTION
## Problem
The shared axios instance sets a 30s default timeout. Chat calls used it with no override, but /chat/{id}/message and /chat/{id}/confirm are awaited inline on the backend and hold the HTTP connection open for the entire agent turn. A turn that spans several LLM round-trips and tool calls exceeds 30s and is killed client-side.

## Solution
Add a dedicated CHAT_REQUEST_TIMEOUT_MS (5 minutes) and apply it to sendMessage and confirmAction. cancelAction and getTools keep the 30s default since they return quickly.

## Verify
- `( cd frontend && npx tsc --noEmit )` passes
- Manual: send a chat message that triggers a multi-step agent turn taking >30s; it now completes instead of erroring at 30s