### PR TITLE
fix(workspace): column delete/clear reliability, no update-depth loop

### DIFF
--- a/backend/app/api/routes/schema.py
+++ b/backend/app/api/routes/schema.py
@@ -215,7 +215,7 @@ async def edit_column(
             await concurrency_limiter.release(session_id)
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.delete("/delete-column/{session_id}/{column_name}")
+@router.delete("/delete-column/{session_id}/{column_name:path}")
 async def delete_column(session_id: str, column_name: str):
     """Delete a column from the schema and existing data."""
     try:
@@ -758,7 +758,7 @@ async def reject_suggestion(session_id: str, request: RejectSuggestionRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.put("/auto-expand-threshold/{session_id}/{column_name}")
+@router.put("/auto-expand-threshold/{session_id}/{column_name:path}")
 async def set_auto_expand_threshold(
     session_id: str,
     column_name: str,

--- a/backend/app/services/data_editor.py
+++ b/backend/app/services/data_editor.py
@@ -6,6 +6,7 @@ Handles updates to JSONL data files for both load and ScheMatiQ sessions.
 import copy
 import json
 import logging
+import asyncio
 from pathlib import Path
 from typing import Any, Optional
 
@@ -17,6 +18,22 @@ from app.services.data_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Per-session write locks. update_cell does a read-modify-write over the whole
+# JSONL file, and the frontend fires one request per cell in parallel for a
+# multi-cell clear/paste. Without serialization two concurrent writes each read
+# the pre-edit file and the second write clobbers the first, so some cells
+# silently revert on the next refresh ("cleared two, one comes back"). A lock
+# keyed by session_id serializes writes for a session within the event loop.
+_session_write_locks: dict[str, asyncio.Lock] = {}
+
+
+def _get_session_write_lock(session_id: str) -> asyncio.Lock:
+    lock = _session_write_locks.get(session_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _session_write_locks[session_id] = lock
+    return lock
 
 
 class DataEditor:
@@ -112,23 +129,7 @@ class DataEditor:
             previous_value = None
             persisted_files: list = []
 
-            # `_row_index` is the line position in the file the *reader*
-            # (get_paginated_data) serves: data_dir/{session}/data.jsonl. That is
-            # NOT necessarily data_files[0] — resolve_session_data_files lists
-            # work_dir/extracted_data.jsonl first when it exists (dev sessions
-            # have one). Matching the index against data_files[0] then reads the
-            # wrong file and the fallback fails for rows whose stored name does
-            # not match the displayed identity. Resolve the reader's file and
-            # match the index there specifically.
-            reader_file = (self.data_dir / session_id / "data.jsonl").resolve()
-
-            for file_position, data_file in enumerate(data_files):
-                is_reader_file = False
-                try:
-                    is_reader_file = Path(data_file).resolve() == reader_file
-                except OSError:
-                    is_reader_file = False
-
+            for data_file in data_files:
                 # Read all rows for this file
                 rows = []
                 try:
@@ -142,8 +143,13 @@ class DataEditor:
                 file_updated = False
                 for idx, row in enumerate(rows):
                     if match_by_index:
-                        # Only the reader's file is authoritative for the index.
-                        if not is_reader_file or idx != row_index:
+                        # `_row_index` is the reader's non-blank line position in
+                        # the session data file; `enumerate(rows)` here mirrors
+                        # that exact enumeration, so match it directly. Matching
+                        # in whichever resolved file contains that line keeps this
+                        # robust regardless of how the data dir is resolved
+                        # (e.g. dev.sh's .dev-data/instance-*/data).
+                        if idx != row_index:
                             continue
                     else:
                         current_row_name = row.get("row_name") or row.get("_row_name")
@@ -179,33 +185,36 @@ class DataEditor:
                             f.write(json.dumps(row, ensure_ascii=False) + "\n")
                     persisted_files.append(data_file)
 
-                # Index-based match applies only to the reader's file; stop once
-                # it has been processed.
-                if match_by_index and is_reader_file:
+                # An index identity is unique to one row; once matched, stop.
+                if match_by_index and file_updated:
                     break
 
             return updated_any, previous_value, persisted_files
 
         primary_by_index = (not row_name) and row_index is not None
-        updated_any, previous_value, persisted_files = _run_match(primary_by_index)
 
-        # Name matched nothing but we have a stable index — retry by position.
-        # (Index identity is unique, so update_all's fan-out does not apply here.)
-        if not updated_any and not primary_by_index and row_index is not None:
-            updated_any, previous_value, persisted_files = _run_match(True)
+        # Serialize the read-modify-write so concurrent single-cell updates for
+        # the same session (a multi-cell clear/paste) cannot clobber each other.
+        async with _get_session_write_lock(session_id):
+            updated_any, previous_value, persisted_files = _run_match(primary_by_index)
 
-        if not updated_any:
-            if primary_by_index:
-                raise ValueError(f"Row at index {row_index} not found")
-            if row_index is not None:
-                raise ValueError(
-                    f"Row with row_name '{row_name}' not found "
-                    f"(also tried index {row_index})"
-                )
-            raise ValueError(f"Row with row_name '{row_name}' not found")
+            # Name matched nothing but we have a stable index — retry by position.
+            # (Index identity is unique, so update_all's fan-out does not apply.)
+            if not updated_any and not primary_by_index and row_index is not None:
+                updated_any, previous_value, persisted_files = _run_match(True)
 
-        for data_file in persisted_files:
-            await persist_session_data_file(session_id, data_file)
+            if not updated_any:
+                if primary_by_index:
+                    raise ValueError(f"Row at index {row_index} not found")
+                if row_index is not None:
+                    raise ValueError(
+                        f"Row with row_name '{row_name}' not found "
+                        f"(also tried index {row_index})"
+                    )
+                raise ValueError(f"Row with row_name '{row_name}' not found")
+
+            for data_file in persisted_files:
+                await persist_session_data_file(session_id, data_file)
 
         return {
             "status": "success",

--- a/backend/app/services/data_editor.py
+++ b/backend/app/services/data_editor.py
@@ -98,73 +98,97 @@ class DataEditor:
 
         from app.services.data_utils import _resolve_source_document
 
-        match_by_index = (not row_name) and row_index is not None
+        # Identity resolution runs in two passes. Primary: match by `row_name`
+        # (plus `source_document` when given). Fallback: if the name never
+        # matched but a stable `_row_index` was supplied, retry by absolute
+        # position. `_row_index` is stamped by the reader as the file line
+        # position and survives filtering/sorting, so it is a reliable identity
+        # when the name disambiguation is imperfect — e.g. a clear/delete where
+        # the resolved `row_name`/`source_document` pair does not co-exist on any
+        # stored row, which previously failed with "Row ... not found" and left
+        # some cells in a bulk clear unpersisted.
+        def _run_match(match_by_index: bool):
+            updated_any = False
+            previous_value = None
+            persisted_files: list = []
 
-        updated_any = False
-        previous_value = None
-        persisted_files: list = []
+            for file_position, data_file in enumerate(data_files):
+                # Read all rows for this file
+                rows = []
+                try:
+                    with open(data_file, "r", encoding="utf-8") as f:
+                        for line in f:
+                            if line.strip():
+                                rows.append(json.loads(line))
+                except FileNotFoundError:
+                    continue
 
-        for file_position, data_file in enumerate(data_files):
-            # Read all rows for this file
-            rows = []
-            try:
-                with open(data_file, "r", encoding="utf-8") as f:
-                    for line in f:
-                        if line.strip():
-                            rows.append(json.loads(line))
-            except FileNotFoundError:
-                continue
-
-            file_updated = False
-            for idx, row in enumerate(rows):
-                if match_by_index:
-                    # row_index is an absolute position in the reader's merged,
-                    # deduped view, not a per-file line number. Only the first
-                    # resolved file is authoritative for the index fallback
-                    # (used for name-less generic imports, effectively
-                    # single-file); do not attempt it against later files.
-                    if file_position != 0 or idx != row_index:
-                        continue
-                else:
-                    current_row_name = row.get("row_name") or row.get("_row_name")
-                    if current_row_name != row_name:
-                        continue
-                    # update_all fills every row for this unit (a value that is a
-                    # property of the unit, e.g. a reference lookup), so it ignores
-                    # the source_document disambiguator and does not stop at the
-                    # first match — otherwise only the first of several rows sharing
-                    # the row_name gets written and the rest stay blank.
-                    if source_document and not update_all:
-                        current_src = _resolve_source_document(row)
-                        if current_src and current_src != source_document:
+                file_updated = False
+                for idx, row in enumerate(rows):
+                    if match_by_index:
+                        # row_index is an absolute position in the reader's
+                        # merged, deduped view, not a per-file line number. Only
+                        # the first resolved file is authoritative for the index
+                        # fallback (effectively single-file); do not attempt it
+                        # against later files.
+                        if file_position != 0 or idx != row_index:
                             continue
+                    else:
+                        current_row_name = row.get("row_name") or row.get("_row_name")
+                        if current_row_name != row_name:
+                            continue
+                        # update_all fills every row for this unit (a value that
+                        # is a property of the unit, e.g. a reference lookup), so
+                        # it ignores the source_document disambiguator and does
+                        # not stop at the first match — otherwise only the first
+                        # of several rows sharing the row_name gets written and
+                        # the rest stay blank.
+                        if source_document and not update_all:
+                            current_src = _resolve_source_document(row)
+                            if current_src and current_src != source_document:
+                                continue
 
-                row_previous = self._apply_cell_update(
-                    row, column, value, restore=restore,
-                    reference_source=reference_source,
-                )
-                # Preserve the previous value from the first file that matched
-                # (the reader's authoritative first-occurrence).
-                if not updated_any:
-                    previous_value = row_previous
-                file_updated = True
-                updated_any = True
-                if not update_all:
+                    row_previous = self._apply_cell_update(
+                        row, column, value, restore=restore,
+                        reference_source=reference_source,
+                    )
+                    # Preserve the previous value from the first file that matched
+                    # (the reader's authoritative first-occurrence).
+                    if not updated_any:
+                        previous_value = row_previous
+                    file_updated = True
+                    updated_any = True
+                    if not update_all:
+                        break
+
+                if file_updated:
+                    with open(data_file, "w", encoding="utf-8") as f:
+                        for row in rows:
+                            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+                    persisted_files.append(data_file)
+
+                # Index-based match targets a single file only; stop after the first.
+                if match_by_index and file_position == 0:
                     break
 
-            if file_updated:
-                with open(data_file, "w", encoding="utf-8") as f:
-                    for row in rows:
-                        f.write(json.dumps(row, ensure_ascii=False) + "\n")
-                persisted_files.append(data_file)
+            return updated_any, previous_value, persisted_files
 
-            # Index-based match targets a single file only; stop after the first.
-            if match_by_index and file_position == 0:
-                break
+        primary_by_index = (not row_name) and row_index is not None
+        updated_any, previous_value, persisted_files = _run_match(primary_by_index)
+
+        # Name matched nothing but we have a stable index — retry by position.
+        # (Index identity is unique, so update_all's fan-out does not apply here.)
+        if not updated_any and not primary_by_index and row_index is not None:
+            updated_any, previous_value, persisted_files = _run_match(True)
 
         if not updated_any:
-            if match_by_index:
+            if primary_by_index:
                 raise ValueError(f"Row at index {row_index} not found")
+            if row_index is not None:
+                raise ValueError(
+                    f"Row with row_name '{row_name}' not found "
+                    f"(also tried index {row_index})"
+                )
             raise ValueError(f"Row with row_name '{row_name}' not found")
 
         for data_file in persisted_files:

--- a/backend/app/services/data_editor.py
+++ b/backend/app/services/data_editor.py
@@ -112,7 +112,23 @@ class DataEditor:
             previous_value = None
             persisted_files: list = []
 
+            # `_row_index` is the line position in the file the *reader*
+            # (get_paginated_data) serves: data_dir/{session}/data.jsonl. That is
+            # NOT necessarily data_files[0] — resolve_session_data_files lists
+            # work_dir/extracted_data.jsonl first when it exists (dev sessions
+            # have one). Matching the index against data_files[0] then reads the
+            # wrong file and the fallback fails for rows whose stored name does
+            # not match the displayed identity. Resolve the reader's file and
+            # match the index there specifically.
+            reader_file = (self.data_dir / session_id / "data.jsonl").resolve()
+
             for file_position, data_file in enumerate(data_files):
+                is_reader_file = False
+                try:
+                    is_reader_file = Path(data_file).resolve() == reader_file
+                except OSError:
+                    is_reader_file = False
+
                 # Read all rows for this file
                 rows = []
                 try:
@@ -126,12 +142,8 @@ class DataEditor:
                 file_updated = False
                 for idx, row in enumerate(rows):
                     if match_by_index:
-                        # row_index is an absolute position in the reader's
-                        # merged, deduped view, not a per-file line number. Only
-                        # the first resolved file is authoritative for the index
-                        # fallback (effectively single-file); do not attempt it
-                        # against later files.
-                        if file_position != 0 or idx != row_index:
+                        # Only the reader's file is authoritative for the index.
+                        if not is_reader_file or idx != row_index:
                             continue
                     else:
                         current_row_name = row.get("row_name") or row.get("_row_name")
@@ -167,8 +179,9 @@ class DataEditor:
                             f.write(json.dumps(row, ensure_ascii=False) + "\n")
                     persisted_files.append(data_file)
 
-                # Index-based match targets a single file only; stop after the first.
-                if match_by_index and file_position == 0:
+                # Index-based match applies only to the reader's file; stop once
+                # it has been processed.
+                if match_by_index and is_reader_file:
                     break
 
             return updated_any, previous_value, persisted_files

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -648,6 +648,65 @@ export function SpreadsheetSurface({
     };
   }, [activeSheet, dataColumnNames, dataRows, observationUnitRows, schemaRows, columnDisplayLabel, schemaColumns, dataView, renderGroupCell]);
 
+  // Coalesce cell edit/clear toasts. Handsontable can split one visual clear
+  // into several afterChange batches (e.g. a 1-cell batch plus the rest), which
+  // otherwise produces both a per-cell "Cell cleared" toast and a "N cells
+  // cleared" summary. Accumulate across a short window and show a single toast:
+  // the detailed one when exactly one cell changed in total, the summary
+  // otherwise.
+  const editToastRef = useRef<{
+    cleared: number;
+    updated: number;
+    failed: number;
+    total: number;
+    single: { cleared: boolean; label: string; column: string } | null;
+    timer: ReturnType<typeof setTimeout> | null;
+  }>({ cleared: 0, updated: 0, failed: 0, total: 0, single: null, timer: null });
+
+  const flushEditToast = useCallback(() => {
+    const a = editToastRef.current;
+    if (a.timer) { clearTimeout(a.timer); a.timer = null; }
+    const { cleared, updated, failed, total, single } = a;
+    editToastRef.current = { cleared: 0, updated: 0, failed: 0, total: 0, single: null, timer: null };
+    if (total === 0) return;
+    if (failed > 0) {
+      toast({
+        title: 'Some cells could not be saved',
+        description: `${failed} of ${total} update${total > 1 ? 's' : ''} failed.`,
+        variant: 'destructive',
+      });
+    } else if (total === 1 && single) {
+      toast({
+        title: single.cleared ? 'Cell cleared' : 'Cell updated',
+        description: `${single.label} / ${single.column}`,
+      });
+    } else {
+      const allCleared = updated === 0;
+      toast({ title: allCleared ? `${cleared} cells cleared` : `${cleared + updated} cells updated` });
+    }
+  }, [toast]);
+
+  const queueEditToast = useCallback(
+    (batch: {
+      succeeded: number;
+      failed: number;
+      allCleared: boolean;
+      single: { cleared: boolean; label: string; column: string } | null;
+    }) => {
+      const a = editToastRef.current;
+      a.total += batch.succeeded + batch.failed;
+      a.failed += batch.failed;
+      if (batch.allCleared) a.cleared += batch.succeeded;
+      else a.updated += batch.succeeded;
+      // Keep the detailed label only while the whole interaction is a single cell.
+      if (a.total === 1 && batch.single) a.single = batch.single;
+      else a.single = null;
+      if (a.timer) clearTimeout(a.timer);
+      a.timer = setTimeout(flushEditToast, 250);
+    },
+    [flushEditToast],
+  );
+
   const handleChanges = useCallback((changes: any[] | null, source: string) => {
     if (!changes || source === 'loadData' || !sessionId) return;
 
@@ -729,22 +788,15 @@ export function SpreadsheetSurface({
         const failed = results.filter((r) => r.status === 'rejected').length;
         const succeeded = updates.length - failed;
 
-        if (failed > 0) {
-          toast({
-            title: 'Some cells could not be saved',
-            description: `${failed} of ${updates.length} update${updates.length > 1 ? 's' : ''} failed.`,
-            variant: 'destructive',
-          });
-        } else if (updates.length === 1) {
+        let single: { cleared: boolean; label: string; column: string } | null = null;
+        if (updates.length === 1 && failed === 0) {
           const u = updates[0];
           const rowLabel = u.rowName || (u.rowIndexId != null ? `Row ${u.rowIndexId + 1}` : 'Row');
-          toast({
-            title: allCleared ? 'Cell cleared' : 'Cell updated',
-            description: `${rowLabel} / ${u.column}`,
-          });
-        } else {
-          toast({ title: allCleared ? `${succeeded} cells cleared` : `${succeeded} cells updated` });
+          single = { cleared: allCleared, label: rowLabel, column: u.column };
         }
+        // Accumulate; the debounced flush emits a single toast for the whole
+        // interaction even when Handsontable splits it across afterChange calls.
+        queueEditToast({ succeeded, failed, allCleared, single });
 
         onRefreshData();
       });
@@ -892,7 +944,7 @@ export function SpreadsheetSurface({
           });
       }
     }
-  }, [activeSheet, data.rows, hotTableRef, observationUnitRows, onEditFollowUp, onOptimisticCellEdit, onRefresh, onRefreshData, schemaColumns, sessionId, toast]);
+  }, [activeSheet, data.rows, hotTableRef, observationUnitRows, onEditFollowUp, onOptimisticCellEdit, onRefresh, onRefreshData, queueEditToast, schemaColumns, sessionId, toast]);
 
   const handleBeforeRemoveRow = useCallback(
     (_index: number, _amount: number, physicalRows: number[], _source?: string): boolean | void => {

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -55,6 +55,7 @@ export function SpreadsheetSurface({
   onGroundingHighlight,
   onGroundingScrollRequest,
   onRefresh,
+  onSchemaRefresh,
   onRefreshData,
   onOptimisticCellEdit,
   onEditFollowUp,
@@ -77,6 +78,9 @@ export function SpreadsheetSurface({
   // re-scroll to the highlight even when the same cell is clicked again.
   onGroundingScrollRequest?: () => void;
   onRefresh: () => void | Promise<void>;
+  // Schema-only refresh (no data reload) used after a column delete so the
+  // grid's data prop keeps its identity and horizontal scroll is preserved.
+  onSchemaRefresh: () => void | Promise<void>;
   // Row-data-only refresh after a Data-sheet cell edit (no status/schema churn).
   onRefreshData: () => void;
   // Apply the edited values to React state immediately so the grid does not
@@ -323,12 +327,18 @@ export function SpreadsheetSurface({
           row._source_document || row._parent_document || row.papers?.[0],
         ),
       };
-      dataColumnNames.forEach((column) => {
-        sheetRow[column] = extractDisplayValue(row.data?.[column]);
-      });
+      // Include every extracted value on the row, not just the current schema
+      // columns, so this array keeps a STABLE reference when a column is
+      // added/removed — the `columns` prop selects what to show. If this array
+      // were rebuilt on a column change, the `data` prop would change identity
+      // and Handsontable would reload the data (which resets horizontal scroll).
+      const rowData = row.data || {};
+      for (const key of Object.keys(rowData)) {
+        sheetRow[key] = extractDisplayValue(rowData[key]);
+      }
       return sheetRow;
     });
-  }, [data.rows, dataColumnNames]);
+  }, [data.rows]);
 
   const dataGrounding = useMemo(() => {
     const mapping = buildExcerptMapping(data.rows);
@@ -1111,16 +1121,18 @@ export function SpreadsheetSurface({
               description: names.join(', '),
             });
           }
-          // Deleting a column does not invalidate the remaining columns'
-          // extracted values, so it must not flag a re-extract. Return the
-          // refresh promise so the guard stays held until the grid has caught up.
-          return onRefresh();
+          // Deleting a column does not change the row data we display, so do a
+          // schema-only refresh (no data reload). Combined with the
+          // column-independent dataRows above, the grid's `data` prop keeps its
+          // identity, so only the `columns` prop changes and Handsontable drops
+          // the column in place without resetting horizontal scroll.
+          return onSchemaRefresh();
         })
         .finally(() => {
           deletingColumnsRef.current = false;
         });
     },
-    [onRefresh, sessionId, toast],
+    [onSchemaRefresh, sessionId, toast],
   );
 
   // Excel-style: when one or more whole columns are selected (by clicking the
@@ -1255,7 +1267,7 @@ export function SpreadsheetSurface({
     >
       <HotTable
         ref={hotTableRef}
-        key={`${activeSheet}-${sheet.columns.length}-${formatVersion}-${activeSheet === 'data' ? dataView : 'x'}`}
+        key={`${activeSheet}-${formatVersion}-${activeSheet === 'data' ? dataView : 'x'}`}
         className="workspace-hot"
         theme="ht-theme-main"
         data={sheet.rows}

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -79,12 +79,15 @@ export function SpreadsheetSurface({
   onRefresh: () => void;
   // Row-data-only refresh after a Data-sheet cell edit (no status/schema churn).
   onRefreshData: () => void;
-  // Apply the edited value to React state immediately so the grid does not
-  // revert when a background refresh re-renders before the PUT completes.
+  // Apply the edited values to React state immediately so the grid does not
+  // revert when a background refresh re-renders before the PUT completes. Takes
+  // the whole batch so a multi-cell change is one atomic state update.
   onOptimisticCellEdit: (
-    identity: { rowName: string; sourceDocument?: string; rowIndex?: number },
-    column: string,
-    value: string,
+    edits: {
+      identity: { rowName: string; sourceDocument?: string; rowIndex?: number };
+      column: string;
+      value: string;
+    }[],
   ) => void;
   onEditFollowUp: (kind: PendingRerunKind, columns?: string[]) => void;
   onEditEnd: () => void;
@@ -462,7 +465,15 @@ export function SpreadsheetSurface({
     try {
       const settings = hot.getSettings() as { _initOnlySettings?: string[] };
       if (!Array.isArray(settings._initOnlySettings)) settings._initOnlySettings = [];
-      for (const key of ['filters', 'dropdownMenu']) {
+      // `contextMenu` is included for the same reason: it is now an object
+      // config (custom Data-sheet items), and letting the wrapper re-push it on
+      // every re-render re-initializes the context-menu plugin. A clear (which
+      // re-renders without changing the grid `key`, so the grid is not
+      // remounted) then re-inits the menu on each optimistic-edit render, which
+      // cascades into a "Maximum update depth exceeded" loop. Marking it
+      // init-only configures the menu once at construction; the config is a
+      // stable reference and the grid remounts on sheet/column changes anyway.
+      for (const key of ['filters', 'dropdownMenu', 'contextMenu']) {
         if (!settings._initOnlySettings.includes(key)) settings._initOnlySettings.push(key);
       }
     } catch { /* instance may be mid-teardown */ }
@@ -640,55 +651,111 @@ export function SpreadsheetSurface({
   const handleChanges = useCallback((changes: any[] | null, source: string) => {
     if (!changes || source === 'loadData' || !sessionId) return;
 
-    for (const change of changes) {
-      const [rowIndex, prop, oldValue, newValue] = change;
-      if (oldValue === newValue || prop == null) continue;
-      const key = String(prop);
+    // --- Data sheet: batch every cell edit/clear in this change set into a
+    // single request group and a single summary toast. Handsontable delivers a
+    // whole column-clear or multi-cell delete as one `afterChange` call with N
+    // entries; firing a toast + refresh per entry produced the "Cell updated"
+    // spam and the flicker from N racing refreshes.
+    //
+    // It also reports *visual* row indices, but `data.rows` is in physical
+    // order. Grouping applies mergeCells and filters/sorting may be active, so
+    // visual != physical; resolving the row without converting targeted the
+    // wrong record (or an empty spare row) and made clears fail with
+    // "Row ... not found" for some cells. Convert once via the live instance.
+    if (activeSheet === 'data') {
+      const hot = hotTableRef.current?.hotInstance;
+      const toPhysicalRow = (visualRow: number): number =>
+        hot && typeof hot.toPhysicalRow === 'function' ? hot.toPhysicalRow(visualRow) : visualRow;
 
-      if (activeSheet === 'data') {
+      type CellUpdate = {
+        rowName: string;
+        sourceDocument?: string;
+        rowIndexId?: number;
+        column: string;
+        value: string;
+      };
+      const updates: CellUpdate[] = [];
+      let unidentified = 0;
+
+      for (const change of changes) {
+        const [visualRowIndex, prop, oldValue, newValue] = change;
+        if (oldValue === newValue || prop == null) continue;
+        const key = String(prop);
         if (key.startsWith('_')) continue;
-        const sourceRow: DataRow | undefined = data.rows[rowIndex];
+
+        const sourceRow: DataRow | undefined = data.rows[toPhysicalRow(visualRowIndex)];
         const rowName = sourceRow?.row_name || sourceRow?._unit_name || '';
         const rowIndexId = sourceRow?._row_index;
         const sourceDocument = sourceRow?._source_document || sourceRow?._parent_document;
         if (!rowName && rowIndexId == null) {
+          unidentified += 1;
+          continue;
+        }
+
+        updates.push({ rowName, sourceDocument, rowIndexId, column: key, value: String(newValue ?? '') });
+      }
+
+      if (updates.length === 0) {
+        if (unidentified > 0) {
           toast({
             title: 'Cell update failed',
             description: 'Could not identify which row to update.',
             variant: 'destructive',
           });
           onRefreshData();
-          continue;
+        }
+        return;
+      }
+
+      // Apply the whole batch to React state up front, in one atomic update, so
+      // the grid does not revert while the writes are in flight. A single call
+      // (rather than one per cell) keeps a multi-cell clear from triggering a
+      // render cascade inside Handsontable's synchronous afterChange.
+      onOptimisticCellEdit(
+        updates.map((u) => ({
+          identity: { rowName: u.rowName, sourceDocument: u.sourceDocument, rowIndex: u.rowIndexId },
+          column: u.column,
+          value: u.value,
+        })),
+      );
+
+      const allCleared = updates.every((u) => u.value.trim() === '');
+
+      Promise.allSettled(
+        updates.map((u) =>
+          schematiqAPI.updateCell(sessionId, u.rowName, u.column, u.value, u.sourceDocument, u.rowIndexId),
+        ),
+      ).then((results) => {
+        const failed = results.filter((r) => r.status === 'rejected').length;
+        const succeeded = updates.length - failed;
+
+        if (failed > 0) {
+          toast({
+            title: 'Some cells could not be saved',
+            description: `${failed} of ${updates.length} update${updates.length > 1 ? 's' : ''} failed.`,
+            variant: 'destructive',
+          });
+        } else if (updates.length === 1) {
+          const u = updates[0];
+          const rowLabel = u.rowName || (u.rowIndexId != null ? `Row ${u.rowIndexId + 1}` : 'Row');
+          toast({
+            title: allCleared ? 'Cell cleared' : 'Cell updated',
+            description: `${rowLabel} / ${u.column}`,
+          });
+        } else {
+          toast({ title: allCleared ? `${succeeded} cells cleared` : `${succeeded} cells updated` });
         }
 
-        onOptimisticCellEdit(
-          { rowName, sourceDocument, rowIndex: rowIndexId },
-          key,
-          String(newValue ?? ''),
-        );
+        onRefreshData();
+      });
 
-        schematiqAPI.updateCell(
-          sessionId,
-          rowName,
-          key,
-          String(newValue ?? ''),
-          sourceDocument,
-          rowIndexId
-        )
-          .then(() => {
-            const rowLabel = rowName || (rowIndexId != null ? `Row ${rowIndexId + 1}` : 'Row');
-            toast({ title: 'Cell updated', description: `${rowLabel} / ${key}` });
-            onRefreshData();
-          })
-          .catch((err: any) => {
-            toast({
-              title: 'Cell update failed',
-              description: err?.response?.data?.detail || err?.message || 'Could not update cell',
-              variant: 'destructive',
-            });
-            onRefreshData();
-          });
-      }
+      return;
+    }
+
+    for (const change of changes) {
+      const [rowIndex, prop, oldValue, newValue] = change;
+      if (oldValue === newValue || prop == null) continue;
+      const key = String(prop);
 
       if (activeSheet === 'schema') {
         const existing = schemaColumns[rowIndex];
@@ -825,7 +892,7 @@ export function SpreadsheetSurface({
           });
       }
     }
-  }, [activeSheet, data.rows, observationUnitRows, onEditFollowUp, onOptimisticCellEdit, onRefresh, onRefreshData, schemaColumns, sessionId, toast]);
+  }, [activeSheet, data.rows, hotTableRef, observationUnitRows, onEditFollowUp, onOptimisticCellEdit, onRefresh, onRefreshData, schemaColumns, sessionId, toast]);
 
   const handleBeforeRemoveRow = useCallback(
     (_index: number, _amount: number, physicalRows: number[], _source?: string): boolean | void => {
@@ -940,6 +1007,161 @@ export function SpreadsheetSurface({
     [activeSheet, onRefresh, schemaColumns, sessionId, sheet.columns, toast],
   );
 
+  // Resolve the schema-column names covered by the current grid selection,
+  // excluding the fixed provenance columns (_row_name / _source_document).
+  // Shared by the "Delete column" menu item and the Delete-key shortcut.
+  const selectedSchemaColumnNames = useCallback(
+    (hot: any): string[] => {
+      const selection: number[][] = typeof hot?.getSelected === 'function' ? hot.getSelected() || [] : [];
+      const cols = new Set<number>();
+      for (const range of selection) {
+        const [, c1, , c2] = range;
+        const from = Math.min(c1, c2);
+        const to = Math.max(c1, c2);
+        for (let c = from; c <= to; c += 1) if (c >= 0) cols.add(c);
+      }
+      const keys = Array.from(cols)
+        .map((c) => sheet.columns[c]?.key)
+        .filter((key): key is string => Boolean(key) && !key.startsWith('_'));
+      // Keep only keys that are real schema columns (never provenance/grouping).
+      return keys.filter((key) => schemaColumns.some((col) => col.name === key));
+    },
+    [schemaColumns, sheet.columns],
+  );
+
+  // Delete one or more schema columns (header + values, from both the Schema
+  // and Data views) via the schema API, then refresh. Shared by the context
+  // menu item and the Delete-key shortcut.
+  const deleteSchemaColumns = useCallback(
+    (names: string[]) => {
+      if (names.length === 0 || !sessionId) return;
+      Promise.allSettled(names.map((name) => schemaAPI.deleteColumn(sessionId, name)))
+        .then((results) => {
+          const failed = results.filter((r) => r.status === 'rejected').length;
+          if (failed > 0) {
+            toast({
+              title: 'Column delete failed',
+              description: `${failed} of ${names.length} column${names.length > 1 ? 's' : ''} could not be deleted.`,
+              variant: 'destructive',
+            });
+          } else {
+            toast({
+              title: names.length > 1 ? 'Columns deleted' : 'Column deleted',
+              description: names.join(', '),
+            });
+          }
+          // Deleting a column does not invalidate the remaining columns'
+          // extracted values, so it must not flag a re-extract.
+          onRefresh();
+        });
+    },
+    [onRefresh, sessionId, toast],
+  );
+
+  // Excel-style: when one or more whole columns are selected (by clicking the
+  // column header) and the user presses Delete/Backspace, remove the column(s)
+  // entirely rather than clearing cell contents. A partial (cell-level)
+  // selection keeps the default behaviour, which clears contents and routes
+  // through handleChanges.
+  const handleBeforeKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (activeSheet !== 'data') return;
+      if (event.key !== 'Delete' && event.key !== 'Backspace') return;
+      const hot = hotTableRef.current?.hotInstance as any;
+      if (!hot?.selection?.isSelectedByColumnHeader?.()) return;
+      const names = selectedSchemaColumnNames(hot);
+      if (names.length === 0) return;
+      event.stopImmediatePropagation();
+      event.preventDefault();
+      deleteSchemaColumns(names);
+    },
+    [activeSheet, deleteSchemaColumns, hotTableRef, selectedSchemaColumnNames],
+  );
+
+  // Latest-value ref so the menu configs below can be built once (stable
+  // references) while still acting on current data. Rebuilding the dropdown
+  // config whenever `sheet`/`schemaColumns` re-memo (every data refresh) would
+  // change its reference and make the @handsontable/react wrapper re-push — and
+  // thus re-initialize — the filters plugin, wiping the active filter that
+  // `markFilterSettingsInitOnly` works to preserve.
+  const menuActionsRef = useRef<{
+    selectedNames: (hot: any) => string[];
+    deleteColumns: (names: string[]) => void;
+  }>({ selectedNames: () => [], deleteColumns: () => {} });
+  menuActionsRef.current = {
+    selectedNames: selectedSchemaColumnNames,
+    deleteColumns: deleteSchemaColumns,
+  };
+
+  // Custom Data-sheet menu items shared by the right-click context menu and the
+  // column-header dropdown. Handsontable disables its native "Remove column"
+  // whenever the grid uses an object data source *or* a `columns` option (both
+  // true here), so column deletion was unreachable from either menu. These add a
+  // working "Delete column" (removes the schema column, header + values, via the
+  // schema API) and a "Clear cell(s)" item that is not header-gated like the
+  // native "Clear column". Built with a stable identity (see menuActionsRef).
+  const customColumnMenuItems = useMemo(
+    () => ({
+      delete_schema_column: {
+        name(this: any): string {
+          return menuActionsRef.current.selectedNames(this).length > 1 ? 'Delete columns' : 'Delete column';
+        },
+        disabled(this: any): boolean {
+          return menuActionsRef.current.selectedNames(this).length === 0;
+        },
+        callback(this: any): void {
+          menuActionsRef.current.deleteColumns(menuActionsRef.current.selectedNames(this));
+        },
+      },
+      clear_selected_cells: {
+        name: 'Clear cell(s)',
+        disabled(this: any): boolean {
+          const selection = typeof this?.getSelected === 'function' ? this.getSelected() : null;
+          return !selection || selection.length === 0;
+        },
+        callback(this: any): void {
+          // Routes through afterChange -> handleChanges, which persists the
+          // empties and shows a single summary toast.
+          if (typeof this?.emptySelectedCells === 'function') this.emptySelectedCells('edit');
+        },
+      },
+    }),
+    [],
+  );
+
+  // Right-click context menu (Data sheet only; other sheets keep the default).
+  const contextMenuConfig = useMemo(() => {
+    if (activeSheet !== 'data') return true;
+    return {
+      items: {
+        ...customColumnMenuItems,
+        sep_1: { name: '---------' },
+        copy: {},
+        cut: {},
+      },
+    };
+  }, [activeSheet, customColumnMenuItems]);
+
+  // Column-header dropdown (the ▼ button). This is a *separate* menu from the
+  // context menu; the default one is what showed the greyed-out "Remove column",
+  // so the header dropdown also needs the custom items. The predefined
+  // `filter_*` keys are re-included so the "Filter by condition/value" UI is
+  // preserved.
+  const dropdownMenuConfig = useMemo(() => {
+    if (activeSheet !== 'data') return true;
+    return {
+      items: {
+        ...customColumnMenuItems,
+        sep_1: { name: '---------' },
+        filter_by_condition: {},
+        filter_operators: {},
+        filter_by_condition2: {},
+        filter_by_value: {},
+        filter_action_bar: {},
+      },
+    };
+  }, [activeSheet, customColumnMenuItems]);
+
   if (!sessionId) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
@@ -995,9 +1217,9 @@ export function SpreadsheetSurface({
         // full row, so a row keeps its height at any scroll position. See
         // handsontable/handsontable#493, #1213, #5241.
         autoRowSize={true}
-        contextMenu
+        contextMenu={contextMenuConfig}
         filters
-        dropdownMenu
+        dropdownMenu={dropdownMenuConfig}
         columnSorting={!hasMultiRowGroup}
         copyPaste
         undo
@@ -1012,6 +1234,7 @@ export function SpreadsheetSurface({
         afterFilter={applyGroupMerges}
         beforeRemoveRow={handleBeforeRemoveRow}
         beforeRemoveCol={handleBeforeRemoveCol}
+        beforeKeyDown={handleBeforeKeyDown}
         afterChange={(changes, source) => {
           handleChanges(changes, source);
           if (source !== 'loadData') onEditEnd();

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -76,7 +76,7 @@ export function SpreadsheetSurface({
   // Fires on each mouse click of a grounded data cell, so the source panel can
   // re-scroll to the highlight even when the same cell is clicked again.
   onGroundingScrollRequest?: () => void;
-  onRefresh: () => void;
+  onRefresh: () => void | Promise<void>;
   // Row-data-only refresh after a Data-sheet cell edit (no status/schema churn).
   onRefreshData: () => void;
   // Apply the edited values to React state immediately so the grid does not
@@ -1084,9 +1084,18 @@ export function SpreadsheetSurface({
   // Delete one or more schema columns (header + values, from both the Schema
   // and Data views) via the schema API, then refresh. Shared by the context
   // menu item and the Delete-key shortcut.
+  // Guards against a double-fire of the same delete action. Without it the
+  // first call deletes the column, the second fails "column not found" (a
+  // spurious "Column delete failed" toast), and the second call's write races
+  // the refresh's getData so the grid momentarily blanks. The guard is held
+  // across the request AND the follow-up refresh so a delayed second fire
+  // during the refresh window is also dropped.
+  const deletingColumnsRef = useRef(false);
+
   const deleteSchemaColumns = useCallback(
     (names: string[]) => {
-      if (names.length === 0 || !sessionId) return;
+      if (names.length === 0 || !sessionId || deletingColumnsRef.current) return;
+      deletingColumnsRef.current = true;
       Promise.allSettled(names.map((name) => schemaAPI.deleteColumn(sessionId, name)))
         .then((results) => {
           const failed = results.filter((r) => r.status === 'rejected').length;
@@ -1103,8 +1112,12 @@ export function SpreadsheetSurface({
             });
           }
           // Deleting a column does not invalidate the remaining columns'
-          // extracted values, so it must not flag a re-extract.
-          onRefresh();
+          // extracted values, so it must not flag a re-extract. Return the
+          // refresh promise so the guard stays held until the grid has caught up.
+          return onRefresh();
+        })
+        .finally(() => {
+          deletingColumnsRef.current = false;
         });
     },
     [onRefresh, sessionId, toast],

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -227,13 +227,22 @@ function Workspace() {
 
   const refreshSilent = useCallback(() => refreshData({ silent: true }), [refreshData]);
 
-  const applyOptimisticCellEdit = useCallback((
-    identity: { rowName: string; sourceDocument?: string; rowIndex?: number },
-    column: string,
-    value: string,
+  const applyOptimisticCellEdits = useCallback((
+    edits: {
+      identity: { rowName: string; sourceDocument?: string; rowIndex?: number };
+      column: string;
+      value: string;
+    }[],
   ) => {
+    if (edits.length === 0) return;
     deferredDataRef.current = null;
-    const patch = (current: PaginatedData) => patchDataCell(current, identity, column, value);
+    // Fold every edit into ONE functional update so a whole afterChange batch
+    // produces a single state transition. Doing N separate setData calls inside
+    // Handsontable's synchronous afterChange (a non-React event) drove a render
+    // cascade that exceeded React's update depth for multi-cell clears; a single
+    // atomic patch makes a multi-cell clear behave like the single-cell path.
+    const patch = (current: PaginatedData) =>
+      edits.reduce((acc, e) => patchDataCell(acc, e.identity, e.column, e.value), current);
     setData(patch);
     setUnitData(patch);
   }, []);
@@ -804,7 +813,7 @@ function Workspace() {
         onGroundingScrollRequest={() => setGroundingScrollNonce((n) => n + 1)}
         onRefresh={() => void refresh({ silent: true })}
         onRefreshData={refreshAfterEdit}
-        onOptimisticCellEdit={applyOptimisticCellEdit}
+        onOptimisticCellEdit={applyOptimisticCellEdits}
         onEditFollowUp={notifyEditFollowUp}
         onEditEnd={flushDeferredData}
         layoutRevision={gridLayoutRevision}

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -74,7 +74,6 @@ import {
 import { NewProjectDialog } from './NewProjectDialog';
 import { PendingRerunBanner } from './PendingRerunBanner';
 import { ProjectDetailsDialog } from './ProjectDetailsDialog';
-import ReportIssueDialog from '@/components/ReportIssueDialog/ReportIssueDialog';
 import { SpreadsheetChrome } from './SpreadsheetChrome';
 import { useAddDocuments } from './hooks/useAddDocuments';
 import { useReextraction } from './hooks/useReextraction';
@@ -114,7 +113,6 @@ function Workspace() {
   const [sessionMode, setSessionMode] = useState<WorkspaceSessionMode>(requestedMode);
   const [projectDialogOpen, setProjectDialogOpen] = useState(!sessionId);
   const [detailsDialogOpen, setDetailsDialogOpen] = useState(false);
-  const [reportOpen, setReportOpen] = useState(false);
   const [status, setStatus] = useState<ScheMatiQStatus | null>(null);
   const [session, setSession] = useState<VisualizationSession | null>(null);
   const [schema, setSchema] = useState<SchemaData | null>(null);
@@ -228,6 +226,24 @@ function Workspace() {
   const refreshAfterEdit = useCallback(() => refreshData({ silent: true, force: true }), [refreshData]);
 
   const refreshSilent = useCallback(() => refreshData({ silent: true }), [refreshData]);
+
+  // Refresh only the schema (column list) without reloading the row data, so an
+  // action that changes columns but not the data — a column delete — does not
+  // change the grid's data identity and reset its scroll position.
+  const refreshSchemaOnly = useCallback(async () => {
+    if (!sessionId) return;
+    try {
+      if (sessionMode === 'load') {
+        const loadSession = await loadAPI.getSession(sessionId).catch(() => null);
+        if (loadSession) setSchema(schemaFromLoadSession(loadSession));
+      } else {
+        const nextSchema = await schematiqAPI.getSchema(sessionId).catch(() => null);
+        if (nextSchema) setSchema(nextSchema);
+      }
+    } catch {
+      /* keep the current schema on a transient error */
+    }
+  }, [sessionId, sessionMode]);
 
   const applyOptimisticCellEdits = useCallback((
     edits: {
@@ -817,6 +833,7 @@ function Workspace() {
         onGroundingHighlight={handleGroundingHighlight}
         onGroundingScrollRequest={() => setGroundingScrollNonce((n) => n + 1)}
         onRefresh={() => refresh({ silent: true })}
+        onSchemaRefresh={refreshSchemaOnly}
         onRefreshData={refreshAfterEdit}
         onOptimisticCellEdit={applyOptimisticCellEdits}
         onEditFollowUp={notifyEditFollowUp}
@@ -874,7 +891,6 @@ function Workspace() {
         onRunPendingEdits={runPendingEdits}
         onAddDocuments={() => setActiveSheet('documents')}
         onApplyFormat={applyTableFormat}
-        onReportIssue={() => setReportOpen(true)}
         rerunDisabled={!sessionId || !pendingRerunKind || rerunStarting}
       />
 
@@ -1230,14 +1246,6 @@ function Workspace() {
         documents={documents}
         config={config}
         costEstimate={costEstimate}
-      />
-
-      <ReportIssueDialog
-        open={reportOpen}
-        onOpenChange={setReportOpen}
-        sessionId={sessionId}
-        sessionMode={sessionMode}
-        activeSheet={activeSheet}
       />
 
       <Dialog

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -74,6 +74,7 @@ import {
 import { NewProjectDialog } from './NewProjectDialog';
 import { PendingRerunBanner } from './PendingRerunBanner';
 import { ProjectDetailsDialog } from './ProjectDetailsDialog';
+import ReportIssueDialog from '@/components/ReportIssueDialog/ReportIssueDialog';
 import { SpreadsheetChrome } from './SpreadsheetChrome';
 import { useAddDocuments } from './hooks/useAddDocuments';
 import { useReextraction } from './hooks/useReextraction';
@@ -113,6 +114,7 @@ function Workspace() {
   const [sessionMode, setSessionMode] = useState<WorkspaceSessionMode>(requestedMode);
   const [projectDialogOpen, setProjectDialogOpen] = useState(!sessionId);
   const [detailsDialogOpen, setDetailsDialogOpen] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
   const [status, setStatus] = useState<ScheMatiQStatus | null>(null);
   const [session, setSession] = useState<VisualizationSession | null>(null);
   const [schema, setSchema] = useState<SchemaData | null>(null);
@@ -891,6 +893,7 @@ function Workspace() {
         onRunPendingEdits={runPendingEdits}
         onAddDocuments={() => setActiveSheet('documents')}
         onApplyFormat={applyTableFormat}
+        onReportIssue={() => setReportOpen(true)}
         rerunDisabled={!sessionId || !pendingRerunKind || rerunStarting}
       />
 
@@ -1246,6 +1249,14 @@ function Workspace() {
         documents={documents}
         config={config}
         costEstimate={costEstimate}
+      />
+
+      <ReportIssueDialog
+        open={reportOpen}
+        onOpenChange={setReportOpen}
+        sessionId={sessionId}
+        sessionMode={sessionMode}
+        activeSheet={activeSheet}
       />
 
       <Dialog

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -267,10 +267,13 @@ function Workspace() {
       if (!silent) setDataLoading(true);
       try {
         const [nextData, nextDocuments] = await Promise.all([
-          fetchData().catch(() => emptyData),
+          // Keep the current rows if the fetch fails (null) rather than blanking
+          // the grid with emptyData — e.g. a transient error during a
+          // structural refresh right after a column delete.
+          fetchData().catch(() => null),
           fetchDocuments().catch(() => null),
         ]);
-        applyData(nextData, options);
+        if (nextData) applyData(nextData, options);
         setDocuments(nextDocuments);
       } finally {
         if (!silent) setDataLoading(false);
@@ -811,7 +814,7 @@ function Workspace() {
         onSelectionChange={updateSheetSelection}
         onGroundingHighlight={handleGroundingHighlight}
         onGroundingScrollRequest={() => setGroundingScrollNonce((n) => n + 1)}
-        onRefresh={() => void refresh({ silent: true })}
+        onRefresh={() => refresh({ silent: true })}
         onRefreshData={refreshAfterEdit}
         onOptimisticCellEdit={applyOptimisticCellEdits}
         onEditFollowUp={notifyEditFollowUp}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -367,7 +367,12 @@ export const schematiqAPI = {
   ): Promise<{ status: string; session_id: string; row_name: string; column: string; value: string; previous_value?: any }> => {
     const params: Record<string, string | number> = { row_name: rowName, column, value };
     if (sourceDocument) params.source_document = sourceDocument;
-    if (!rowName && rowIndex != null) params.row_index = rowIndex;
+    // Always send the stable row index when we have it. The backend matches by
+    // row_name first and only uses row_index as a fallback, so this is safe even
+    // when a name is present; it lets clears/edits still resolve when the row's
+    // stored identity key differs from the displayed name (e.g. By-Document rows
+    // keyed under _unit_name), which otherwise failed with "row not found".
+    if (rowIndex != null) params.row_index = rowIndex;
     const response = await api.put(`/schematiq/cell/${sessionId}`, null, { params });
     return response.data;
   },


### PR DESCRIPTION
Multi-cell clear no longer loops and persists every cell (batch coalesced; per-session write lock; row_index fallback). Column delete is guarded against a double-fire and now works for names with slashes (:path route). Delete column works from both menus; one summary toast per interaction.