### PR TITLE
perf(workspace): data-only refresh on re-extraction progress

### DIFF
--- a/frontend/src/pages/Workspace/hooks/useWorkspaceSocket.ts
+++ b/frontend/src/pages/Workspace/hooks/useWorkspaceSocket.ts
@@ -91,7 +91,12 @@ export function useWorkspaceSocket({
           totalDocuments: payload.total_documents ?? current?.totalDocuments ?? 0,
           currentColumn: payload.column || current?.currentColumn,
         }));
-        void refresh({ silent: true });
+        // Progress fires once per cell, alongside a `cell_extracted` event that
+        // already triggers a data-only refresh. Re-extraction never changes the
+        // schema/status/config/session, so a full `refresh` here re-fetches and
+        // re-sets four structural payloads per cell for no benefit, flooding the
+        // backend and churning the grid. Fetch only the rows that actually change.
+        void refreshSilent();
         return;
       }
 


### PR DESCRIPTION
## Problem
During re-extraction the backend emits both a `cell_extracted` and a `reextraction_progress` event per cell (reextraction_service.py:1275 and :1293). The socket handler already refreshes rows on `cell_extracted` via `refreshSilent()`, but `reextraction_progress` triggered a full `refresh({ silent: true })` — re-fetching status + schema + config + session + documents on top of data, once per cell. Those four structural payloads never change during a re-extraction, so this floods the backend (~7 endpoint calls/cell instead of ~2) and churns the grid with redundant re-renders.

## Solution
Downgrade the `reextraction_progress` branch in useWorkspaceSocket to `refreshSilent()` (data-only). The progress banner state is still updated from the payload; live cell updates still come through. No other branches changed.

## Verify
- `( cd frontend && npx tsc --noEmit )` passes.
- Run a re-extraction: cells still stream in live, the progress banner still advances, and the network tab shows only `/data/` polling during progress instead of status/schema/config/session/documents per cell.