### PR TITLE
fix(quota): serialize LLMCallTracker access across concurrent reextraction/continue-discovery runs

### DIFF
--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -89,6 +89,24 @@ concurrency_limiter = ConcurrencyLimiter(MAX_CONCURRENT_SESSIONS)
 logger.info("[concurrency] Concurrency limiter initialized: max %d sessions", MAX_CONCURRENT_SESSIONS)
 
 
+# ── Serializes access to the process-global LLMCallTracker singleton ─
+# Verified from schematiq-lib source (schematiq/core/llm_call_tracker.py):
+# LLMCallTracker.get_instance() returns one instance per process, and
+# _current_stage plus _counts live directly on that instance with no
+# per-session or contextvar scoping. set_stage() changes which stage
+# increment() credits for *every* concurrent caller, and get_counts() reads
+# the same shared dict. Reextraction and continue-discovery record their
+# LLM usage by snapshotting get_counts() before and after their run and
+# recording the delta (see reextraction_service.py / continue_discovery_
+# service.py). MAX_CONCURRENT_SESSIONS defaults to 5 and concurrency_limiter
+# actually permits that many simultaneous runs, so without this lock two
+# overlapping runs could both mislabel each other's calls (via set_stage)
+# and corrupt each other's before/after delta. This lock makes each
+# snapshot-run-snapshot sequence exclusive across the whole process for
+# these two services.
+llm_call_tracker_lock = asyncio.Lock()
+
+
 def find_session_data_file_sync(session_id: str) -> Optional[Path]:
     """Find the primary data file for a session, hydrating from storage when needed.
 

--- a/backend/app/services/continue_discovery_service.py
+++ b/backend/app/services/continue_discovery_service.py
@@ -26,7 +26,7 @@ from app.models.session import (
 from app.services.websocket_manager import WebSocketManager
 from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
-from app.services import schematiq_thread_pool, concurrency_limiter
+from app.services import schematiq_thread_pool, concurrency_limiter, llm_call_tracker_lock
 from app.storage.factory import get_storage
 from app.core.config import DEVELOPER_MODE, MAX_DOCUMENTS
 from app.core.logging_utils import set_session_context
@@ -949,11 +949,24 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
 
         # Set session context for logging
         set_session_context(operation.session_id)
-        LLMCallTracker.get_instance().set_stage("continue_discovery")
-        # Snapshot the shared tracker's stage counter so we record only this run's
-        # calls (same pattern as _run_reextraction; the singleton may hold counts
-        # from an earlier run). The delta is recorded in the ``finally`` below.
-        llm_calls_before = LLMCallTracker.get_instance().get_counts().get("continue_discovery", 0)
+
+        # Held for the entire run (released in the ``finally`` below).
+        # LLMCallTracker.get_instance() is a process-global singleton with no
+        # per-session scoping: set_stage() and _counts are shared by every
+        # concurrent caller. MAX_CONCURRENT_SESSIONS (default 5) means another
+        # reextraction/continue-discovery run could otherwise overlap this one
+        # and both mislabel calls and corrupt the before/after delta below.
+        # See llm_call_tracker_lock's definition for details.
+        await llm_call_tracker_lock.acquire()
+        try:
+            LLMCallTracker.get_instance().set_stage("continue_discovery")
+            # Snapshot the shared tracker's stage counter so we record only this run's
+            # calls (same pattern as _run_reextraction; the singleton may hold counts
+            # from an earlier run). The delta is recorded in the ``finally`` below.
+            llm_calls_before = LLMCallTracker.get_instance().get_counts().get("continue_discovery", 0)
+        except Exception:
+            llm_call_tracker_lock.release()
+            raise
 
         logger.info(f"_run_continue_discovery started for operation {operation_id}")
 
@@ -1366,6 +1379,8 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                     )
             except Exception as exc:
                 logger.debug("Could not record continue-discovery LLM usage: %s", exc)
+            finally:
+                llm_call_tracker_lock.release()
             await concurrency_limiter.release(operation.session_id)
             # Only cleanup on stopped — failed operations persist for polling,
             # successful operations persist for the confirm/extraction step.

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -19,7 +19,7 @@ from app.models.session import (
 from app.services.websocket_manager import WebSocketManager
 from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
-from app.services import schematiq_thread_pool, concurrency_limiter
+from app.services import schematiq_thread_pool, concurrency_limiter, llm_call_tracker_lock
 from app.services.data_utils import row_name_of
 from app.storage.factory import get_storage
 from app.core.config import DEVELOPER_MODE, RELEASE_CONFIG
@@ -1118,12 +1118,25 @@ class ReextractionService(WebSocketBroadcasterMixin):
             return
 
         set_session_context(operation.session_id)
-        LLMCallTracker.get_instance().set_stage("reextraction")
-        # Snapshot the shared tracker's stage counter so we record only the calls
-        # this run makes. The tracker is a process-global singleton and may
-        # already hold counts from an earlier run; the delta is recorded in the
-        # ``finally`` block below.
-        llm_calls_before = LLMCallTracker.get_instance().get_counts().get("reextraction", 0)
+
+        # Held for the entire run (released in the ``finally`` below).
+        # LLMCallTracker.get_instance() is a process-global singleton with no
+        # per-session scoping: set_stage() and _counts are shared by every
+        # concurrent caller. MAX_CONCURRENT_SESSIONS (default 5) means another
+        # reextraction/continue-discovery run could otherwise overlap this one
+        # and both mislabel calls and corrupt the before/after delta below.
+        # See llm_call_tracker_lock's definition for details.
+        await llm_call_tracker_lock.acquire()
+        try:
+            LLMCallTracker.get_instance().set_stage("reextraction")
+            # Snapshot the shared tracker's stage counter so we record only the calls
+            # this run makes. The tracker is a process-global singleton and may
+            # already hold counts from an earlier run; the delta is recorded in the
+            # ``finally`` block below.
+            llm_calls_before = LLMCallTracker.get_instance().get_counts().get("reextraction", 0)
+        except Exception:
+            llm_call_tracker_lock.release()
+            raise
         logger.debug(f"_run_reextraction started for operation {operation_id}")
 
         try:
@@ -1455,6 +1468,8 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     )
             except Exception as exc:
                 logger.debug("Could not record re-extraction LLM usage: %s", exc)
+            finally:
+                llm_call_tracker_lock.release()
             await concurrency_limiter.release(operation.session_id)
             self._cleanup_operation(operation_id)
 


### PR DESCRIPTION
## Problem
PR #316 (merged) records reextraction/continue-discovery LLM calls toward the global quota by snapshotting `LLMCallTracker.get_instance().get_counts()` before and after each run.

Verified from schematiq-lib source: `LLMCallTracker` is a process-global singleton with no per-session or contextvar scoping — `set_stage()` and `_counts` are shared by every concurrent caller. `MAX_CONCURRENT_SESSIONS` defaults to 5, and `concurrency_limiter` permits that many simultaneous runs. Two overlapping runs (two sessions both running reextraction, or one overlapping the main pipeline) can mislabel each other's calls via `set_stage` and corrupt each other's before/after delta — under- or over-counting the global quota.

## Solution
Added `llm_call_tracker_lock` (`asyncio.Lock` in `app/services/__init__.py`, alongside the existing `concurrency_limiter`) and hold it for the entire `set_stage -> run -> snapshot -> record` sequence in both `_run_reextraction` and `_run_continue_discovery`, so no two runs touch the shared tracker for their stage concurrently. Released safely even if the initial `set_stage`/`get_counts` call raises.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone of main: passes
- `python -m py_compile` on the three touched files: passes
- `( cd frontend && npx tsc --noEmit )`: passes (no frontend files touched)
- No new automated test covers the race directly; manual verification would need two overlapping reextraction/continue_discovery runs with LLM_CALL_GLOBAL_LIMIT set low enough to observe drift.