### PR TITLE
feat(config): enable user LLM selection for everyone + log resolved model

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -108,7 +108,7 @@ RELEASE_CONFIG = {
 }
 
 # Convenience: whether LLM config UI should be shown
-ALLOW_LLM_CONFIG = DEVELOPER_MODE
+ALLOW_LLM_CONFIG = os.environ.get("ALLOW_LLM_CONFIG", "true").lower() == "true"
 
 # Model used for per-row "fill column from reference" lookups. This is a narrow
 # extraction task (pull one value out of a reference excerpt), not open-ended

--- a/backend/app/services/pipeline/llm_factory.py
+++ b/backend/app/services/pipeline/llm_factory.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Optional
 
-from app.core.config import DEVELOPER_MODE, RELEASE_CONFIG
+from app.core.config import ALLOW_LLM_CONFIG, DEVELOPER_MODE, RELEASE_CONFIG
 
 logger = logging.getLogger(__name__)
 
@@ -75,12 +75,23 @@ def enforce_release_llm_config(backend_config: dict, is_schema_creation: bool = 
     Returns:
         The config dict, potentially with provider/model/temperature overridden
     """
-    if DEVELOPER_MODE:
+    role = "schema_creation" if is_schema_creation else "value_extraction"
+
+    if DEVELOPER_MODE or ALLOW_LLM_CONFIG:
+        logger.info(
+            "LLM config (%s): provider=%s model=%s (user-selected)",
+            role, backend_config.get("provider"), backend_config.get("model"),
+        )
         return backend_config
 
-    return {
+    resolved = {
         **backend_config,
         "provider": RELEASE_CONFIG["llm_provider"],
         "model": RELEASE_CONFIG["schema_creation_model"] if is_schema_creation else RELEASE_CONFIG["value_extraction_model"],
         "temperature": RELEASE_CONFIG["llm_temperature"],
     }
+    logger.info(
+        "LLM config (%s): provider=%s model=%s (release-enforced)",
+        role, resolved["provider"], resolved["model"],
+    )
+    return resolved


### PR DESCRIPTION
## Problem
Model selection in the New Project screen was gated on allow_llm_config, hardwired to DEVELOPER_MODE, so it was hidden for normal users. enforce_release_llm_config also overrode any chosen model with RELEASE_CONFIG outside developer mode. No explicit log recorded the resolved schema/value model.

## Solution
- Read ALLOW_LLM_CONFIG from its own env var, default true (independent of DEVELOPER_MODE). Set ALLOW_LLM_CONFIG=false to lock to release models.
- enforce_release_llm_config returns the user's config unchanged when DEVELOPER_MODE or ALLOW_LLM_CONFIG is set, and logs 'LLM config (role): provider=... model=... (user-selected|release-enforced)'.

## Verify
- python -m py_compile on both files passes.
- With defaults, the New Project advanced settings show the Schema/Value LLM selectors (below 'Observation Unit') and the chosen model is used and logged.

## Note
Defaulting on removes the release model lock for everyone (cost implications). Set ALLOW_LLM_CONFIG=false to restore locking.