### PR TITLE
feat(support): drag-and-drop image attachments

### DIFF
--- a/backend/app/api/routes/support.py
+++ b/backend/app/api/routes/support.py
@@ -42,6 +42,7 @@ class ScreenshotAttachment(BaseModel):
 class IssueReportRequest(BaseModel):
     session_id: Optional[str] = Field(None, max_length=200)
     description: str = Field(..., min_length=1, max_length=5000)
+    reporter_email: Optional[str] = Field(None, max_length=254)
     project_json: Optional[str] = Field(None)          # full export JSON as text
     client_context: Optional[Dict[str, Any]] = Field(None)
     screenshots: Optional[List[ScreenshotAttachment]] = Field(None)
@@ -158,6 +159,20 @@ async def submit_issue_report(request: IssueReportRequest):
         session_id = request.session_id or ""
         context_rows = _build_context_rows(session_id, request.client_context)
 
+        # Optional reporter email: show it in the report and use it as Reply-To so
+        # a reply reaches them. Guard against header injection (no CR/LF) and only
+        # trust something that at least looks like an address.
+        reporter_email = (request.reporter_email or "").strip()
+        valid_email = (
+            reporter_email
+            and "@" in reporter_email
+            and "\n" not in reporter_email
+            and "\r" not in reporter_email
+        )
+        reply_to = reporter_email if valid_email else None
+        if reporter_email:
+            context_rows.insert(0, ("Reporter email", reporter_email))
+
         project_bytes: Optional[bytes] = (
             request.project_json.encode("utf-8") if request.project_json else None
         )
@@ -225,6 +240,7 @@ async def submit_issue_report(request: IssueReportRequest):
                 attachment_subtype=attachment_subtype,
                 attachment_note=attachment_note,
                 screenshots=shots,
+                reply_to=reply_to,
                 wait=True,
             )
         )

--- a/backend/app/core/email_alerts.py
+++ b/backend/app/core/email_alerts.py
@@ -83,6 +83,7 @@ def _send_email(
     attachment: Optional[Tuple[str, bytes, str]] = None,
     attachments: Optional[List[Tuple[str, bytes, str]]] = None,
     wait: bool = False,
+    reply_to: Optional[str] = None,
 ) -> Optional[str]:
     """Send an email via Gmail API. Never raises.
 
@@ -121,6 +122,8 @@ def _send_email(
                 msg["To"] = to_addr
                 if cc_list:
                     msg["Cc"] = ", ".join(cc_list)
+                if reply_to:
+                    msg["Reply-To"] = reply_to
                 body = MIMEMultipart("alternative")
                 body.attach(MIMEText(html_body, "html"))
                 msg.attach(body)
@@ -139,6 +142,8 @@ def _send_email(
                 msg["To"] = to_addr
                 if cc_list:
                     msg["Cc"] = ", ".join(cc_list)
+                if reply_to:
+                    msg["Reply-To"] = reply_to
                 msg.attach(MIMEText(html_body, "html"))
 
             raw = base64.urlsafe_b64encode(msg.as_bytes()).decode()
@@ -260,6 +265,7 @@ def send_issue_report(
     screenshots: Optional[List[Tuple[str, bytes, str]]] = None,
     cc: Optional[Union[List[str], str]] = None,
     wait: bool = False,
+    reply_to: Optional[str] = None,
 ) -> Optional[str]:
     """Email a user-submitted issue report to SUPPORT_EMAIL_TO. Never raises.
 
@@ -323,4 +329,5 @@ def send_issue_report(
         cc=target_cc,
         attachments=all_attachments,
         wait=wait,
+        reply_to=reply_to,
     )

--- a/frontend/src/components/ReportIssueDialog/ReportIssueDialog.tsx
+++ b/frontend/src/components/ReportIssueDialog/ReportIssueDialog.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
 import { supportAPI } from '../../services/api';
 
 interface ReportIssueDialogProps {
@@ -52,6 +53,7 @@ const ReportIssueDialog: React.FC<ReportIssueDialogProps> = ({
   activeSheet,
 }) => {
   const [description, setDescription] = useState('');
+  const [email, setEmail] = useState('');
   const [shots, setShots] = useState<Shot[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [done, setDone] = useState(false);
@@ -60,6 +62,7 @@ const ReportIssueDialog: React.FC<ReportIssueDialogProps> = ({
 
   const reset = useCallback(() => {
     setDescription('');
+    setEmail('');
     setShots([]);
     setSubmitting(false);
     setDone(false);
@@ -116,6 +119,7 @@ const ReportIssueDialog: React.FC<ReportIssueDialogProps> = ({
       const res = await supportAPI.reportIssue({
         session_id: sessionId,
         description: text,
+        reporter_email: email.trim() || undefined,
         project_json: projectJson,
         screenshots,
         client_context: {
@@ -175,6 +179,18 @@ const ReportIssueDialog: React.FC<ReportIssueDialogProps> = ({
               rows={6}
               className="resize-none"
             />
+
+            <div>
+              <Input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="Your email (optional)"
+              />
+              <p className="mt-1.5 text-xs text-muted-foreground">
+                Add your email if you'd like us to reply or let you know when it's fixed.
+              </p>
+            </div>
 
             <div>
               <Button

--- a/frontend/src/components/ReportIssueDialog/ReportIssueDialog.tsx
+++ b/frontend/src/components/ReportIssueDialog/ReportIssueDialog.tsx
@@ -58,7 +58,9 @@ const ReportIssueDialog: React.FC<ReportIssueDialogProps> = ({
   const [submitting, setSubmitting] = useState(false);
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [dragActive, setDragActive] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const dragDepth = useRef(0);
 
   const reset = useCallback(() => {
     setDescription('');
@@ -67,6 +69,8 @@ const ReportIssueDialog: React.FC<ReportIssueDialogProps> = ({
     setSubmitting(false);
     setDone(false);
     setError(null);
+    setDragActive(false);
+    dragDepth.current = 0;
   }, []);
 
   const handleOpenChange = useCallback((next: boolean) => {
@@ -88,6 +92,41 @@ const ReportIssueDialog: React.FC<ReportIssueDialogProps> = ({
   const onFileInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) addFiles(Array.from(e.target.files));
     e.target.value = '';
+  }, [addFiles]);
+
+  // Drag a file from the OS onto the dialog to attach it, same as the picker.
+  // A depth counter keeps the highlight stable while dragging over child nodes.
+  const isFileDrag = (e: React.DragEvent) =>
+    Array.from(e.dataTransfer?.types || []).includes('Files');
+
+  const onDragEnter = useCallback((e: React.DragEvent) => {
+    if (!isFileDrag(e)) return;
+    e.preventDefault();
+    dragDepth.current += 1;
+    setDragActive(true);
+  }, []);
+
+  const onDragOver = useCallback((e: React.DragEvent) => {
+    if (isFileDrag(e)) e.preventDefault();
+  }, []);
+
+  const onDragLeave = useCallback((e: React.DragEvent) => {
+    if (!isFileDrag(e)) return;
+    e.preventDefault();
+    dragDepth.current -= 1;
+    if (dragDepth.current <= 0) {
+      dragDepth.current = 0;
+      setDragActive(false);
+    }
+  }, []);
+
+  const onDrop = useCallback((e: React.DragEvent) => {
+    if (!isFileDrag(e)) return;
+    e.preventDefault();
+    dragDepth.current = 0;
+    setDragActive(false);
+    const files = e.dataTransfer?.files;
+    if (files && files.length) addFiles(Array.from(files));
   }, [addFiles]);
 
   const removeShot = useCallback((id: string) => {
@@ -142,7 +181,19 @@ const ReportIssueDialog: React.FC<ReportIssueDialogProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-[480px]">
+      <DialogContent
+        className="relative sm:max-w-[480px]"
+        onDragEnter={onDragEnter}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+      >
+        {!done && dragActive && (
+          <div className="pointer-events-none absolute inset-0 z-50 flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-primary bg-background/90 text-primary">
+            <ImagePlus className="h-8 w-8" />
+            <span className="text-sm font-medium">Drop image to attach</span>
+          </div>
+        )}
         {done ? (
           <div className="flex flex-col items-center gap-3 py-6 text-center">
             <CheckCircle2 className="h-10 w-10 text-green-600" />
@@ -204,7 +255,8 @@ const ReportIssueDialog: React.FC<ReportIssueDialogProps> = ({
                 Add image
               </Button>
               <p className="mt-1.5 text-xs text-muted-foreground">
-                We recommend attaching a screenshot of the problem ({shots.length}/{MAX_SHOTS}).
+                We recommend attaching a screenshot. Drag an image here or use Add image
+                ({shots.length}/{MAX_SHOTS}).
               </p>
               <input
                 ref={fileInputRef}

--- a/frontend/src/components/ReportIssueDialog/ReportIssueDialog.tsx
+++ b/frontend/src/components/ReportIssueDialog/ReportIssueDialog.tsx
@@ -182,7 +182,7 @@ const ReportIssueDialog: React.FC<ReportIssueDialogProps> = ({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="relative sm:max-w-[480px]"
+        className="sm:max-w-[480px]"
         onDragEnter={onDragEnter}
         onDragOver={onDragOver}
         onDragLeave={onDragLeave}

--- a/frontend/src/components/ReportIssueDialog/ReportIssueDialog.tsx
+++ b/frontend/src/components/ReportIssueDialog/ReportIssueDialog.tsx
@@ -31,6 +31,19 @@ interface Shot {
 const MAX_SHOTS = 5;
 const MAX_EACH_BYTES = 8 * 1024 * 1024; // 8 MB per image
 
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|bmp|svg|heic|heif)$/i;
+
+// Dropped files sometimes arrive with an empty File.type, so fall back to the
+// filename extension when deciding whether something is an image.
+const isImageFile = (f: File): boolean =>
+  (f.type.startsWith('image/') || IMAGE_EXT_RE.test(f.name)) && f.size <= MAX_EACH_BYTES;
+
+const guessMime = (f: File): string => {
+  if (f.type) return f.type;
+  const ext = (f.name.match(IMAGE_EXT_RE)?.[1] || 'png').toLowerCase();
+  return `image/${ext === 'jpg' ? 'jpeg' : ext}`;
+};
+
 const readImage = (file: File): Promise<Shot | null> =>
   new Promise((resolve) => {
     const reader = new FileReader();
@@ -38,7 +51,7 @@ const readImage = (file: File): Promise<Shot | null> =>
       resolve({
         id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
         name: file.name || 'screenshot.png',
-        mime: file.type || 'image/png',
+        mime: guessMime(file),
         dataUrl: String(reader.result || ''),
       });
     reader.onerror = () => resolve(null);
@@ -79,9 +92,7 @@ const ReportIssueDialog: React.FC<ReportIssueDialogProps> = ({
   }, [onOpenChange, reset]);
 
   const addFiles = useCallback(async (files: File[]) => {
-    const images = files.filter(
-      (f) => f.type.startsWith('image/') && f.size <= MAX_EACH_BYTES,
-    );
+    const images = files.filter(isImageFile);
     if (images.length === 0) return;
     const read = (await Promise.all(images.map(readImage))).filter(
       (s): s is Shot => s !== null,
@@ -100,18 +111,19 @@ const ReportIssueDialog: React.FC<ReportIssueDialogProps> = ({
     Array.from(e.dataTransfer?.types || []).includes('Files');
 
   const onDragEnter = useCallback((e: React.DragEvent) => {
-    if (!isFileDrag(e)) return;
+    // Always prevent default so the browser does not try to open the file.
     e.preventDefault();
     dragDepth.current += 1;
-    setDragActive(true);
+    if (isFileDrag(e)) setDragActive(true);
   }, []);
 
   const onDragOver = useCallback((e: React.DragEvent) => {
-    if (isFileDrag(e)) e.preventDefault();
-  }, []);
+    // A drop event only fires if dragover cancels the default, so do it always.
+    e.preventDefault();
+    if (!dragActive && isFileDrag(e)) setDragActive(true);
+  }, [dragActive]);
 
   const onDragLeave = useCallback((e: React.DragEvent) => {
-    if (!isFileDrag(e)) return;
     e.preventDefault();
     dragDepth.current -= 1;
     if (dragDepth.current <= 0) {
@@ -121,7 +133,6 @@ const ReportIssueDialog: React.FC<ReportIssueDialogProps> = ({
   }, []);
 
   const onDrop = useCallback((e: React.DragEvent) => {
-    if (!isFileDrag(e)) return;
     e.preventDefault();
     dragDepth.current = 0;
     setDragActive(false);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -123,6 +123,7 @@ export const supportAPI = {
   reportIssue: async (data: {
     session_id?: string;
     description: string;
+    reporter_email?: string;
     project_json?: string;
     screenshots?: { name?: string; mime: string; data_b64: string }[];
     client_context?: Record<string, unknown>;


### PR DESCRIPTION
## Problem
Attaching an image required clicking Add image and browsing. Dragging a file straight onto the dialog is faster.

## Solution
Make the report dialog a drop zone. Dragging image files onto it attaches them through the same addFiles path as the picker (same image filter, size cap, and 5-image limit). A dashed overlay ('Drop image to attach') shows while dragging; a depth counter keeps it stable over child nodes, and only file drags trigger it.

## Verify
- Open the report dialog, drag an image file from the OS onto it, confirm the thumbnail appears and the report sends with it attached.
- ( cd frontend && npx tsc --noEmit ) passes.