### PR TITLE
fix(workspace): column delete from both menus, reliable clears, no update-depth loop

### DIFF
--- a/backend/app/services/data_editor.py
+++ b/backend/app/services/data_editor.py
@@ -98,73 +98,97 @@ class DataEditor:
 
         from app.services.data_utils import _resolve_source_document
 
-        match_by_index = (not row_name) and row_index is not None
+        # Identity resolution runs in two passes. Primary: match by `row_name`
+        # (plus `source_document` when given). Fallback: if the name never
+        # matched but a stable `_row_index` was supplied, retry by absolute
+        # position. `_row_index` is stamped by the reader as the file line
+        # position and survives filtering/sorting, so it is a reliable identity
+        # when the name disambiguation is imperfect — e.g. a clear/delete where
+        # the resolved `row_name`/`source_document` pair does not co-exist on any
+        # stored row, which previously failed with "Row ... not found" and left
+        # some cells in a bulk clear unpersisted.
+        def _run_match(match_by_index: bool):
+            updated_any = False
+            previous_value = None
+            persisted_files: list = []
 
-        updated_any = False
-        previous_value = None
-        persisted_files: list = []
+            for file_position, data_file in enumerate(data_files):
+                # Read all rows for this file
+                rows = []
+                try:
+                    with open(data_file, "r", encoding="utf-8") as f:
+                        for line in f:
+                            if line.strip():
+                                rows.append(json.loads(line))
+                except FileNotFoundError:
+                    continue
 
-        for file_position, data_file in enumerate(data_files):
-            # Read all rows for this file
-            rows = []
-            try:
-                with open(data_file, "r", encoding="utf-8") as f:
-                    for line in f:
-                        if line.strip():
-                            rows.append(json.loads(line))
-            except FileNotFoundError:
-                continue
-
-            file_updated = False
-            for idx, row in enumerate(rows):
-                if match_by_index:
-                    # row_index is an absolute position in the reader's merged,
-                    # deduped view, not a per-file line number. Only the first
-                    # resolved file is authoritative for the index fallback
-                    # (used for name-less generic imports, effectively
-                    # single-file); do not attempt it against later files.
-                    if file_position != 0 or idx != row_index:
-                        continue
-                else:
-                    current_row_name = row.get("row_name") or row.get("_row_name")
-                    if current_row_name != row_name:
-                        continue
-                    # update_all fills every row for this unit (a value that is a
-                    # property of the unit, e.g. a reference lookup), so it ignores
-                    # the source_document disambiguator and does not stop at the
-                    # first match — otherwise only the first of several rows sharing
-                    # the row_name gets written and the rest stay blank.
-                    if source_document and not update_all:
-                        current_src = _resolve_source_document(row)
-                        if current_src and current_src != source_document:
+                file_updated = False
+                for idx, row in enumerate(rows):
+                    if match_by_index:
+                        # row_index is an absolute position in the reader's
+                        # merged, deduped view, not a per-file line number. Only
+                        # the first resolved file is authoritative for the index
+                        # fallback (effectively single-file); do not attempt it
+                        # against later files.
+                        if file_position != 0 or idx != row_index:
                             continue
+                    else:
+                        current_row_name = row.get("row_name") or row.get("_row_name")
+                        if current_row_name != row_name:
+                            continue
+                        # update_all fills every row for this unit (a value that
+                        # is a property of the unit, e.g. a reference lookup), so
+                        # it ignores the source_document disambiguator and does
+                        # not stop at the first match — otherwise only the first
+                        # of several rows sharing the row_name gets written and
+                        # the rest stay blank.
+                        if source_document and not update_all:
+                            current_src = _resolve_source_document(row)
+                            if current_src and current_src != source_document:
+                                continue
 
-                row_previous = self._apply_cell_update(
-                    row, column, value, restore=restore,
-                    reference_source=reference_source,
-                )
-                # Preserve the previous value from the first file that matched
-                # (the reader's authoritative first-occurrence).
-                if not updated_any:
-                    previous_value = row_previous
-                file_updated = True
-                updated_any = True
-                if not update_all:
+                    row_previous = self._apply_cell_update(
+                        row, column, value, restore=restore,
+                        reference_source=reference_source,
+                    )
+                    # Preserve the previous value from the first file that matched
+                    # (the reader's authoritative first-occurrence).
+                    if not updated_any:
+                        previous_value = row_previous
+                    file_updated = True
+                    updated_any = True
+                    if not update_all:
+                        break
+
+                if file_updated:
+                    with open(data_file, "w", encoding="utf-8") as f:
+                        for row in rows:
+                            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+                    persisted_files.append(data_file)
+
+                # Index-based match targets a single file only; stop after the first.
+                if match_by_index and file_position == 0:
                     break
 
-            if file_updated:
-                with open(data_file, "w", encoding="utf-8") as f:
-                    for row in rows:
-                        f.write(json.dumps(row, ensure_ascii=False) + "\n")
-                persisted_files.append(data_file)
+            return updated_any, previous_value, persisted_files
 
-            # Index-based match targets a single file only; stop after the first.
-            if match_by_index and file_position == 0:
-                break
+        primary_by_index = (not row_name) and row_index is not None
+        updated_any, previous_value, persisted_files = _run_match(primary_by_index)
+
+        # Name matched nothing but we have a stable index — retry by position.
+        # (Index identity is unique, so update_all's fan-out does not apply here.)
+        if not updated_any and not primary_by_index and row_index is not None:
+            updated_any, previous_value, persisted_files = _run_match(True)
 
         if not updated_any:
-            if match_by_index:
+            if primary_by_index:
                 raise ValueError(f"Row at index {row_index} not found")
+            if row_index is not None:
+                raise ValueError(
+                    f"Row with row_name '{row_name}' not found "
+                    f"(also tried index {row_index})"
+                )
             raise ValueError(f"Row with row_name '{row_name}' not found")
 
         for data_file in persisted_files:

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -462,7 +462,15 @@ export function SpreadsheetSurface({
     try {
       const settings = hot.getSettings() as { _initOnlySettings?: string[] };
       if (!Array.isArray(settings._initOnlySettings)) settings._initOnlySettings = [];
-      for (const key of ['filters', 'dropdownMenu']) {
+      // `contextMenu` is included for the same reason: it is now an object
+      // config (custom Data-sheet items), and letting the wrapper re-push it on
+      // every re-render re-initializes the context-menu plugin. A clear (which
+      // re-renders without changing the grid `key`, so the grid is not
+      // remounted) then re-inits the menu on each optimistic-edit render, which
+      // cascades into a "Maximum update depth exceeded" loop. Marking it
+      // init-only configures the menu once at construction; the config is a
+      // stable reference and the grid remounts on sheet/column changes anyway.
+      for (const key of ['filters', 'dropdownMenu', 'contextMenu']) {
         if (!settings._initOnlySettings.includes(key)) settings._initOnlySettings.push(key);
       }
     } catch { /* instance may be mid-teardown */ }
@@ -640,55 +648,109 @@ export function SpreadsheetSurface({
   const handleChanges = useCallback((changes: any[] | null, source: string) => {
     if (!changes || source === 'loadData' || !sessionId) return;
 
-    for (const change of changes) {
-      const [rowIndex, prop, oldValue, newValue] = change;
-      if (oldValue === newValue || prop == null) continue;
-      const key = String(prop);
+    // --- Data sheet: batch every cell edit/clear in this change set into a
+    // single request group and a single summary toast. Handsontable delivers a
+    // whole column-clear or multi-cell delete as one `afterChange` call with N
+    // entries; firing a toast + refresh per entry produced the "Cell updated"
+    // spam and the flicker from N racing refreshes.
+    //
+    // It also reports *visual* row indices, but `data.rows` is in physical
+    // order. Grouping applies mergeCells and filters/sorting may be active, so
+    // visual != physical; resolving the row without converting targeted the
+    // wrong record (or an empty spare row) and made clears fail with
+    // "Row ... not found" for some cells. Convert once via the live instance.
+    if (activeSheet === 'data') {
+      const hot = hotTableRef.current?.hotInstance;
+      const toPhysicalRow = (visualRow: number): number =>
+        hot && typeof hot.toPhysicalRow === 'function' ? hot.toPhysicalRow(visualRow) : visualRow;
 
-      if (activeSheet === 'data') {
+      type CellUpdate = {
+        rowName: string;
+        sourceDocument?: string;
+        rowIndexId?: number;
+        column: string;
+        value: string;
+      };
+      const updates: CellUpdate[] = [];
+      let unidentified = 0;
+
+      for (const change of changes) {
+        const [visualRowIndex, prop, oldValue, newValue] = change;
+        if (oldValue === newValue || prop == null) continue;
+        const key = String(prop);
         if (key.startsWith('_')) continue;
-        const sourceRow: DataRow | undefined = data.rows[rowIndex];
+
+        const sourceRow: DataRow | undefined = data.rows[toPhysicalRow(visualRowIndex)];
         const rowName = sourceRow?.row_name || sourceRow?._unit_name || '';
         const rowIndexId = sourceRow?._row_index;
         const sourceDocument = sourceRow?._source_document || sourceRow?._parent_document;
         if (!rowName && rowIndexId == null) {
+          unidentified += 1;
+          continue;
+        }
+
+        updates.push({ rowName, sourceDocument, rowIndexId, column: key, value: String(newValue ?? '') });
+      }
+
+      if (updates.length === 0) {
+        if (unidentified > 0) {
           toast({
             title: 'Cell update failed',
             description: 'Could not identify which row to update.',
             variant: 'destructive',
           });
           onRefreshData();
-          continue;
+        }
+        return;
+      }
+
+      // Apply every edit to React state up front so the grid does not revert
+      // while the writes are in flight.
+      updates.forEach((u) =>
+        onOptimisticCellEdit(
+          { rowName: u.rowName, sourceDocument: u.sourceDocument, rowIndex: u.rowIndexId },
+          u.column,
+          u.value,
+        ),
+      );
+
+      const allCleared = updates.every((u) => u.value.trim() === '');
+
+      Promise.allSettled(
+        updates.map((u) =>
+          schematiqAPI.updateCell(sessionId, u.rowName, u.column, u.value, u.sourceDocument, u.rowIndexId),
+        ),
+      ).then((results) => {
+        const failed = results.filter((r) => r.status === 'rejected').length;
+        const succeeded = updates.length - failed;
+
+        if (failed > 0) {
+          toast({
+            title: 'Some cells could not be saved',
+            description: `${failed} of ${updates.length} update${updates.length > 1 ? 's' : ''} failed.`,
+            variant: 'destructive',
+          });
+        } else if (updates.length === 1) {
+          const u = updates[0];
+          const rowLabel = u.rowName || (u.rowIndexId != null ? `Row ${u.rowIndexId + 1}` : 'Row');
+          toast({
+            title: allCleared ? 'Cell cleared' : 'Cell updated',
+            description: `${rowLabel} / ${u.column}`,
+          });
+        } else {
+          toast({ title: allCleared ? `${succeeded} cells cleared` : `${succeeded} cells updated` });
         }
 
-        onOptimisticCellEdit(
-          { rowName, sourceDocument, rowIndex: rowIndexId },
-          key,
-          String(newValue ?? ''),
-        );
+        onRefreshData();
+      });
 
-        schematiqAPI.updateCell(
-          sessionId,
-          rowName,
-          key,
-          String(newValue ?? ''),
-          sourceDocument,
-          rowIndexId
-        )
-          .then(() => {
-            const rowLabel = rowName || (rowIndexId != null ? `Row ${rowIndexId + 1}` : 'Row');
-            toast({ title: 'Cell updated', description: `${rowLabel} / ${key}` });
-            onRefreshData();
-          })
-          .catch((err: any) => {
-            toast({
-              title: 'Cell update failed',
-              description: err?.response?.data?.detail || err?.message || 'Could not update cell',
-              variant: 'destructive',
-            });
-            onRefreshData();
-          });
-      }
+      return;
+    }
+
+    for (const change of changes) {
+      const [rowIndex, prop, oldValue, newValue] = change;
+      if (oldValue === newValue || prop == null) continue;
+      const key = String(prop);
 
       if (activeSheet === 'schema') {
         const existing = schemaColumns[rowIndex];
@@ -825,7 +887,7 @@ export function SpreadsheetSurface({
           });
       }
     }
-  }, [activeSheet, data.rows, observationUnitRows, onEditFollowUp, onOptimisticCellEdit, onRefresh, onRefreshData, schemaColumns, sessionId, toast]);
+  }, [activeSheet, data.rows, hotTableRef, observationUnitRows, onEditFollowUp, onOptimisticCellEdit, onRefresh, onRefreshData, schemaColumns, sessionId, toast]);
 
   const handleBeforeRemoveRow = useCallback(
     (_index: number, _amount: number, physicalRows: number[], _source?: string): boolean | void => {
@@ -940,6 +1002,161 @@ export function SpreadsheetSurface({
     [activeSheet, onRefresh, schemaColumns, sessionId, sheet.columns, toast],
   );
 
+  // Resolve the schema-column names covered by the current grid selection,
+  // excluding the fixed provenance columns (_row_name / _source_document).
+  // Shared by the "Delete column" menu item and the Delete-key shortcut.
+  const selectedSchemaColumnNames = useCallback(
+    (hot: any): string[] => {
+      const selection: number[][] = typeof hot?.getSelected === 'function' ? hot.getSelected() || [] : [];
+      const cols = new Set<number>();
+      for (const range of selection) {
+        const [, c1, , c2] = range;
+        const from = Math.min(c1, c2);
+        const to = Math.max(c1, c2);
+        for (let c = from; c <= to; c += 1) if (c >= 0) cols.add(c);
+      }
+      const keys = Array.from(cols)
+        .map((c) => sheet.columns[c]?.key)
+        .filter((key): key is string => Boolean(key) && !key.startsWith('_'));
+      // Keep only keys that are real schema columns (never provenance/grouping).
+      return keys.filter((key) => schemaColumns.some((col) => col.name === key));
+    },
+    [schemaColumns, sheet.columns],
+  );
+
+  // Delete one or more schema columns (header + values, from both the Schema
+  // and Data views) via the schema API, then refresh. Shared by the context
+  // menu item and the Delete-key shortcut.
+  const deleteSchemaColumns = useCallback(
+    (names: string[]) => {
+      if (names.length === 0 || !sessionId) return;
+      Promise.allSettled(names.map((name) => schemaAPI.deleteColumn(sessionId, name)))
+        .then((results) => {
+          const failed = results.filter((r) => r.status === 'rejected').length;
+          if (failed > 0) {
+            toast({
+              title: 'Column delete failed',
+              description: `${failed} of ${names.length} column${names.length > 1 ? 's' : ''} could not be deleted.`,
+              variant: 'destructive',
+            });
+          } else {
+            toast({
+              title: names.length > 1 ? 'Columns deleted' : 'Column deleted',
+              description: names.join(', '),
+            });
+          }
+          // Deleting a column does not invalidate the remaining columns'
+          // extracted values, so it must not flag a re-extract.
+          onRefresh();
+        });
+    },
+    [onRefresh, sessionId, toast],
+  );
+
+  // Excel-style: when one or more whole columns are selected (by clicking the
+  // column header) and the user presses Delete/Backspace, remove the column(s)
+  // entirely rather than clearing cell contents. A partial (cell-level)
+  // selection keeps the default behaviour, which clears contents and routes
+  // through handleChanges.
+  const handleBeforeKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (activeSheet !== 'data') return;
+      if (event.key !== 'Delete' && event.key !== 'Backspace') return;
+      const hot = hotTableRef.current?.hotInstance as any;
+      if (!hot?.selection?.isSelectedByColumnHeader?.()) return;
+      const names = selectedSchemaColumnNames(hot);
+      if (names.length === 0) return;
+      event.stopImmediatePropagation();
+      event.preventDefault();
+      deleteSchemaColumns(names);
+    },
+    [activeSheet, deleteSchemaColumns, hotTableRef, selectedSchemaColumnNames],
+  );
+
+  // Latest-value ref so the menu configs below can be built once (stable
+  // references) while still acting on current data. Rebuilding the dropdown
+  // config whenever `sheet`/`schemaColumns` re-memo (every data refresh) would
+  // change its reference and make the @handsontable/react wrapper re-push — and
+  // thus re-initialize — the filters plugin, wiping the active filter that
+  // `markFilterSettingsInitOnly` works to preserve.
+  const menuActionsRef = useRef<{
+    selectedNames: (hot: any) => string[];
+    deleteColumns: (names: string[]) => void;
+  }>({ selectedNames: () => [], deleteColumns: () => {} });
+  menuActionsRef.current = {
+    selectedNames: selectedSchemaColumnNames,
+    deleteColumns: deleteSchemaColumns,
+  };
+
+  // Custom Data-sheet menu items shared by the right-click context menu and the
+  // column-header dropdown. Handsontable disables its native "Remove column"
+  // whenever the grid uses an object data source *or* a `columns` option (both
+  // true here), so column deletion was unreachable from either menu. These add a
+  // working "Delete column" (removes the schema column, header + values, via the
+  // schema API) and a "Clear cell(s)" item that is not header-gated like the
+  // native "Clear column". Built with a stable identity (see menuActionsRef).
+  const customColumnMenuItems = useMemo(
+    () => ({
+      delete_schema_column: {
+        name(this: any): string {
+          return menuActionsRef.current.selectedNames(this).length > 1 ? 'Delete columns' : 'Delete column';
+        },
+        disabled(this: any): boolean {
+          return menuActionsRef.current.selectedNames(this).length === 0;
+        },
+        callback(this: any): void {
+          menuActionsRef.current.deleteColumns(menuActionsRef.current.selectedNames(this));
+        },
+      },
+      clear_selected_cells: {
+        name: 'Clear cell(s)',
+        disabled(this: any): boolean {
+          const selection = typeof this?.getSelected === 'function' ? this.getSelected() : null;
+          return !selection || selection.length === 0;
+        },
+        callback(this: any): void {
+          // Routes through afterChange -> handleChanges, which persists the
+          // empties and shows a single summary toast.
+          if (typeof this?.emptySelectedCells === 'function') this.emptySelectedCells('edit');
+        },
+      },
+    }),
+    [],
+  );
+
+  // Right-click context menu (Data sheet only; other sheets keep the default).
+  const contextMenuConfig = useMemo(() => {
+    if (activeSheet !== 'data') return true;
+    return {
+      items: {
+        ...customColumnMenuItems,
+        sep_1: { name: '---------' },
+        copy: {},
+        cut: {},
+      },
+    };
+  }, [activeSheet, customColumnMenuItems]);
+
+  // Column-header dropdown (the ▼ button). This is a *separate* menu from the
+  // context menu; the default one is what showed the greyed-out "Remove column",
+  // so the header dropdown also needs the custom items. The predefined
+  // `filter_*` keys are re-included so the "Filter by condition/value" UI is
+  // preserved.
+  const dropdownMenuConfig = useMemo(() => {
+    if (activeSheet !== 'data') return true;
+    return {
+      items: {
+        ...customColumnMenuItems,
+        sep_1: { name: '---------' },
+        filter_by_condition: {},
+        filter_operators: {},
+        filter_by_condition2: {},
+        filter_by_value: {},
+        filter_action_bar: {},
+      },
+    };
+  }, [activeSheet, customColumnMenuItems]);
+
   if (!sessionId) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
@@ -985,9 +1202,9 @@ export function SpreadsheetSurface({
         stretchH="none"
         manualColumnResize
         manualRowResize
-        contextMenu
+        contextMenu={contextMenuConfig}
         filters
-        dropdownMenu
+        dropdownMenu={dropdownMenuConfig}
         columnSorting={!hasMultiRowGroup}
         copyPaste
         undo
@@ -1002,6 +1219,7 @@ export function SpreadsheetSurface({
         afterFilter={applyGroupMerges}
         beforeRemoveRow={handleBeforeRemoveRow}
         beforeRemoveCol={handleBeforeRemoveCol}
+        beforeKeyDown={handleBeforeKeyDown}
         afterChange={(changes, source) => {
           handleChanges(changes, source);
           if (source !== 'loadData') onEditEnd();


### PR DESCRIPTION
## Problem
Clearing cells threw `Maximum update depth exceeded`. Separately, the column-header dropdown still showed a disabled "Remove column", and clears could fail (`Row ... not found`), spam one toast per cell, and flicker.

## Solution
- **Update-depth loop:** `@handsontable/react` re-pushes any non-init-only prop on every `updateSettings`, re-initializing that plugin (verified in the wrapper's `shouldSkipProp`). `contextMenu` became an object config but was not marked init-only, so a clear — which re-renders without changing the grid `key` (no remount) — re-inited the menu plugin on each optimistic-edit render and looped. Delete column was unaffected because the column-count change remounts the grid. Fix: mark `contextMenu` init-only (alongside `filters`/`dropdownMenu`); its reference is stable, so the wrapper skips re-pushing it.
- **Both menus:** custom "Delete column" + non-header-gated "Clear cell(s)" added to context menu and header dropdown; the dropdown re-includes the `filter_*` items so filtering is preserved. Configs use a stable reference so the init-only skip holds across data refreshes.
- **Delete key:** Delete/Backspace on a header-selected column removes it (Excel-style); partial selections clear contents.
- **Clears not persisting:** `afterChange` visual rows converted via `toPhysicalRow`; `update_cell` falls back to the stable `_row_index` when a name lookup finds nothing.
- **Toast spam + flicker:** one request group, one summary toast, one refresh per `afterChange` batch.

## Verify
- `git apply --ignore-whitespace --check`, `tsc --noEmit`, and `py_compile` all pass on a clean clone.
- Manual: clear a column via header dropdown "Clear cell(s)" or Delete on a cell selection — cells empty, stay empty after refresh, one toast, no console errors; Delete column and Filter by value still work from the header dropdown.