### PR TITLE
Fix header/cell border drift at the far-right scroll edge

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -117,6 +117,7 @@ export function SpreadsheetSurface({
   }, []);
   const lastGridSizeRef = useRef({ width: 0, height: 0 });
   const [gridSize, setGridSize] = useState({ width: 0, height: 0 });
+  const scrollResyncTimerRef = useRef<number | undefined>(undefined);
 
   const applyGridSize = useCallback((width: number, height: number) => {
     const nextWidth = Math.max(320, Math.floor(width));
@@ -151,6 +152,36 @@ export function SpreadsheetSurface({
     hot.refreshDimensions();
     applyGridSize(width, height);
   }, [applyGridSize, hotTableRef]);
+
+  // At the far-right edge of horizontal scroll, Handsontable's sticky header
+  // clone (ht_clone_top) and the body's own scroll container occasionally
+  // settle on slightly different maximum-scroll offsets -- the body hits its
+  // scrollLeft ceiling first, but the header clone (positioned by its own
+  // internal offset bookkeeping, not by scrollLeft directly) overshoots by a
+  // few pixels, so its column borders end up past the body's. It only shows
+  // up once you're pinned to the end of the scroll range; the fix is to force
+  // Handsontable to recompute and repaint both overlays' offsets once
+  // scrolling settles, which resyncs them to the true clamped position. A
+  // short debounce (not every scroll tick) keeps this from adding render
+  // cost during active scrolling. See handsontable/handsontable#7306, #4426.
+  const resyncAfterScroll = useCallback(() => {
+    if (scrollResyncTimerRef.current !== undefined) {
+      window.clearTimeout(scrollResyncTimerRef.current);
+    }
+    scrollResyncTimerRef.current = window.setTimeout(() => {
+      const hot = hotTableRef.current?.hotInstance;
+      if (!hot || hot.isDestroyed) return;
+      hot.render();
+    }, 80);
+  }, [hotTableRef]);
+
+  useEffect(() => {
+    return () => {
+      if (scrollResyncTimerRef.current !== undefined) {
+        window.clearTimeout(scrollResyncTimerRef.current);
+      }
+    };
+  }, []);
 
   useLayoutEffect(() => {
     const element = gridContainerEl;
@@ -1309,6 +1340,7 @@ export function SpreadsheetSurface({
         }}
         afterColumnSort={applyGroupMerges}
         afterFilter={applyGroupMerges}
+        afterScrollHorizontally={resyncAfterScroll}
         beforeRemoveRow={handleBeforeRemoveRow}
         beforeRemoveCol={handleBeforeRemoveCol}
         beforeKeyDown={handleBeforeKeyDown}


### PR DESCRIPTION
## Problem
When scrolling all the way to the right, the body stops at its scroll ceiling but the sticky header clone overshoots by a few pixels, so header borders (and their dropdown arrows) end up misaligned with the body cells beneath them. Only visible pinned at the max scroll position.

## Solution
Handsontable's header clone (`ht_clone_top`) and the body scroll container are positioned by separate internal mechanisms; at the scroll ceiling they can settle a few pixels apart. Added a debounced `hot.render()` call on `afterScrollHorizontally` (80ms after scrolling settles) to force both overlays to recompute against the true clamped position.

## Verify
- Fresh clone + `git apply --ignore-whitespace --check` — passes
- `npx tsc --noEmit` on the applied clone — passes, 0 errors
- Manual: open a sheet with 10+ columns, scroll all the way right, confirm header/cell borders line up exactly at the scroll ceiling — including after resizing a column near the edge