### PR TITLE
feat(chat): model picker in chat panel + Gemini 3.6 Flash default

### DIFF
--- a/backend/app/api/routes/chat.py
+++ b/backend/app/api/routes/chat.py
@@ -39,6 +39,7 @@ async def send_chat_message(
             session_mode=request.session_mode,
             chat_id=request.chat_id,
             pinned_tool=request.pinned_tool,
+            model=request.model,
         )
         return ChatMessageResponse(
             chat_id=result["chat_id"],

--- a/backend/app/models/chat.py
+++ b/backend/app/models/chat.py
@@ -10,6 +10,7 @@ class ChatMessageRequest(BaseModel):
     chat_id: Optional[str] = None
     session_mode: Literal["schematiq", "load"] = "schematiq"
     pinned_tool: Optional[str] = None
+    model: Optional[str] = None
 
 
 class ChatConfirmRequest(BaseModel):

--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -107,8 +107,9 @@ class ChatAgentService:
         session_mode: str,
         chat_id: Optional[str] = None,
         pinned_tool: Optional[str] = None,
+        model: Optional[str] = None,
     ) -> dict[str, Any]:
-        state = self._get_or_create_session(session_id, session_mode, chat_id)
+        state = self._get_or_create_session(session_id, session_mode, chat_id, model)
         outbound_messages: list[dict[str, Any]] = []
         if state.pending:
             abort_messages, new_pending = await self._abort_pending(
@@ -152,7 +153,7 @@ class ChatAgentService:
             if self._is_stale_chat_error(exc) and chat_id:
                 logger.warning("Stale chat session %s, starting fresh: %s", chat_id, exc)
                 chat_session_store.delete(chat_id)
-                state = self._get_or_create_session(session_id, session_mode, None)
+                state = self._get_or_create_session(session_id, session_mode, None, model)
                 result = await self._run_loop(state, user_text, outbound_messages)
                 return {
                     "chat_id": state.chat_id,
@@ -302,13 +303,14 @@ class ChatAgentService:
         session_id: str,
         session_mode: str,
         chat_id: Optional[str],
+        model: Optional[str] = None,
     ) -> ChatSessionState:
         if chat_id:
             existing = chat_session_store.get(chat_id)
             if existing and existing.workspace_session_id == session_id:
                 return existing
 
-        client, chat = self._create_gemini_chat(session_id, session_mode)
+        client, chat = self._create_gemini_chat(session_id, session_mode, model)
         state = ChatSessionState(
             client=client,
             chat=chat,
@@ -334,7 +336,9 @@ class ChatAgentService:
                     self._genai_client = genai.Client(api_key=get_gemini_api_key())
         return self._genai_client
 
-    def _create_gemini_chat(self, session_id: str, session_mode: str) -> tuple[Any, Any]:
+    def _create_gemini_chat(
+        self, session_id: str, session_mode: str, model: Optional[str] = None
+    ) -> tuple[Any, Any]:
         from google.genai import types
 
         tools = get_tools_for_context(session_id, session_mode)
@@ -349,7 +353,7 @@ class ChatAgentService:
             system_instruction=CHAT_SYSTEM_PROMPT,
         )
         client = self._get_genai_client()
-        chat = client.aio.chats.create(model=CHAT_MODEL, config=config)
+        chat = client.aio.chats.create(model=model or CHAT_MODEL, config=config)
         return client, chat
 
     async def _run_loop(

--- a/backend/app/services/chat/deps.py
+++ b/backend/app/services/chat/deps.py
@@ -58,7 +58,7 @@ reference_fill_service = ReferenceFillService(
     schematiq_runner=schematiq_runner,
 )
 
-CHAT_MODEL = ModelNames.GEMINI_35_FLASH
+CHAT_MODEL = ModelNames.GEMINI_36_FLASH
 WORK_DIR = Path(DEFAULT_SCHEMATIQ_WORK_DIR)
 
 

--- a/frontend/src/components/ModelSelector/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector/ModelSelector.tsx
@@ -75,9 +75,9 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
         <SelectTrigger>
           <SelectValue placeholder={placeholder}>
             {selectedModel && (
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 min-w-0">
                 {getModelIcon(selectedModel)}
-                <span>{selectedModel.label}</span>
+                <span className="truncate">{selectedModel.label}</span>
               </div>
             )}
           </SelectValue>

--- a/frontend/src/constants/llmModels.ts
+++ b/frontend/src/constants/llmModels.ts
@@ -109,13 +109,22 @@ export const LLM_MODELS: LLMModelDefinition[] = [
     contextWindow: 1000000,
   },
   {
+    id: 'gemini-3.6-flash',
+    provider: 'gemini',
+    label: 'Gemini 3.6 Flash',
+    description: 'Latest Flash: better token efficiency and agentic planning at lower cost than 3.5 Flash',
+    cost: 'medium',
+    speed: 'fast',
+    isDefault: true,
+    contextWindow: 1000000,
+  },
+  {
     id: 'gemini-3.5-flash',
     provider: 'gemini',
     label: 'Gemini 3.5 Flash',
     description: 'Frontier intelligence for schema discovery and agentic tasks',
     cost: 'medium',
     speed: 'fast',
-    isDefault: true,
     contextWindow: 1000000,
   },
   {
@@ -132,7 +141,7 @@ export const LLM_MODELS: LLMModelDefinition[] = [
 ];
 
 // ── Default model constants ─────────────────────────────────────────
-export const DEFAULT_SCHEMA_MODEL = 'gemini-3.5-flash';
+export const DEFAULT_SCHEMA_MODEL = 'gemini-3.6-flash';
 export const DEFAULT_EXTRACTION_MODEL = 'gemini-3.5-flash-lite';
 export const DEFAULT_RELEASE_EXTRACTION_MODEL = 'gemini-3.5-flash-lite';
 

--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -4,9 +4,10 @@
 import { type ChangeEvent, type DragEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowUp, Bot, Check, FileText, Loader2, Paperclip, X } from 'lucide-react';
 
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { ModelSelector } from '@/components/ModelSelector';
+import { getDefaultModelForProvider } from '@/constants';
 import { chatAPI, referenceAPI, type ReferenceDocumentInfo } from '@/services/api';
 import webSocketService from '@/services/websocket';
 import type { ChatToolInfo, PaginatedData, SchemaData, ScheMatiQStatus, WebSocketMessage } from '@/types';
@@ -78,6 +79,7 @@ export function ChatPanel({
   const [input, setInput] = useState('');
   const [busy, setBusy] = useState(false);
   const [chatId, setChatId] = useState<string | null>(null);
+  const [chatModel, setChatModel] = useState<string>(() => getDefaultModelForProvider('gemini'));
   const [pinnedTool, setPinnedTool] = useState<string | null>(null);
   const [availableTools, setAvailableTools] = useState<ChatToolInfo[]>([]);
   const [pendingAction, setPendingAction] = useState<PendingChatAction | null>(null);
@@ -346,6 +348,7 @@ export function ChatPanel({
         chat_id: chatId || undefined,
         session_mode: sessionMode,
         pinned_tool: pinnedTool || undefined,
+        model: chatModel || undefined,
       });
       applyChatResponse(response);
     } catch (err: any) {
@@ -440,16 +443,21 @@ export function ChatPanel({
         </div>
       )}
       <div className="workspace-chat-header">
-        <div className="flex items-center gap-2 text-sm font-medium">
-          <Bot className="h-4 w-4" />
-          Chat
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <Bot className="h-4 w-4 shrink-0" />
+          <div className="min-w-0 flex-1">
+            <ModelSelector
+              provider="gemini"
+              value={chatModel}
+              onChange={setChatModel}
+              disabled={busy}
+              showDetails={false}
+            />
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          <Badge variant="outline">gemini-3.5-flash</Badge>
-          <Button size="sm" variant="outline" onClick={showToolsList} disabled={busy}>
-            Tools
-          </Button>
-        </div>
+        <Button size="sm" variant="outline" className="ml-2 shrink-0" onClick={showToolsList} disabled={busy}>
+          Tools
+        </Button>
       </div>
 
       {SHOW_TOOL_SUGGESTION && availableTools.length > 0 && (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1082,6 +1082,7 @@ export const chatAPI = {
       chat_id?: string;
       session_mode: 'schematiq' | 'load';
       pinned_tool?: string;
+      model?: string;
     },
   ): Promise<ChatMessageResponse> => {
     const response = await api.post(`/chat/${sessionId}/message`, payload, { timeout: CHAT_REQUEST_TIMEOUT_MS });

--- a/schematiq-lib/schematiq/core/model_specs.py
+++ b/schematiq-lib/schematiq/core/model_specs.py
@@ -39,6 +39,7 @@ class ModelNames:
     GEMINI_31_FLASH_LITE = "gemini-3.1-flash-lite"
     GEMINI_35_FLASH = "gemini-3.5-flash"
     GEMINI_35_FLASH_LITE = "gemini-3.5-flash-lite"
+    GEMINI_36_FLASH = "gemini-3.6-flash"
     GEMINI_31_PRO_PREVIEW = "gemini-3.1-pro-preview"
     GEMINI_15_FLASH = "gemini-1.5-flash"
 
@@ -61,7 +62,7 @@ class ModelNames:
     TIKTOKEN_ENCODING_MODEL = "gpt-4o"
 
     # Role-based defaults
-    DEFAULT_SCHEMA_CREATION = GEMINI_35_FLASH
+    DEFAULT_SCHEMA_CREATION = GEMINI_36_FLASH
     DEFAULT_VALUE_EXTRACTION = GEMINI_35_FLASH_LITE
     DEFAULT_RELEASE_EXTRACTION = GEMINI_35_FLASH_LITE
     DEFAULT_EVALUATION = GEMINI_15_FLASH
@@ -78,6 +79,7 @@ MODEL_SPECS: Dict[str, Dict[str, ModelSpec]] = {
         ModelNames.GEMINI_25_PRO: ModelSpec(1_048_576, 65_535, supports_thinking=True),
         ModelNames.GEMINI_31_FLASH_LITE: ModelSpec(1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True),
         ModelNames.GEMINI_35_FLASH: ModelSpec(1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True),
+        ModelNames.GEMINI_36_FLASH: ModelSpec(1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True),
         ModelNames.GEMINI_35_FLASH_LITE: ModelSpec(1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True),
         ModelNames.GEMINI_31_PRO_PREVIEW: ModelSpec(1_000_000, 64_000, supports_thinking=True, uses_thinking_level=True),
         "_default": ModelSpec(1_000_000, 32_000, supports_thinking=False),


### PR DESCRIPTION
## Problem
The chat header showed a hardcoded gemini-3.5-flash badge with no way to change the model, and long model names clipped in the fixed-width control. The chat endpoint accepted no model parameter, so the model was fixed at CHAT_MODEL.

## Solution
- **Frontend:** Replace the static badge with the compact ModelSelector; drop the 'Chat' label and let the selector grow so long names fit; add truncate so the label never wraps. Track the choice in chatModel state and send it as model on every sendMessage.
- **Backend:** Add model to ChatMessageRequest; thread it through send_message -> _get_or_create_session -> _create_gemini_chat, which now calls chats.create(model=model or CHAT_MODEL).
- **Registry:** Add GEMINI_36_FLASH to ModelNames and a MODEL_SPECS entry with uses_thinking_level=True; set DEFAULT_SCHEMA_CREATION and CHAT_MODEL to it; add it to the frontend catalog as default.

## Verify
- ( cd frontend && npx tsc --noEmit ) passes
- python -m py_compile on all five backend/lib files passes
- Chat header dropdown lists the Gemini models; picking one and starting a new chat routes through it.

## Note
The Gemini chat object is cached per chat_id, so a model change takes effect on the next new chat, not mid-conversation.