### PR TITLE
feat(workspace): add recent-projects popover to new-project dialog

### DIFF
--- a/frontend/src/pages/Workspace/NewProjectDialog.tsx
+++ b/frontend/src/pages/Workspace/NewProjectDialog.tsx
@@ -40,11 +40,12 @@ import {
   type LLMProviderKey,
 } from '@/constants';
 import { cloudAPI, configAPI, loadAPI, schematiqAPI } from '@/services/api';
-import type { CostEstimate } from '@/types';
+import type { CostEstimate, VisualizationSession } from '@/types';
 import { getConfiguredProviders } from '@/utils/apiKeyStorage';
 
 import { DEFAULT_PROVIDER, SHOW_API_KEY_FIELD, WORKSPACE_DEFAULT_ADVANCED } from './constants';
 import { buildConfig, formatCost, formatFileSize } from './helpers';
+import { RecentProjects } from './RecentProjects';
 import type { DocumentSourceInput, NewProjectDialogProps } from './types';
 
 export function NewProjectDialog({ open, onOpenChange, onCreated }: NewProjectDialogProps) {
@@ -182,6 +183,14 @@ export function NewProjectDialog({ open, onOpenChange, onCreated }: NewProjectDi
       setCreating(false);
     }
   }, [apiKey, files, navigate, onCreated, onOpenChange, query, toast, advanced, documentSource, selectedDatasets]);
+
+  const openExisting = useCallback((session: VisualizationSession) => {
+    onOpenChange(false);
+    // Load-type sessions carry the ?mode=load hint so the workspace skips the
+    // schematiq-first probe and its fallback round-trip.
+    const suffix = session.type === 'load' ? '?mode=load' : '';
+    navigate(`/workspace/${session.id}${suffix}`, { replace: true });
+  }, [navigate, onOpenChange]);
 
   const startProject = useCallback(async () => {
     if (!query.trim() || !hasDocuments) {
@@ -347,6 +356,8 @@ export function NewProjectDialog({ open, onOpenChange, onCreated }: NewProjectDi
               }}
             />
           </div>
+
+          <RecentProjects onOpenProject={openExisting} />
 
           {SHOW_API_KEY_FIELD && (
           <div className="grid gap-2">

--- a/frontend/src/pages/Workspace/RecentProjects.tsx
+++ b/frontend/src/pages/Workspace/RecentProjects.tsx
@@ -1,0 +1,164 @@
+// "Recent projects" control for the New Project dialog. Rendered as a trigger
+// button that opens a popover; the list is only fetched and shown once opened.
+//
+// The list is scoped to this browser via localStorage (see utils/recentProjects):
+// it only shows projects opened here, never the full multi-user session list,
+// because the backend has no per-user scoping. Parent: NewProjectDialog.
+
+import { useEffect, useState } from 'react';
+import { Clock, FileText, Loader2, Table2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { loadAPI } from '@/services/api';
+import type { VisualizationSession } from '@/types';
+import { forgetProjects, getRecentProjectIds } from '@/utils/recentProjects';
+
+// How many stored ids to fetch details for (a few more than we display, so the
+// list still fills after pruning ids that no longer resolve).
+const FETCH_LIMIT = 10;
+const MAX_RECENT = 6;
+
+function projectDisplayName(session: VisualizationSession): string {
+  const query =
+    session.creation_metadata?.creation_query?.trim() ||
+    session.schema_query?.trim() ||
+    session.metadata?.source?.trim();
+  if (query) return query.length > 80 ? `${query.slice(0, 79)}\u2026` : query;
+  return `Untitled project (${session.id.slice(0, 8)})`;
+}
+
+function sessionTime(session: VisualizationSession): number {
+  const iso = session.metadata?.last_modified || session.metadata?.created;
+  const value = iso ? new Date(iso).getTime() : 0;
+  return Number.isNaN(value) ? 0 : value;
+}
+
+function formatRelativeTime(iso?: string): string {
+  if (!iso) return '';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const diffMs = then - Date.now();
+  const abs = Math.abs(diffMs);
+  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  const week = 7 * day;
+  const month = 30 * day;
+  const year = 365 * day;
+  if (abs < hour) return rtf.format(Math.round(diffMs / minute), 'minute');
+  if (abs < day) return rtf.format(Math.round(diffMs / hour), 'hour');
+  if (abs < week) return rtf.format(Math.round(diffMs / day), 'day');
+  if (abs < month) return rtf.format(Math.round(diffMs / week), 'week');
+  if (abs < year) return rtf.format(Math.round(diffMs / month), 'month');
+  return rtf.format(Math.round(diffMs / year), 'year');
+}
+
+export function RecentProjects({
+  onOpenProject,
+}: {
+  onOpenProject: (session: VisualizationSession) => void;
+}) {
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [sessions, setSessions] = useState<VisualizationSession[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Fetch only when the popover is opened, so the dialog stays cheap otherwise.
+  useEffect(() => {
+    if (!popoverOpen) return;
+    const ids = getRecentProjectIds().slice(0, FETCH_LIMIT);
+    if (ids.length === 0) {
+      setSessions([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      // Fetch each remembered project by id. The backend resolves a session by
+      // id regardless of type, so one endpoint covers both load and schematiq
+      // projects; the returned `type` drives navigation mode.
+      const results = await Promise.all(
+        ids.map((id) =>
+          loadAPI.getSession(id).then(
+            (session) => ({ id, session: session as VisualizationSession | null }),
+            () => ({ id, session: null as VisualizationSession | null }),
+          ),
+        ),
+      );
+      if (cancelled) return;
+      const missing = results.filter((r) => r.session === null).map((r) => r.id);
+      if (missing.length > 0) forgetProjects(missing);
+      const found = results
+        .map((r) => r.session)
+        .filter((s): s is VisualizationSession => s !== null)
+        .sort((a, b) => sessionTime(b) - sessionTime(a));
+      setSessions(found);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [popoverOpen]);
+
+  const handleOpen = (session: VisualizationSession) => {
+    setPopoverOpen(false);
+    onOpenProject(session);
+  };
+
+  return (
+    <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+      <PopoverTrigger asChild>
+        <Button type="button" variant="outline" size="sm" className="w-fit justify-start gap-2">
+          <Clock className="h-4 w-4" />
+          Recent projects
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-96 p-2">
+        {loading && !sessions ? (
+          <div className="flex items-center gap-2 px-2 py-3 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading recent projects{'\u2026'}
+          </div>
+        ) : !sessions || sessions.length === 0 ? (
+          <div className="px-2 py-3 text-sm text-muted-foreground">
+            No recent projects in this browser yet.
+          </div>
+        ) : (
+          <div className="grid max-h-80 gap-1.5 overflow-y-auto">
+            {sessions.slice(0, MAX_RECENT).map((session) => {
+              const rowCount = session.metadata?.row_count;
+              return (
+                <button
+                  key={session.id}
+                  type="button"
+                  onClick={() => handleOpen(session)}
+                  className="flex items-center gap-3 rounded-md border border-border/60 bg-background px-3 py-2 text-left transition-colors hover:border-primary hover:bg-muted/50"
+                >
+                  <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-medium text-foreground">
+                      {projectDisplayName(session)}
+                    </div>
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <span>{formatRelativeTime(session.metadata?.last_modified || session.metadata?.created)}</span>
+                      {typeof rowCount === 'number' && (
+                        <>
+                          <span aria-hidden>{'\u00b7'}</span>
+                          <span className="inline-flex items-center gap-1">
+                            <Table2 className="h-3 w-3" />
+                            {rowCount} {rowCount === 1 ? 'row' : 'rows'}
+                          </span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -46,6 +46,7 @@ import { ViewModeToggle } from '@/components/ViewMode/ViewModeToggle';
 import MissingDocumentsSection from '@/components/SchemaEditor/MissingDocumentsSection';
 import TableFeedbackWidget from '@/components/TableFeedbackWidget/TableFeedbackWidget';
 import api, { configAPI, loadAPI, schematiqAPI, unitsAPI } from '@/services/api';
+import { rememberProject } from '@/utils/recentProjects';
 import type {
   CostEstimate,
   DataRow,
@@ -382,6 +383,14 @@ function Workspace() {
     setProjectDialogOpen(!sessionId);
     setSessionMode(requestedMode);
   }, [requestedMode, sessionId]);
+
+  // Record every project opened in this browser so the New Project dialog can
+  // offer a per-browser "recent projects" list. There is no server-side user
+  // scoping, so this is intentionally local: it never surfaces other people's
+  // projects. Ids that no longer resolve are pruned when the list is fetched.
+  useEffect(() => {
+    if (sessionId) rememberProject(sessionId);
+  }, [sessionId]);
 
   // Mark the body while the Workspace is mounted so global toasts can be lifted
   // above the fixed bottombar (see Workspace.css). Scoped to this route only so

--- a/frontend/src/utils/recentProjects.ts
+++ b/frontend/src/utils/recentProjects.ts
@@ -1,0 +1,45 @@
+// Per-browser registry of projects opened in the workspace.
+//
+// ScheMatiQ has no server-side user scoping: the /sessions endpoints return
+// every session for every user. To avoid surfacing other people's projects in
+// the "recent projects" list, we track ids locally in this browser instead of
+// listing everything from the server. This is a UI-scoping measure, not access
+// control — the API itself remains open, and a known session id still resolves.
+
+const STORAGE_KEY = 'workspace.recentProjectIds';
+const MAX_STORED = 30;
+
+export function getRecentProjectIds(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is string => typeof id === 'string');
+  } catch {
+    return [];
+  }
+}
+
+export function rememberProject(sessionId: string): void {
+  if (!sessionId) return;
+  try {
+    const ids = getRecentProjectIds().filter((id) => id !== sessionId);
+    ids.unshift(sessionId);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids.slice(0, MAX_STORED)));
+  } catch {
+    // localStorage unavailable (private mode / quota) — the recent list simply
+    // stays empty, which is acceptable.
+  }
+}
+
+export function forgetProjects(sessionIds: string[]): void {
+  if (sessionIds.length === 0) return;
+  try {
+    const drop = new Set(sessionIds);
+    const ids = getRecentProjectIds().filter((id) => !drop.has(id));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Problem
The New Project dialog gives no way to reopen an existing project. The unused listSessions endpoints return every user's sessions, so listing them directly would leak other users' projects — ScheMatiQ has no server-side user scoping.

## Solution
Track project ids opened in this browser in localStorage (utils/recentProjects), registered from the workspace as each session loads (covers create, import, url, recent-click). Add a 'Recent projects' button below the Research question and Documents fields; clicking it opens a popover that fetches those ids by id (backend resolves a session by id regardless of type; returned type drives nav mode) and lists them newest-first. Fetch happens only on open; unresolved ids are pruned; load-type sessions open with ?mode=load to skip the schematiq-first probe.

UI-level scoping only: the /sessions API stays open and a known id still resolves. Server-side auth remains a separate, tracked gap.

## Verify
- git apply --ignore-whitespace --check passes on a clean clone
- ( cd frontend && npx tsc --noEmit ) passes (0 errors)
- Open a couple of projects, reopen the dialog: the 'Recent projects' button sits under Documents; clicking opens a popover listing only those, newest first; a fresh browser shows the empty message; a second profile shows its own list