### PR TITLE
refactor: dedup path literals in API routes

### DIFF
--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -10,6 +10,7 @@ import random
 from datetime import datetime, timedelta
 from typing import List, Optional, Dict, Any
 from pathlib import Path
+from app.core.config import DEFAULT_DATA_DIR
 from fastapi import APIRouter, UploadFile, File, HTTPException, BackgroundTasks, Query
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
@@ -93,7 +94,7 @@ async def load_template(template_name: str):
         )
 
         # Save template content as uploaded file
-        session_dir = Path("./data") / session_id
+        session_dir = Path(DEFAULT_DATA_DIR) / session_id
         session_dir.mkdir(parents=True, exist_ok=True)
 
         # Write template content to file
@@ -260,7 +261,7 @@ async def parse_file(session_id: str, mapping: Optional[ColumnMappingRequest] = 
 
             # Create a parsed schema file with the extracted LLM configuration
             if metadata.get('llm_config'):
-                session_dir = Path("./data") / session_id
+                session_dir = Path(DEFAULT_DATA_DIR) / session_id
                 parsed_schema_file = session_dir / "parsed_schema.json"
                 
                 schema_data = {
@@ -504,7 +505,7 @@ async def process_dual_files(session_id: str, mapping: Optional[ColumnMappingReq
         result = await parser.parse_file(session_id, mapping)
         
         # Load parsed schema
-        session_dir = Path("./data") / session_id
+        session_dir = Path(DEFAULT_DATA_DIR) / session_id
         schema_file = session_dir / "parsed_schema.json"
         
         if schema_file.exists():
@@ -1298,7 +1299,7 @@ async def process_documents(session_id: str, background_tasks: BackgroundTasks, 
             logger.debug(f"Using user-provided LLM config: {config_for_log}, {api_key_info}")
 
             # Store the user configuration in session directory for processing
-            session_dir = Path("./data") / session_id
+            session_dir = Path(DEFAULT_DATA_DIR) / session_id
             session_dir.mkdir(parents=True, exist_ok=True)  # Ensure directory exists
             user_config_file = session_dir / "user_llm_config.json"
 
@@ -1495,7 +1496,7 @@ async def export_complete_data(session_id: str, format: str = "json"):
             export_data["observation_unit"] = session.observation_unit.model_dump()
 
         # Include documents_batch_size from schematiq_config if available
-        session_dir = Path("./data") / session_id
+        session_dir = Path(DEFAULT_DATA_DIR) / session_id
         schematiq_config_file = session_dir / "schematiq_config.json"
         if schematiq_config_file.exists():
             try:
@@ -1568,7 +1569,7 @@ async def export_complete_data(session_id: str, format: str = "json"):
                     }
                     
                     # Include LLM configuration if available from parsed schema
-                    session_dir = Path("./data") / session_id
+                    session_dir = Path(DEFAULT_DATA_DIR) / session_id
                     parsed_schema_file = session_dir / "parsed_schema.json"
                     
                     if parsed_schema_file.exists():

--- a/backend/app/api/routes/schema.py
+++ b/backend/app/api/routes/schema.py
@@ -10,6 +10,7 @@ import json
 import asyncio
 import logging
 from pathlib import Path
+from app.core.config import DEFAULT_DATA_DIR
 
 from app.models.session import ColumnInfo
 from app.models.modification import ModificationAction
@@ -375,7 +376,7 @@ async def add_column(
 
         # Save user-provided LLM config if provided (for value extraction)
         if add_request.llm_config:
-            session_dir = Path("./data") / session_id
+            session_dir = Path(DEFAULT_DATA_DIR) / session_id
             session_dir.mkdir(parents=True, exist_ok=True)
             user_config_file = session_dir / "user_llm_config.json"
             with open(user_config_file, 'w') as f:
@@ -586,7 +587,7 @@ async def create_schema_backup(session_id: str):
         }
         
         # Save backup file
-        session_dir = Path("./data") / session_id
+        session_dir = Path(DEFAULT_DATA_DIR) / session_id
         session_dir.mkdir(exist_ok=True)
         backup_file = session_dir / f"schema_backup_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
         
@@ -1020,7 +1021,7 @@ async def start_reextraction(
 
         # Save user-provided LLM config if provided
         if request.llm_config:
-            session_dir = Path("./data") / session_id
+            session_dir = Path(DEFAULT_DATA_DIR) / session_id
             session_dir.mkdir(parents=True, exist_ok=True)
             user_config_file = session_dir / "user_llm_config.json"
             with open(user_config_file, 'w') as f:
@@ -1136,7 +1137,7 @@ async def upload_missing_papers(
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
 
-        session_dir = Path("./data") / session_id
+        session_dir = Path(DEFAULT_DATA_DIR) / session_id
         docs_dir = session_dir / "documents"
         docs_dir.mkdir(parents=True, exist_ok=True)
 

--- a/backend/app/api/routes/schematiq.py
+++ b/backend/app/api/routes/schematiq.py
@@ -8,6 +8,7 @@ import io
 import json
 from datetime import datetime, timedelta
 from pathlib import Path
+from app.core.config import DEFAULT_DATA_DIR, DEFAULT_SCHEMATIQ_WORK_DIR
 from typing import Any, List, Optional
 from fastapi import APIRouter, HTTPException, BackgroundTasks, Query
 from pydantic import BaseModel
@@ -73,7 +74,7 @@ def _resolve_docs_path(path: str, session_id: Optional[str] = None) -> Optional[
     
     # Add session-specific path if session_id provided
     if session_id:
-        candidates.insert(1, Path("./data") / session_id / "pending_documents")
+        candidates.insert(1, Path(DEFAULT_DATA_DIR) / session_id / "pending_documents")
     
     for candidate in candidates:
         if candidate.exists() and candidate.is_dir():
@@ -174,7 +175,7 @@ async def estimate_schematiq_cost(session_id: str):
             raise HTTPException(status_code=404, detail="Session not found")
         
         # Load the saved config for this session
-        config_file = Path("./schematiq_work") / session_id / "config.json"
+        config_file = Path(DEFAULT_SCHEMATIQ_WORK_DIR) / session_id / "config.json"
         if not config_file.exists():
             raise HTTPException(
                 status_code=400,
@@ -196,7 +197,7 @@ async def estimate_schematiq_cost(session_id: str):
                     documents.extend(_load_documents_from_path(resolved))
         
         # Also check for uploaded documents in data directory
-        upload_dir = Path("./data") / session_id / "pending_documents"
+        upload_dir = Path(DEFAULT_DATA_DIR) / session_id / "pending_documents"
         if upload_dir.exists() and not documents:
             documents.extend(_load_documents_from_path(upload_dir))
         
@@ -760,7 +761,7 @@ async def export_complete_schematiq_data(
         data = await schematiq_runner.get_data(session_id, page=0, page_size=10000)
         
         # Load ScheMatiQ configuration if available
-        session_dir = Path("./data") / session_id
+        session_dir = Path(DEFAULT_DATA_DIR) / session_id
         schematiq_config_file = session_dir / "schematiq_config.json"
         llm_configuration = None
         
@@ -1155,7 +1156,7 @@ async def export_schematiq_schema_only(
             raise HTTPException(status_code=404, detail="Session not found")
         
         # Load ScheMatiQ configuration if available
-        session_dir = Path("./data") / session_id
+        session_dir = Path(DEFAULT_DATA_DIR) / session_id
         schematiq_config_file = session_dir / "schematiq_config.json"
         llm_configuration = None
         


### PR DESCRIPTION
## Problem
API route modules hardcoded `Path("./data")` / `Path("./schematiq_work")`, duplicating the config constants.
## Solution
Add a top-level `app.core.config` import and reference `DEFAULT_DATA_DIR` / `DEFAULT_SCHEMATIQ_WORK_DIR`. Identical values, behavior unchanged.
## Verify
- git apply --ignore-whitespace --check on a clean clone: passes
- python -m py_compile on the three files: passes