### PR TITLE
fix(workspace): keep column headers aligned when scrolled fully right

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -152,6 +152,47 @@ export function SpreadsheetSurface({
     applyGridSize(width, height);
   }, [applyGridSize, hotTableRef]);
 
+  // Keep the column headers lined up with their columns at the right end of the
+  // horizontal scroll range.
+  //
+  // Handsontable draws the headers in a separate overlay table (.ht_clone_top)
+  // and mirrors the master table's scroll position onto it with a plain
+  // `headerHolder.scrollLeft = master.scrollLeft` assignment
+  // (Overlays.syncScrollPositions). The browser clamps that assignment to the
+  // overlay's own maximum scrollLeft, and the overlay sizes its viewport itself
+  // in TopOverlay.adjustRootElementSize as
+  // `min(workspaceWidth - (hasVerticalScroll() ? scrollbarWidth : 0), rootScrollWidth)`.
+  // When that vertical-scroll check disagrees with the master's real viewport the
+  // overlay viewport ends up one scrollbar wider than the master's, so it runs out
+  // of scroll range one scrollbar early: alignment is exact everywhere until the
+  // last ~15px of the range, and once scrolled fully right every header sits
+  // ~15px to the right of the column it belongs to.
+  //
+  // Give the overlay the same maximum by extending its hider (the scrollable
+  // content) by exactly that overhang, then re-apply the master's scroll
+  // position. Both numbers are recomputed from the live DOM on every call, so
+  // this is a no-op whenever Handsontable sizes the overlay correctly (overhang
+  // 0 means the target width is the width Handsontable itself assigns).
+  const syncHeaderOverlayScroll = useCallback(() => {
+    const root = hotTableRef.current?.hotInstance?.rootElement;
+    if (!root) return;
+
+    const masterHolder = root.querySelector<HTMLElement>('.ht_master .wtHolder');
+    const headerHolder = root.querySelector<HTMLElement>('.ht_clone_top .wtHolder');
+    const masterHider = root.querySelector<HTMLElement>('.ht_master .wtHider');
+    const headerHider = root.querySelector<HTMLElement>('.ht_clone_top .wtHider');
+    if (!masterHolder || !headerHolder || !masterHider || !headerHider) return;
+
+    const overhang = Math.max(0, headerHolder.clientWidth - masterHolder.clientWidth);
+    const targetHiderWidth = masterHider.offsetWidth + overhang;
+    if (Math.abs(headerHider.offsetWidth - targetHiderWidth) >= 1) {
+      headerHider.style.width = `${targetHiderWidth}px`;
+    }
+    if (headerHolder.scrollLeft !== masterHolder.scrollLeft) {
+      headerHolder.scrollLeft = masterHolder.scrollLeft;
+    }
+  }, [hotTableRef]);
+
   useLayoutEffect(() => {
     const element = gridContainerEl;
     if (!element) return undefined;
@@ -1306,7 +1347,12 @@ export function SpreadsheetSurface({
           syncHotTableDimensions();
           applyGroupMerges();
           markFilterSettingsInitOnly();
+          syncHeaderOverlayScroll();
         }}
+        // Runs after Handsontable has drawn and (mis)clamped the header overlay's
+        // scroll position, so the compensation above lands on final values.
+        afterScrollHorizontally={syncHeaderOverlayScroll}
+        afterViewRender={syncHeaderOverlayScroll}
         afterColumnSort={applyGroupMerges}
         afterFilter={applyGroupMerges}
         beforeRemoveRow={handleBeforeRemoveRow}


### PR DESCRIPTION
Problem
Scrolling the data grid all the way right leaves every column header offset ~15px to the right of the column it belongs to. Handsontable draws the headers in a separate overlay table (.ht_clone_top) and mirrors the master scroll position with a plain `headerHolder.scrollLeft = master.scrollLeft` assignment (Overlays.syncScrollPositions), which the browser clamps to the overlay's own maximum scrollLeft. The overlay sizes its viewport in TopOverlay.adjustRootElementSize as `min(workspaceWidth - (hasVerticalScroll() ? scrollbarWidth : 0), rootScrollWidth)`; when that vertical-scroll check disagrees with the master's real viewport the overlay is one scrollbar wider than the master and runs out of scroll range one scrollbar early. Alignment is therefore exact everywhere except the last ~15px of the horizontal range.

Solution
Add syncHeaderOverlayScroll(): extend the header overlay's hider by exactly the overhang between its viewport and the master's, so both share the same maximum scrollLeft, then re-apply the master's scroll position. Values are read from the live DOM on every call, so it is a no-op (writes the same width Handsontable writes) whenever the overlay is sized correctly. Wired to afterScrollHorizontally, afterViewRender and afterInit; afterScrollHorizontally runs after Handsontable's own draw and clamped assignment.

Verify
- Open a project with enough columns to scroll horizontally, scroll fully right: every header stays aligned with its column, including at the extreme right edge.
- Mid-range scroll positions, column resize, sorting, filtering and grouping (mergeCells) are unchanged.
- `( cd frontend && npx tsc --noEmit )` passes.
- Reproduced the failure mode in a standalone Handsontable 17.0.1 harness by forcing the header overlay viewport one scrollbar wider than the master's: offset 0 at all mid positions, 10px at max-5, 15px at max; with this fix, 0 at every position.