### PR TITLE
feat: show a thinking indicator in chat while awaiting the agent

### DIFF
--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -97,7 +97,7 @@ export function ChatPanel({
       top: container.scrollHeight,
       behavior: 'smooth',
     });
-  }, [messages, pendingAction]);
+  }, [messages, pendingAction, busy]);
 
   const loadTools = useCallback(async () => {
     const tools = await chatAPI.getTools(sessionId, sessionMode);
@@ -483,6 +483,20 @@ export function ChatPanel({
               <ChatMessageBody message={item.message} />
             </div>
           ),
+        )}
+
+        {busy && (
+          <div className="workspace-chat-message" data-role="assistant">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <img
+                src="/icon.png"
+                alt=""
+                aria-hidden="true"
+                className="h-4 w-4 animate-pulse"
+              />
+              <span>Thinking…</span>
+            </div>
+          </div>
         )}
 
         {fillRunning && (


### PR DESCRIPTION
## Problem
After sending a chat message the conversation area stays empty until the full agent response arrives. The only feedback is a small spinner inside the send button, which is easy to miss, so the user cannot tell the request was received and is being worked on.

## Solution
Render an inline assistant 'Thinking…' indicator in the message list whenever a chat request is in flight (the existing `busy` state). It uses the existing ScheMatiQ mark (/icon.png) with a gentle pulse, mirroring the existing fillRunning status row. Also add `busy` to the auto-scroll deps so the indicator scrolls into view.

## Verify
- `( cd frontend && npx tsc --noEmit )` passes
- Manual: send a message that takes a moment; a pulsing ScheMatiQ mark with 'Thinking…' appears immediately and disappears when the reply lands