### PR TITLE
feat(config): honor user LLM selection via ALLOW_LLM_CONFIG

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -107,8 +107,10 @@ RELEASE_CONFIG = {
     "llm_temperature": 0,
 }
 
-# Convenience: whether LLM config UI should be shown
-ALLOW_LLM_CONFIG = DEVELOPER_MODE
+# Whether users may choose the LLM provider/model (shown in the UI and honored
+# by the pipeline). Defaults to DEVELOPER_MODE; set ALLOW_LLM_CONFIG=true to
+# expose model selection in release mode as well.
+ALLOW_LLM_CONFIG = os.environ.get("ALLOW_LLM_CONFIG", str(DEVELOPER_MODE).lower()).lower() == "true"
 
 # Model used for per-row "fill column from reference" lookups. This is a narrow
 # extraction task (pull one value out of a reference excerpt), not open-ended

--- a/backend/app/services/pipeline/llm_factory.py
+++ b/backend/app/services/pipeline/llm_factory.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Optional
 
-from app.core.config import DEVELOPER_MODE, RELEASE_CONFIG
+from app.core.config import ALLOW_LLM_CONFIG, DEVELOPER_MODE, RELEASE_CONFIG
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +75,7 @@ def enforce_release_llm_config(backend_config: dict, is_schema_creation: bool = 
     Returns:
         The config dict, potentially with provider/model/temperature overridden
     """
-    if DEVELOPER_MODE:
+    if DEVELOPER_MODE or ALLOW_LLM_CONFIG:
         return backend_config
 
     return {


### PR DESCRIPTION
## Problem
Model selection in the New Project screen is gated on allow_llm_config, which was hardwired to DEVELOPER_MODE. In release mode the selectors were hidden AND enforce_release_llm_config overrode any provided model with RELEASE_CONFIG, so selection could not be enabled in production.

## Solution
- Read ALLOW_LLM_CONFIG from its own env var, defaulting to DEVELOPER_MODE (no behavior change unless explicitly set).
- In enforce_release_llm_config, return the user's backend config unchanged when DEVELOPER_MODE or ALLOW_LLM_CONFIG is set, instead of forcing release models.

Setting ALLOW_LLM_CONFIG=true then both shows the New Project model selectors and makes them take effect.

## Verify
- python -m py_compile on both files passes
- With ALLOW_LLM_CONFIG=true, the New Project advanced settings show the Schema/Value LLM selectors and the chosen model is used by the run.

## Note
Off by default. Enabling it lets production users pick models, which has cost implications.