### PR TITLE
feat: animated thinking indicator in chat

### DIFF
--- a/frontend/src/pages/Workspace/Workspace.css
+++ b/frontend/src/pages/Workspace/Workspace.css
@@ -1290,7 +1290,7 @@
     filter: saturate(0.6);
   }
   50% {
-    transform: scale(1.18);
+    transform: scale(1.1);
     opacity: 1;
     filter: saturate(1.35);
   }
@@ -1298,7 +1298,7 @@
 
 .workspace-chat-thinking-logo {
   transform-origin: center;
-  animation: schematiq-thinking 1.1s ease-in-out infinite;
+  animation: schematiq-thinking 1.5s ease-in-out infinite;
   will-change: transform, opacity;
 }
 

--- a/frontend/src/pages/Workspace/Workspace.css
+++ b/frontend/src/pages/Workspace/Workspace.css
@@ -1279,3 +1279,37 @@
     display: none;
   }
 }
+
+/* Chat "thinking" indicator: the ScheMatiQ mark breathes (grows/shrinks with a
+   brightness and color-saturation shift) while an agent turn is in flight, so
+   it reads as clearly alive and is easy to notice. */
+@keyframes schematiq-thinking {
+  0%, 100% {
+    transform: scale(0.82);
+    opacity: 0.5;
+    filter: saturate(0.6);
+  }
+  50% {
+    transform: scale(1.18);
+    opacity: 1;
+    filter: saturate(1.35);
+  }
+}
+
+.workspace-chat-thinking-logo {
+  transform-origin: center;
+  animation: schematiq-thinking 1.1s ease-in-out infinite;
+  will-change: transform, opacity;
+}
+
+/* Respect users who prefer reduced motion: fall back to a gentle fade only. */
+@media (prefers-reduced-motion: reduce) {
+  .workspace-chat-thinking-logo {
+    animation: schematiq-thinking-fade 1.6s ease-in-out infinite;
+  }
+}
+
+@keyframes schematiq-thinking-fade {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}

--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -97,7 +97,7 @@ export function ChatPanel({
       top: container.scrollHeight,
       behavior: 'smooth',
     });
-  }, [messages, pendingAction]);
+  }, [messages, pendingAction, busy]);
 
   const loadTools = useCallback(async () => {
     const tools = await chatAPI.getTools(sessionId, sessionMode);
@@ -483,6 +483,20 @@ export function ChatPanel({
               <ChatMessageBody message={item.message} />
             </div>
           ),
+        )}
+
+        {busy && (
+          <div className="workspace-chat-message" data-role="assistant">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <img
+                src="/icon.png"
+                alt=""
+                aria-hidden="true"
+                className="workspace-chat-thinking-logo h-5 w-5"
+              />
+              <span>Thinking…</span>
+            </div>
+          </div>
         )}
 
         {fillRunning && (


### PR DESCRIPTION
## Problem
After sending a chat message the conversation area stays empty until the full agent response arrives. The only feedback is a small spinner in the send button, easy to miss.

## Solution
Render an inline assistant 'Thinking…' indicator in the message list while a chat request is in flight (existing busy state). Uses the ScheMatiQ mark with a breathing animation; prefers-reduced-motion degrades to an opacity fade. Adds busy to the auto-scroll deps so the indicator scrolls into view.

## Verify
- ( cd frontend && npx tsc --noEmit ) passes
- Manual: send a message that takes a moment — a pulsing mark with 'Thinking…' appears immediately and disappears when the reply lands