### PR TITLE
refactor: dedup hardcoded gemini-3.5-flash model string

### DIFF
--- a/backend/app/services/chat/deps.py
+++ b/backend/app/services/chat/deps.py
@@ -7,6 +7,8 @@ import os
 from pathlib import Path
 from typing import Any
 
+from schematiq.core.model_specs import ModelNames
+
 from app.core.config import DEFAULT_SCHEMATIQ_WORK_DIR, RELEASE_CONFIG
 from app.services import (
     session_manager,
@@ -56,7 +58,7 @@ reference_fill_service = ReferenceFillService(
     schematiq_runner=schematiq_runner,
 )
 
-CHAT_MODEL = "gemini-3.5-flash"
+CHAT_MODEL = ModelNames.GEMINI_35_FLASH
 WORK_DIR = Path(DEFAULT_SCHEMATIQ_WORK_DIR)
 
 

--- a/backend/app/services/reference_fill_service.py
+++ b/backend/app/services/reference_fill_service.py
@@ -26,6 +26,7 @@ from typing import Any, Optional
 
 from app.core.config import LLM_CALL_GLOBAL_LIMIT
 from schematiq.core.llm_call_tracker import QuotaExceededError
+from schematiq.core.model_specs import ModelNames
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ REFERENCE_RAG_BUDGET_CHARS = int(
 REFERENCE_RAG_MAX_CHUNKS = int(os.getenv("REFERENCE_RAG_MAX_CHUNKS", "4000"))
 # Model for the one end-of-run recap call. A recap is light reasoning over the
 # outcomes, so use a capable chat-class model (not the lite per-row extractor).
-REFERENCE_SUMMARY_MODEL = os.getenv("REFERENCE_SUMMARY_MODEL", "gemini-3.5-flash")
+REFERENCE_SUMMARY_MODEL = os.getenv("REFERENCE_SUMMARY_MODEL", ModelNames.GEMINI_35_FLASH)
 # How many per-row model calls may be in flight at once. The rows are independent,
 # so we fan them out instead of awaiting one at a time. Low by default because other
 # jobs/users may share the same API rate limit, and it also keeps any over-run past


### PR DESCRIPTION
## Problem
The literal "gemini-3.5-flash" was hardcoded in two places (chat/deps.py CHAT_MODEL and reference_fill_service.py REFERENCE_SUMMARY_MODEL default), duplicating the canonical ModelNames.GEMINI_35_FLASH already defined in schematiq.core.model_specs.

Supersedes #321, which was opened before #320 (dedup-dir-defaults) merged and now conflicts on deps.py's surrounding context.

## Solution
Reference ModelNames.GEMINI_35_FLASH in both sites, rebased onto current main. The constant resolves to the same string, so behavior is unchanged.

## Verify
- git apply --ignore-whitespace --check on a clean clone: passes
- python -m py_compile backend/app/services/chat/deps.py backend/app/services/reference_fill_service.py: passes
- No frontend files touched