### PR TITLE
fix(pipeline): reconcile pending_values across value-extraction re-runs

### DIFF
--- a/backend/app/services/pipeline/value_extraction.py
+++ b/backend/app/services/pipeline/value_extraction.py
@@ -273,6 +273,15 @@ async def process_suggested_values(
                     col.allowed_values = []
                 col.allowed_values.append(value)
                 auto_added.append(value)
+                # If this value was pending from an earlier run, it is now
+                # promoted to allowed_values. Drop the stale pending entry so the
+                # value does not linger in both lists once it crosses threshold.
+                if value in existing_pending:
+                    existing_pending.discard(value)
+                    if col.pending_values:
+                        col.pending_values = [pv for pv in col.pending_values if pv.value != value]
+                        if not col.pending_values:
+                            col.pending_values = None
                 logger.info("  Auto-added '%s' to %s (appeared in %d docs, threshold=%d)", value, col.name, doc_count, threshold)
             elif value not in existing_pending:
                 existing_pending.add(value)
@@ -282,6 +291,16 @@ async def process_suggested_values(
                     first_seen=datetime.now(),
                     documents=documents[:10]
                 ))
+            else:
+                # Already pending from an earlier run. Counts are recomputed
+                # cumulatively over all current documents on every run, so refresh
+                # the stored count/documents to the latest figures instead of
+                # leaving the first-seen values stale.
+                for pv in (col.pending_values or []):
+                    if pv.value == value:
+                        pv.document_count = doc_count
+                        pv.documents = documents[:10]
+                        break
 
         if pending:
             if col.pending_values is None:


### PR DESCRIPTION
## Problem
After #315 stopped duplicate pending values, two related inconsistencies remained across value-extraction re-runs (e.g. after continue-discovery adds documents). Counts are recomputed cumulatively over all current documents on every run.

1. When a previously pending value crosses its auto_expand_threshold on a later run, it is promoted to allowed_values but its stale PendingValue is never removed, leaving the value in both lists.
2. When a value stays pending but its cumulative document_count grows, the stored PendingValue keeps its first-seen count/documents, so the review UI shows a stale, too-low count.

## Solution
In process_suggested_values:
- On promotion to allowed_values, drop any matching pending entry (mirrors the existing removal pattern in schema.py, setting pending_values to None when empty).
- When a value is already pending and still sub-threshold, refresh its document_count and documents to the latest cumulative figures. first_seen is preserved.

Backend-only, contained to one function. No frontend changes.

## Verify
- git apply --ignore-whitespace --check on a clean clone: passes
- python -m py_compile app/services/pipeline/value_extraction.py: passes
- Behavioral simulation of 4 scenarios passes, including a regression check that #315 dedup still holds