### PR TITLE
Fix header/cell border misalignment on horizontal scroll

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -1294,6 +1294,17 @@ export function SpreadsheetSurface({
         // full row, so a row keeps its height at any scroll position. See
         // handsontable/handsontable#493, #1213, #5241.
         autoRowSize={true}
+        // Handsontable virtualises columns by default: only columns currently
+        // in the horizontal viewport are kept in the DOM, and the header row
+        // (thead) and body rows are virtualised independently. Over long
+        // scroll sessions their internal offset bookkeeping drifts apart, so
+        // header cell borders (and the filter/sort dropdown arrows anchored
+        // to them) stop lining up with the body cells beneath them -- a
+        // longstanding Handsontable rendering issue (e.g.
+        // handsontable/handsontable#7306, #4426). Schema/data sheets here
+        // stay in the tens-of-columns range, so disabling column
+        // virtualization removes the desync at a negligible rendering cost.
+        renderAllColumns
         contextMenu={contextMenuConfig}
         filters
         dropdownMenu={dropdownMenuConfig}


### PR DESCRIPTION
## Problem
Scrolling right through many columns causes column header borders (and their filter/sort dropdown arrows) to drift out of alignment with the body cells beneath them. Works correctly near the start of the sheet, breaks progressively further right.

## Solution
Handsontable virtualizes columns by default — only columns in the current horizontal viewport are kept in the DOM, with the header row and body rows virtualized independently. Over long scroll sessions their internal offset bookkeeping drifts apart, a known Handsontable rendering issue (handsontable/handsontable#7306, #4426). Added `renderAllColumns` to disable column virtualization; our sheets stay in the tens-of-columns range so the rendering cost is negligible.

## Verify
- Fresh clone + `git apply --ignore-whitespace --check` — passes
- `npx tsc --noEmit` on the applied clone — passes, 0 errors
- Manual: open a sheet with 10+ columns, scroll right to the last columns, confirm header borders/dropdown arrows line up with cell borders at every scroll position