### PR TITLE
fix(workspace): stabilize row heights during horizontal scroll

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -985,6 +985,16 @@ export function SpreadsheetSurface({
         stretchH="none"
         manualColumnResize
         manualRowResize
+        // Measure each row's height across ALL of its cells, not just the ones
+        // currently in the horizontal viewport. Handsontable virtualises columns,
+        // so without this the row height tracks only the tallest *visible* cell:
+        // scrolling right past a long wrapped cell shrinks the row, scrolling a
+        // different long cell into view grows it, and the whole grid shifts
+        // vertically as you scroll horizontally (the row you started on drifts
+        // out of place). AutoRowSize caches a stable per-row height from the
+        // full row, so a row keeps its height at any scroll position. See
+        // handsontable/handsontable#493, #1213, #5241.
+        autoRowSize={true}
         contextMenu
         filters
         dropdownMenu


### PR DESCRIPTION
## Problem
In the Workspace spreadsheet (Handsontable), rows change height while scrolling horizontally. Cells wrap (white-space: pre-wrap), so rows have variable heights, and Handsontable virtualizes columns. Without autoRowSize, each row's height tracks only the tallest cell currently in the horizontal viewport: scrolling a long wrapped cell out of view shrinks the row, scrolling a different one in grows it. The vertical scroll offset barely moves, but the set of visible rows shifts, so the row you started on drifts out of place.

## Solution
Enable the AutoRowSize plugin (autoRowSize={true}) on the HotTable. It measures each row's height across all of its cells and caches a stable per-row height, so a row keeps its height at any horizontal scroll position. This is the Handsontable-recommended fix (handsontable/handsontable#493, #1213, #5241). Merges only cover the short grouping column and there is no fixedColumnsStart, so heights are not over-inflated.

## Verify
- Open the Workspace data sheet with wrapped multi-line cells.
- Scroll all the way right, then back left: the starting row stays in place; row heights no longer jump.
- git apply --ignore-whitespace --check passes on clean main; (cd frontend && npx tsc --noEmit) passes.