### PR TITLE
fix(workspace): column delete, reliable cell clears, one toast per batch

### DIFF
--- a/backend/app/services/data_editor.py
+++ b/backend/app/services/data_editor.py
@@ -98,73 +98,97 @@ class DataEditor:
 
         from app.services.data_utils import _resolve_source_document
 
-        match_by_index = (not row_name) and row_index is not None
+        # Identity resolution runs in two passes. Primary: match by `row_name`
+        # (plus `source_document` when given). Fallback: if the name never
+        # matched but a stable `_row_index` was supplied, retry by absolute
+        # position. `_row_index` is stamped by the reader as the file line
+        # position and survives filtering/sorting, so it is a reliable identity
+        # when the name disambiguation is imperfect — e.g. a clear/delete where
+        # the resolved `row_name`/`source_document` pair does not co-exist on any
+        # stored row, which previously failed with "Row ... not found" and left
+        # some cells in a bulk clear unpersisted.
+        def _run_match(match_by_index: bool):
+            updated_any = False
+            previous_value = None
+            persisted_files: list = []
 
-        updated_any = False
-        previous_value = None
-        persisted_files: list = []
+            for file_position, data_file in enumerate(data_files):
+                # Read all rows for this file
+                rows = []
+                try:
+                    with open(data_file, "r", encoding="utf-8") as f:
+                        for line in f:
+                            if line.strip():
+                                rows.append(json.loads(line))
+                except FileNotFoundError:
+                    continue
 
-        for file_position, data_file in enumerate(data_files):
-            # Read all rows for this file
-            rows = []
-            try:
-                with open(data_file, "r", encoding="utf-8") as f:
-                    for line in f:
-                        if line.strip():
-                            rows.append(json.loads(line))
-            except FileNotFoundError:
-                continue
-
-            file_updated = False
-            for idx, row in enumerate(rows):
-                if match_by_index:
-                    # row_index is an absolute position in the reader's merged,
-                    # deduped view, not a per-file line number. Only the first
-                    # resolved file is authoritative for the index fallback
-                    # (used for name-less generic imports, effectively
-                    # single-file); do not attempt it against later files.
-                    if file_position != 0 or idx != row_index:
-                        continue
-                else:
-                    current_row_name = row.get("row_name") or row.get("_row_name")
-                    if current_row_name != row_name:
-                        continue
-                    # update_all fills every row for this unit (a value that is a
-                    # property of the unit, e.g. a reference lookup), so it ignores
-                    # the source_document disambiguator and does not stop at the
-                    # first match — otherwise only the first of several rows sharing
-                    # the row_name gets written and the rest stay blank.
-                    if source_document and not update_all:
-                        current_src = _resolve_source_document(row)
-                        if current_src and current_src != source_document:
+                file_updated = False
+                for idx, row in enumerate(rows):
+                    if match_by_index:
+                        # row_index is an absolute position in the reader's
+                        # merged, deduped view, not a per-file line number. Only
+                        # the first resolved file is authoritative for the index
+                        # fallback (effectively single-file); do not attempt it
+                        # against later files.
+                        if file_position != 0 or idx != row_index:
                             continue
+                    else:
+                        current_row_name = row.get("row_name") or row.get("_row_name")
+                        if current_row_name != row_name:
+                            continue
+                        # update_all fills every row for this unit (a value that
+                        # is a property of the unit, e.g. a reference lookup), so
+                        # it ignores the source_document disambiguator and does
+                        # not stop at the first match — otherwise only the first
+                        # of several rows sharing the row_name gets written and
+                        # the rest stay blank.
+                        if source_document and not update_all:
+                            current_src = _resolve_source_document(row)
+                            if current_src and current_src != source_document:
+                                continue
 
-                row_previous = self._apply_cell_update(
-                    row, column, value, restore=restore,
-                    reference_source=reference_source,
-                )
-                # Preserve the previous value from the first file that matched
-                # (the reader's authoritative first-occurrence).
-                if not updated_any:
-                    previous_value = row_previous
-                file_updated = True
-                updated_any = True
-                if not update_all:
+                    row_previous = self._apply_cell_update(
+                        row, column, value, restore=restore,
+                        reference_source=reference_source,
+                    )
+                    # Preserve the previous value from the first file that matched
+                    # (the reader's authoritative first-occurrence).
+                    if not updated_any:
+                        previous_value = row_previous
+                    file_updated = True
+                    updated_any = True
+                    if not update_all:
+                        break
+
+                if file_updated:
+                    with open(data_file, "w", encoding="utf-8") as f:
+                        for row in rows:
+                            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+                    persisted_files.append(data_file)
+
+                # Index-based match targets a single file only; stop after the first.
+                if match_by_index and file_position == 0:
                     break
 
-            if file_updated:
-                with open(data_file, "w", encoding="utf-8") as f:
-                    for row in rows:
-                        f.write(json.dumps(row, ensure_ascii=False) + "\n")
-                persisted_files.append(data_file)
+            return updated_any, previous_value, persisted_files
 
-            # Index-based match targets a single file only; stop after the first.
-            if match_by_index and file_position == 0:
-                break
+        primary_by_index = (not row_name) and row_index is not None
+        updated_any, previous_value, persisted_files = _run_match(primary_by_index)
+
+        # Name matched nothing but we have a stable index — retry by position.
+        # (Index identity is unique, so update_all's fan-out does not apply here.)
+        if not updated_any and not primary_by_index and row_index is not None:
+            updated_any, previous_value, persisted_files = _run_match(True)
 
         if not updated_any:
-            if match_by_index:
+            if primary_by_index:
                 raise ValueError(f"Row at index {row_index} not found")
+            if row_index is not None:
+                raise ValueError(
+                    f"Row with row_name '{row_name}' not found "
+                    f"(also tried index {row_index})"
+                )
             raise ValueError(f"Row with row_name '{row_name}' not found")
 
         for data_file in persisted_files:

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -640,55 +640,109 @@ export function SpreadsheetSurface({
   const handleChanges = useCallback((changes: any[] | null, source: string) => {
     if (!changes || source === 'loadData' || !sessionId) return;
 
-    for (const change of changes) {
-      const [rowIndex, prop, oldValue, newValue] = change;
-      if (oldValue === newValue || prop == null) continue;
-      const key = String(prop);
+    // --- Data sheet: batch every cell edit/clear in this change set into a
+    // single request group and a single summary toast. Handsontable delivers a
+    // whole column-clear or multi-cell delete as one `afterChange` call with N
+    // entries; firing a toast + refresh per entry produced the "Cell updated"
+    // spam and the flicker from N racing refreshes.
+    //
+    // It also reports *visual* row indices, but `data.rows` is in physical
+    // order. Grouping applies mergeCells and filters/sorting may be active, so
+    // visual != physical; resolving the row without converting targeted the
+    // wrong record (or an empty spare row) and made clears fail with
+    // "Row ... not found" for some cells. Convert once via the live instance.
+    if (activeSheet === 'data') {
+      const hot = hotTableRef.current?.hotInstance;
+      const toPhysicalRow = (visualRow: number): number =>
+        hot && typeof hot.toPhysicalRow === 'function' ? hot.toPhysicalRow(visualRow) : visualRow;
 
-      if (activeSheet === 'data') {
+      type CellUpdate = {
+        rowName: string;
+        sourceDocument?: string;
+        rowIndexId?: number;
+        column: string;
+        value: string;
+      };
+      const updates: CellUpdate[] = [];
+      let unidentified = 0;
+
+      for (const change of changes) {
+        const [visualRowIndex, prop, oldValue, newValue] = change;
+        if (oldValue === newValue || prop == null) continue;
+        const key = String(prop);
         if (key.startsWith('_')) continue;
-        const sourceRow: DataRow | undefined = data.rows[rowIndex];
+
+        const sourceRow: DataRow | undefined = data.rows[toPhysicalRow(visualRowIndex)];
         const rowName = sourceRow?.row_name || sourceRow?._unit_name || '';
         const rowIndexId = sourceRow?._row_index;
         const sourceDocument = sourceRow?._source_document || sourceRow?._parent_document;
         if (!rowName && rowIndexId == null) {
+          unidentified += 1;
+          continue;
+        }
+
+        updates.push({ rowName, sourceDocument, rowIndexId, column: key, value: String(newValue ?? '') });
+      }
+
+      if (updates.length === 0) {
+        if (unidentified > 0) {
           toast({
             title: 'Cell update failed',
             description: 'Could not identify which row to update.',
             variant: 'destructive',
           });
           onRefreshData();
-          continue;
+        }
+        return;
+      }
+
+      // Apply every edit to React state up front so the grid does not revert
+      // while the writes are in flight.
+      updates.forEach((u) =>
+        onOptimisticCellEdit(
+          { rowName: u.rowName, sourceDocument: u.sourceDocument, rowIndex: u.rowIndexId },
+          u.column,
+          u.value,
+        ),
+      );
+
+      const allCleared = updates.every((u) => u.value.trim() === '');
+
+      Promise.allSettled(
+        updates.map((u) =>
+          schematiqAPI.updateCell(sessionId, u.rowName, u.column, u.value, u.sourceDocument, u.rowIndexId),
+        ),
+      ).then((results) => {
+        const failed = results.filter((r) => r.status === 'rejected').length;
+        const succeeded = updates.length - failed;
+
+        if (failed > 0) {
+          toast({
+            title: 'Some cells could not be saved',
+            description: `${failed} of ${updates.length} update${updates.length > 1 ? 's' : ''} failed.`,
+            variant: 'destructive',
+          });
+        } else if (updates.length === 1) {
+          const u = updates[0];
+          const rowLabel = u.rowName || (u.rowIndexId != null ? `Row ${u.rowIndexId + 1}` : 'Row');
+          toast({
+            title: allCleared ? 'Cell cleared' : 'Cell updated',
+            description: `${rowLabel} / ${u.column}`,
+          });
+        } else {
+          toast({ title: allCleared ? `${succeeded} cells cleared` : `${succeeded} cells updated` });
         }
 
-        onOptimisticCellEdit(
-          { rowName, sourceDocument, rowIndex: rowIndexId },
-          key,
-          String(newValue ?? ''),
-        );
+        onRefreshData();
+      });
 
-        schematiqAPI.updateCell(
-          sessionId,
-          rowName,
-          key,
-          String(newValue ?? ''),
-          sourceDocument,
-          rowIndexId
-        )
-          .then(() => {
-            const rowLabel = rowName || (rowIndexId != null ? `Row ${rowIndexId + 1}` : 'Row');
-            toast({ title: 'Cell updated', description: `${rowLabel} / ${key}` });
-            onRefreshData();
-          })
-          .catch((err: any) => {
-            toast({
-              title: 'Cell update failed',
-              description: err?.response?.data?.detail || err?.message || 'Could not update cell',
-              variant: 'destructive',
-            });
-            onRefreshData();
-          });
-      }
+      return;
+    }
+
+    for (const change of changes) {
+      const [rowIndex, prop, oldValue, newValue] = change;
+      if (oldValue === newValue || prop == null) continue;
+      const key = String(prop);
 
       if (activeSheet === 'schema') {
         const existing = schemaColumns[rowIndex];
@@ -825,7 +879,7 @@ export function SpreadsheetSurface({
           });
       }
     }
-  }, [activeSheet, data.rows, observationUnitRows, onEditFollowUp, onOptimisticCellEdit, onRefresh, onRefreshData, schemaColumns, sessionId, toast]);
+  }, [activeSheet, data.rows, hotTableRef, observationUnitRows, onEditFollowUp, onOptimisticCellEdit, onRefresh, onRefreshData, schemaColumns, sessionId, toast]);
 
   const handleBeforeRemoveRow = useCallback(
     (_index: number, _amount: number, physicalRows: number[], _source?: string): boolean | void => {
@@ -940,6 +994,118 @@ export function SpreadsheetSurface({
     [activeSheet, onRefresh, schemaColumns, sessionId, sheet.columns, toast],
   );
 
+  // Resolve the schema-column names covered by the current grid selection,
+  // excluding the fixed provenance columns (_row_name / _source_document).
+  // Shared by the "Delete column" menu item and the Delete-key shortcut.
+  const selectedSchemaColumnNames = useCallback(
+    (hot: any): string[] => {
+      const selection: number[][] = typeof hot?.getSelected === 'function' ? hot.getSelected() || [] : [];
+      const cols = new Set<number>();
+      for (const range of selection) {
+        const [, c1, , c2] = range;
+        const from = Math.min(c1, c2);
+        const to = Math.max(c1, c2);
+        for (let c = from; c <= to; c += 1) if (c >= 0) cols.add(c);
+      }
+      const keys = Array.from(cols)
+        .map((c) => sheet.columns[c]?.key)
+        .filter((key): key is string => Boolean(key) && !key.startsWith('_'));
+      // Keep only keys that are real schema columns (never provenance/grouping).
+      return keys.filter((key) => schemaColumns.some((col) => col.name === key));
+    },
+    [schemaColumns, sheet.columns],
+  );
+
+  // Delete one or more schema columns (header + values, from both the Schema
+  // and Data views) via the schema API, then refresh. Shared by the context
+  // menu item and the Delete-key shortcut.
+  const deleteSchemaColumns = useCallback(
+    (names: string[]) => {
+      if (names.length === 0 || !sessionId) return;
+      Promise.allSettled(names.map((name) => schemaAPI.deleteColumn(sessionId, name)))
+        .then((results) => {
+          const failed = results.filter((r) => r.status === 'rejected').length;
+          if (failed > 0) {
+            toast({
+              title: 'Column delete failed',
+              description: `${failed} of ${names.length} column${names.length > 1 ? 's' : ''} could not be deleted.`,
+              variant: 'destructive',
+            });
+          } else {
+            toast({
+              title: names.length > 1 ? 'Columns deleted' : 'Column deleted',
+              description: names.join(', '),
+            });
+          }
+          // Deleting a column does not invalidate the remaining columns'
+          // extracted values, so it must not flag a re-extract.
+          onRefresh();
+        });
+    },
+    [onRefresh, sessionId, toast],
+  );
+
+  // Excel-style: when one or more whole columns are selected (by clicking the
+  // column header) and the user presses Delete/Backspace, remove the column(s)
+  // entirely rather than clearing cell contents. A partial (cell-level)
+  // selection keeps the default behaviour, which clears contents and routes
+  // through handleChanges.
+  const handleBeforeKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (activeSheet !== 'data') return;
+      if (event.key !== 'Delete' && event.key !== 'Backspace') return;
+      const hot = hotTableRef.current?.hotInstance as any;
+      if (!hot?.selection?.isSelectedByColumnHeader?.()) return;
+      const names = selectedSchemaColumnNames(hot);
+      if (names.length === 0) return;
+      event.stopImmediatePropagation();
+      event.preventDefault();
+      deleteSchemaColumns(names);
+    },
+    [activeSheet, deleteSchemaColumns, hotTableRef, selectedSchemaColumnNames],
+  );
+
+  // Context menu. Handsontable disables its native "Remove column" whenever the
+  // data source is an array of objects *or* a `columns` option is set (both are
+  // true here), so column deletion was unreachable from the UI. The Data sheet
+  // therefore gets an explicit menu with a custom, working "Delete column" that
+  // deletes the underlying schema column (header + values) via the schema API,
+  // plus a "Clear cell(s)" item that is not header-gated like the native
+  // "Clear column". Other sheets keep the default menu.
+  const contextMenuConfig = useMemo(() => {
+    if (activeSheet !== 'data') return true;
+    return {
+      items: {
+        delete_schema_column: {
+          name(this: any): string {
+            return selectedSchemaColumnNames(this).length > 1 ? 'Delete columns' : 'Delete column';
+          },
+          disabled(this: any): boolean {
+            return !sessionId || selectedSchemaColumnNames(this).length === 0;
+          },
+          callback(this: any): void {
+            deleteSchemaColumns(selectedSchemaColumnNames(this));
+          },
+        },
+        clear_selected_cells: {
+          name: 'Clear cell(s)',
+          disabled(this: any): boolean {
+            const selection = typeof this?.getSelected === 'function' ? this.getSelected() : null;
+            return !selection || selection.length === 0;
+          },
+          callback(this: any): void {
+            // Routes through afterChange -> handleChanges, which persists the
+            // empties and shows a single summary toast.
+            if (typeof this?.emptySelectedCells === 'function') this.emptySelectedCells('edit');
+          },
+        },
+        sep_1: { name: '---------' },
+        copy: {},
+        cut: {},
+      },
+    };
+  }, [activeSheet, deleteSchemaColumns, selectedSchemaColumnNames, sessionId]);
+
   if (!sessionId) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
@@ -985,7 +1151,7 @@ export function SpreadsheetSurface({
         stretchH="none"
         manualColumnResize
         manualRowResize
-        contextMenu
+        contextMenu={contextMenuConfig}
         filters
         dropdownMenu
         columnSorting={!hasMultiRowGroup}
@@ -1002,6 +1168,7 @@ export function SpreadsheetSurface({
         afterFilter={applyGroupMerges}
         beforeRemoveRow={handleBeforeRemoveRow}
         beforeRemoveCol={handleBeforeRemoveCol}
+        beforeKeyDown={handleBeforeKeyDown}
         afterChange={(changes, source) => {
           handleChanges(changes, source);
           if (source !== 'loadData') onEditEnd();


### PR DESCRIPTION
## Problem
On the Workspace Data sheet: (1) deleting a whole column (header + schema) was impossible — Handsontable disables its native "Remove column" for object data sources / `columns` grids, so `beforeRemoveCol` never fired; (2) clearing a column or a multi-cell selection left some cells unpersisted, failing with `Row with row_name '...' not found`; (3) clearing spammed one "Cell updated" toast per cell and the grid flickered.

## Solution
- **Column delete:** custom Data-sheet context menu with a working "Delete column" (deletes the schema column, header + values, via `schemaAPI.deleteColumn`), plus a non-header-gated "Clear cell(s)". Delete/Backspace on a header-selected column removes it (Excel-style); partial cell selections still clear contents.
- **Clears not persisting:** two root causes. (a) `afterChange` reports *visual* rows while `data.rows` is physical; with grouping merges / filters the wrong row was resolved — fixed with `hot.toPhysicalRow()`. (b) `update_cell` only fell back to the stable `_row_index` when `row_name` was absent; an imperfect `row_name`/`source_document` pair failed even though the index matched — added an index fallback when the name lookup finds nothing.
- **Toast spam + flicker:** batch a whole `afterChange` set into one request group, one summary toast ("N cells cleared" / "N cells updated"), and a single refresh.

## Verify
- `git apply --ignore-whitespace --check` passes on a clean clone.
- `( cd frontend && npx tsc --noEmit )` passes; `python -m py_compile backend/app/services/data_editor.py` passes.
- Manual: right-click a Data column -> Delete column removes header + values from Data and Schema; select the column by header + Delete removes it; select cells + Delete (or Clear cell(s)) empties them and they stay empty after refresh, with a single summary toast and no flicker.