### PR TITLE
refactor: dedup path literals in services

### DIFF
--- a/backend/app/services/data_collection_service.py
+++ b/backend/app/services/data_collection_service.py
@@ -22,7 +22,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
-from app.core.config import DATA_COLLECTION_ENABLED, MAX_DOCUMENTS
+from app.core.config import DATA_COLLECTION_ENABLED, DEFAULT_DATA_DIR, DEFAULT_SCHEMATIQ_WORK_DIR, MAX_DOCUMENTS
 from app.utils.csv_helpers import format_excerpt_for_csv
 
 logger = logging.getLogger(__name__)
@@ -155,7 +155,7 @@ class DataCollectionService:
         # Log LLM usage to separate "LLM Usage" tab
         if self._sheets_logger:
             try:
-                llm_stats_file = Path("./schematiq_work") / session_id / "llm_call_stats.json"
+                llm_stats_file = Path(DEFAULT_SCHEMATIQ_WORK_DIR) / session_id / "llm_call_stats.json"
                 if llm_stats_file.exists():
                     llm_stats = json.loads(llm_stats_file.read_text(encoding="utf-8"))
                     self._sheets_logger.log_llm_usage(
@@ -182,7 +182,7 @@ class DataCollectionService:
         # Read LLM call count from session stats file
         llm_calls = 0
         try:
-            llm_stats_file = Path("./schematiq_work") / session_id / "llm_call_stats.json"
+            llm_stats_file = Path(DEFAULT_SCHEMATIQ_WORK_DIR) / session_id / "llm_call_stats.json"
             if llm_stats_file.exists():
                 llm_stats = json.loads(llm_stats_file.read_text(encoding="utf-8"))
                 llm_calls = llm_stats.get("total_calls", 0)
@@ -438,11 +438,11 @@ class DataCollectionService:
         results = []
 
         candidate_dirs = [
-            Path("./data") / session_id / "documents",
-            Path("./data") / session_id / "pending_documents",
+            Path(DEFAULT_DATA_DIR) / session_id / "documents",
+            Path(DEFAULT_DATA_DIR) / session_id / "pending_documents",
         ]
         # Supabase datasets: schematiq_work/{id}/datasets/{dataset_name}/
-        datasets_root = Path("./schematiq_work") / session_id / "datasets"
+        datasets_root = Path(DEFAULT_SCHEMATIQ_WORK_DIR) / session_id / "datasets"
         if datasets_root.exists():
             for sub in sorted(datasets_root.iterdir()):
                 if sub.is_dir():
@@ -581,7 +581,7 @@ class DataCollectionService:
 
     def _read_and_sanitize_config(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Read ScheMatiQ config, strip secrets."""
-        config_path = Path("./schematiq_work") / session_id / "schematiq_config.json"
+        config_path = Path(DEFAULT_SCHEMATIQ_WORK_DIR) / session_id / "schematiq_config.json"
         if not config_path.exists():
             return None
         try:

--- a/backend/app/services/observation_unit_manager.py
+++ b/backend/app/services/observation_unit_manager.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
+from app.core.config import DEFAULT_DATA_DIR, DEFAULT_SCHEMATIQ_WORK_DIR
 from app.models.session import SessionStatus
 from app.services.session_manager import SessionManager
 from app.services.websocket_manager import WebSocketManager
@@ -65,8 +66,8 @@ class ObservationUnitManager:
         units = []
 
         # Check schematiq_work directory first (primary location for extracted data)
-        schematiq_work_dir = Path("./schematiq_work") / session_id
-        data_dir = Path("./data") / session_id
+        schematiq_work_dir = Path(DEFAULT_SCHEMATIQ_WORK_DIR) / session_id
+        data_dir = Path(DEFAULT_DATA_DIR) / session_id
 
         # Try schematiq_work/extracted_data.jsonl first, then data/data.jsonl
         jsonl_file = schematiq_work_dir / "extracted_data.jsonl"
@@ -137,8 +138,8 @@ class ObservationUnitManager:
             raise ValueError(f"Session {session_id} not found")
 
         # Check schematiq_work directory first (primary location for extracted data)
-        schematiq_work_dir = Path("./schematiq_work") / session_id
-        data_dir = Path("./data") / session_id
+        schematiq_work_dir = Path(DEFAULT_SCHEMATIQ_WORK_DIR) / session_id
+        data_dir = Path(DEFAULT_DATA_DIR) / session_id
         removed = False
         updated_rows = []
 
@@ -247,7 +248,7 @@ class ObservationUnitManager:
         if not session:
             raise ValueError(f"Session {session_id} not found")
 
-        data_dir = Path("./data") / session_id
+        data_dir = Path(DEFAULT_DATA_DIR) / session_id
         data_dir.mkdir(parents=True, exist_ok=True)
 
         # Check if unit already exists
@@ -407,7 +408,7 @@ class ObservationUnitManager:
             session_id: Session identifier
             observation_unit: Updated ObservationUnitInfo
         """
-        schematiq_work_dir = Path("./schematiq_work") / session_id
+        schematiq_work_dir = Path(DEFAULT_SCHEMATIQ_WORK_DIR) / session_id
         schema_file = schematiq_work_dir / "discovered_schema.json"
 
         if schema_file.exists():

--- a/backend/app/services/schema_manager.py
+++ b/backend/app/services/schema_manager.py
@@ -17,7 +17,7 @@ from app.services.websocket_manager import WebSocketManager
 from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
 from app.services import schematiq_thread_pool, concurrency_limiter, find_session_data_file
-from app.core.config import DEVELOPER_MODE, RELEASE_CONFIG
+from app.core.config import DEFAULT_DATA_DIR, DEFAULT_SCHEMATIQ_WORK_DIR, DEVELOPER_MODE, RELEASE_CONFIG
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
         
     def _get_value_extraction_llm_from_session(self, session_id: str):
         """Get value extraction LLM configuration from session, including API key."""
-        session_dir = Path("./data") / session_id
+        session_dir = Path(DEFAULT_DATA_DIR) / session_id
 
         # Priority 0: Check user_llm_config.json (user-provided config from frontend)
         # This is checked FIRST even in release mode, because it contains the user's API key.
@@ -190,7 +190,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
                     schema_data["observation_unit"]["example_names"] = session.observation_unit.example_names
 
             # Save temporary schema file
-            session_dir = Path("./data") / session_id
+            session_dir = Path(DEFAULT_DATA_DIR) / session_id
             schema_file = session_dir / f"temp_schema_{column_name}.json"
             with open(schema_file, 'w') as f:
                 json.dump(schema_data, f, indent=2)
@@ -394,7 +394,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
 
             # Create schema for value extraction — must use "schema" key (list of columns)
             # so that Schema.from_dict() can parse it correctly
-            session_dir = Path("./data") / session_id
+            session_dir = Path(DEFAULT_DATA_DIR) / session_id
             column_entry = {
                 "column": column.name,
                 "definition": column.definition or f"New data field: {column.name}",
@@ -431,7 +431,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
             if documents_path:
                 docs_directories = [Path(documents_path)]
             else:
-                schematiq_dir = Path("./schematiq_work") / session_id
+                schematiq_dir = Path(DEFAULT_SCHEMATIQ_WORK_DIR) / session_id
                 candidate_dirs = [
                     session_dir / "documents",
                     session_dir / "pending_documents",
@@ -712,20 +712,20 @@ class SchemaManager(WebSocketBroadcasterMixin):
 
         # Find ALL data files (same pattern as unit_view_service._get_all_data_files)
         data_files = []
-        schematiq_extracted = Path("./schematiq_work") / session_id / "extracted_data.jsonl"
+        schematiq_extracted = Path(DEFAULT_SCHEMATIQ_WORK_DIR) / session_id / "extracted_data.jsonl"
         if schematiq_extracted.exists():
             data_files.append(schematiq_extracted)
         if not data_files:
-            schematiq_data = Path("./schematiq_work") / session_id / "data.jsonl"
+            schematiq_data = Path(DEFAULT_SCHEMATIQ_WORK_DIR) / session_id / "data.jsonl"
             if schematiq_data.exists():
                 data_files.append(schematiq_data)
-        load_data = Path("./data") / session_id / "data.jsonl"
+        load_data = Path(DEFAULT_DATA_DIR) / session_id / "data.jsonl"
         if load_data.exists() and load_data.resolve() not in [f.resolve() for f in data_files]:
             data_files.append(load_data)
 
         if not data_files:
             # Create new data file in default location
-            session_dir = Path("./data") / session_id
+            session_dir = Path(DEFAULT_DATA_DIR) / session_id
             session_dir.mkdir(parents=True, exist_ok=True)
             data_file = session_dir / "data.jsonl"
             with open(data_file, 'w') as f:
@@ -818,7 +818,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
             )
             
             # Create comprehensive schema context for better LLM understanding
-            session_dir = Path("./data") / session_id
+            session_dir = Path(DEFAULT_DATA_DIR) / session_id
             comprehensive_schema = {
                 "query": session.schema_query or "Extract structured information",
                 "context": f"Processing session: {session.metadata.source}",
@@ -962,7 +962,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
                     enhanced_schema["observation_unit"]["example_names"] = session.observation_unit.example_names
 
             # Save enhanced schema file
-            session_dir = Path("./data") / session_id
+            session_dir = Path(DEFAULT_DATA_DIR) / session_id
             enhanced_schema_file = session_dir / f"enhanced_schema_{column_name}.json"
             with open(enhanced_schema_file, 'w') as f:
                 json.dump(enhanced_schema, f, indent=2)

--- a/backend/app/services/upload_document_processor.py
+++ b/backend/app/services/upload_document_processor.py
@@ -23,7 +23,7 @@ from app.services.websocket_manager import WebSocketManager
 from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
 from app.services import schematiq_thread_pool, concurrency_limiter
-from app.core.config import DEFAULT_TEMPERATURE, DEFAULT_RETRIEVAL_K, PROGRESS_CHECK_INTERVAL, DEVELOPER_MODE, RELEASE_CONFIG
+from app.core.config import DEFAULT_TEMPERATURE, DEFAULT_RETRIEVAL_K, PROGRESS_CHECK_INTERVAL, DEVELOPER_MODE, RELEASE_CONFIG, DEFAULT_DATA_DIR
 
 # Max seconds to wait for build_table_jsonl to observe should_stop() after user stop
 MAX_UPLOAD_EXTRACTION_STOP_WAIT = 120.0
@@ -120,7 +120,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             await self.broadcast_progress(session_id, "Initializing document processing", 0.0, "processing_documents")
             
             # Get paths and configuration
-            session_dir = Path("./data") / session_id
+            session_dir = Path(DEFAULT_DATA_DIR) / session_id
             pending_dir = session_dir / "pending_documents"
             docs_dir = session_dir / "documents"
 
@@ -488,7 +488,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
             session_id: The session ID
             session: The session object (optional, used to get cloud_dataset for document_directory)
         """
-        session_dir = Path("./data") / session_id
+        session_dir = Path(DEFAULT_DATA_DIR) / session_id
         original_data_file = session_dir / "data.jsonl"
         additional_data_file = session_dir / "additional_data.jsonl"
 
@@ -1109,7 +1109,7 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
     
     def _get_llm_config_for_extraction(self, extracted_schema: Dict[str, Any], session_id: str) -> Dict[str, Any]:
         """Get LLM configuration for value extraction, prioritizing user selection."""
-        session_dir = Path("./data") / session_id
+        session_dir = Path(DEFAULT_DATA_DIR) / session_id
         
         # First priority: User-provided LLM configuration
         user_config_file = session_dir / "user_llm_config.json"


### PR DESCRIPTION
## Problem
Service modules hardcoded `Path("./data")` / `Path("./schematiq_work")`, duplicating the config constants.
## Solution
Reference `DEFAULT_DATA_DIR` / `DEFAULT_SCHEMATIQ_WORK_DIR` from `app.core.config`. Identical values, behavior unchanged.
## Verify
- git apply --ignore-whitespace --check on a clean clone: passes
- python -m py_compile on the four files: passes