### PR TITLE
feat(config): enable user LLM selection for everyone + simpler UI + model log

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -93,8 +93,13 @@ SUPABASE_URL = os.environ.get("SUPABASE_URL", "")
 SUPABASE_KEY = os.environ.get("SUPABASE_KEY", "")
 
 # ── Release Mode vs Developer Mode ──────────────────────────────
+def _env_flag(name: str, *, default: bool = False) -> bool:
+    """Read a boolean environment variable (accepts 1/true/yes, any case)."""
+    return os.environ.get(name, str(default)).strip().lower() in {"1", "true", "yes"}
+
+
 # Default: release mode (restricted). Set DEVELOPER_MODE=true to unlock.
-DEVELOPER_MODE = os.environ.get("DEVELOPER_MODE", "false").lower() == "true"
+DEVELOPER_MODE = _env_flag("DEVELOPER_MODE")
 
 # All mode-dependent feature flags live here.
 # To add a new release restriction, add a key with its release-mode default.
@@ -107,8 +112,10 @@ RELEASE_CONFIG = {
     "llm_temperature": 0,
 }
 
-# Convenience: whether LLM config UI should be shown
-ALLOW_LLM_CONFIG = DEVELOPER_MODE
+# Whether users may choose the LLM provider/model. Available to everyone by
+# default; set ALLOW_LLM_CONFIG=false to lock the pipeline to the release
+# models. Developer mode always allows it.
+ALLOW_LLM_CONFIG = _env_flag("ALLOW_LLM_CONFIG", default=True) or DEVELOPER_MODE
 
 # Model used for per-row "fill column from reference" lookups. This is a narrow
 # extraction task (pull one value out of a reference excerpt), not open-ended

--- a/backend/app/services/pipeline/llm_factory.py
+++ b/backend/app/services/pipeline/llm_factory.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Optional
 
-from app.core.config import DEVELOPER_MODE, RELEASE_CONFIG
+from app.core.config import ALLOW_LLM_CONFIG, RELEASE_CONFIG
 
 logger = logging.getLogger(__name__)
 
@@ -75,12 +75,21 @@ def enforce_release_llm_config(backend_config: dict, is_schema_creation: bool = 
     Returns:
         The config dict, potentially with provider/model/temperature overridden
     """
-    if DEVELOPER_MODE:
-        return backend_config
+    role = "schema_creation" if is_schema_creation else "value_extraction"
 
-    return {
-        **backend_config,
-        "provider": RELEASE_CONFIG["llm_provider"],
-        "model": RELEASE_CONFIG["schema_creation_model"] if is_schema_creation else RELEASE_CONFIG["value_extraction_model"],
-        "temperature": RELEASE_CONFIG["llm_temperature"],
-    }
+    if ALLOW_LLM_CONFIG:
+        resolved, source = backend_config, "user-selected"
+    else:
+        resolved = {
+            **backend_config,
+            "provider": RELEASE_CONFIG["llm_provider"],
+            "model": RELEASE_CONFIG["schema_creation_model"] if is_schema_creation else RELEASE_CONFIG["value_extraction_model"],
+            "temperature": RELEASE_CONFIG["llm_temperature"],
+        }
+        source = "release-enforced"
+
+    logger.info(
+        "LLM config (%s): provider=%s model=%s (%s)",
+        role, resolved["provider"], resolved["model"], source,
+    )
+    return resolved

--- a/frontend/src/components/AdvancedSettings/AdvancedSettingsFields.tsx
+++ b/frontend/src/components/AdvancedSettings/AdvancedSettingsFields.tsx
@@ -1,6 +1,4 @@
-import { useState } from 'react';
 import { ChevronDown } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -148,8 +146,6 @@ export function AdvancedSettingsFields({
   maxDocuments,
   className,
 }: AdvancedSettingsFieldsProps) {
-  const [editingSchemaLlm, setEditingSchemaLlm] = useState(false);
-  const [editingValueLlm, setEditingValueLlm] = useState(false);
 
   return (
     <div className={className ?? 'space-y-4'}>
@@ -369,122 +365,86 @@ export function AdvancedSettingsFields({
           <hr />
           {/* Schema creation LLM */}
           <div className="space-y-3">
-            {editingSchemaLlm ? (
-              <>
-                <div className="flex items-center justify-between">
-                  <Label className="text-sm font-medium">Schema Creation LLM</Label>
-                  <Button variant="ghost" size="sm" onClick={() => setEditingSchemaLlm(false)}>Done</Button>
-                </div>
-                <div className="space-y-2">
-                  <div className="space-y-1">
-                    <Label className="text-xs">Provider</Label>
-                    <Select
-                      value={value.schemaProvider}
-                      onValueChange={(provider) => onChange({ schemaProvider: provider, schemaModel: getDefaultModelForProvider(provider as LLMProviderKey) })}
-                    >
-                      <SelectTrigger><SelectValue /></SelectTrigger>
-                      <SelectContent>
-                        {providers.map((provider) => (
-                          <SelectItem key={provider} value={provider}>{LLM_PROVIDER_NAMES[provider]}</SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="space-y-1">
-                    <Label className="text-xs">Model</Label>
-                    <ModelSelector
-                      provider={value.schemaProvider as LLMProviderKey}
-                      value={value.schemaModel}
-                      onChange={(modelId) => onChange({ schemaModel: modelId })}
-                      showDetails
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <Label className="text-xs">Temperature</Label>
-                    <Input
-                      type="number"
-                      min={0}
-                      max={2}
-                      step={0.1}
-                      value={value.schemaTemperature}
-                      onChange={(e) => onChange({ schemaTemperature: parseFloat(e.target.value) || 0 })}
-                    />
-                  </div>
-                </div>
-              </>
-            ) : (
-              <div className="flex items-center justify-between">
-                <div className="text-sm">
-                  <span className="font-medium">Schema LLM:</span>{' '}
-                  <span className="text-muted-foreground">
-                    {LLM_PROVIDER_NAMES[value.schemaProvider as LLMProviderKey]} / {value.schemaModel}
-                    {value.schemaTemperature !== 0 && ` (temp: ${value.schemaTemperature})`}
-                  </span>
-                </div>
-                <Button variant="ghost" size="sm" onClick={() => setEditingSchemaLlm(true)}>Edit</Button>
+            <Label className="text-sm font-medium">Schema Creation LLM</Label>
+            <div className="space-y-2">
+              <div className="space-y-1">
+                <Label className="text-xs">Provider</Label>
+                <Select
+                  value={value.schemaProvider}
+                  onValueChange={(provider) => onChange({ schemaProvider: provider, schemaModel: getDefaultModelForProvider(provider as LLMProviderKey) })}
+                >
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {providers.map((provider) => (
+                      <SelectItem key={provider} value={provider}>{LLM_PROVIDER_NAMES[provider]}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
-            )}
+              <div className="space-y-1">
+                <Label className="text-xs">Model</Label>
+                <ModelSelector
+                  provider={value.schemaProvider as LLMProviderKey}
+                  value={value.schemaModel}
+                  onChange={(modelId) => onChange({ schemaModel: modelId })}
+                  showDetails
+                />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Temperature</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={2}
+                  step={0.1}
+                  value={value.schemaTemperature}
+                  onChange={(e) => onChange({ schemaTemperature: parseFloat(e.target.value) || 0 })}
+                />
+              </div>
+            </div>
           </div>
 
           <hr />
 
           {/* Value extraction LLM */}
           <div className="space-y-3">
-            {editingValueLlm ? (
-              <>
-                <div className="flex items-center justify-between">
-                  <Label className="text-sm font-medium">Value Extraction LLM</Label>
-                  <Button variant="ghost" size="sm" onClick={() => setEditingValueLlm(false)}>Done</Button>
-                </div>
-                <div className="space-y-2">
-                  <div className="space-y-1">
-                    <Label className="text-xs">Provider</Label>
-                    <Select
-                      value={value.valueProvider}
-                      onValueChange={(provider) => onChange({ valueProvider: provider, valueModel: getDefaultModelForProvider(provider as LLMProviderKey) })}
-                    >
-                      <SelectTrigger><SelectValue /></SelectTrigger>
-                      <SelectContent>
-                        {providers.map((provider) => (
-                          <SelectItem key={provider} value={provider}>{LLM_PROVIDER_NAMES[provider]}</SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="space-y-1">
-                    <Label className="text-xs">Model</Label>
-                    <ModelSelector
-                      provider={value.valueProvider as LLMProviderKey}
-                      value={value.valueModel}
-                      onChange={(modelId) => onChange({ valueModel: modelId })}
-                      showDetails
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <Label className="text-xs">Temperature</Label>
-                    <Input
-                      type="number"
-                      min={0}
-                      max={2}
-                      step={0.1}
-                      value={value.valueTemperature}
-                      onChange={(e) => onChange({ valueTemperature: parseFloat(e.target.value) || 0 })}
-                    />
-                  </div>
-                </div>
-              </>
-            ) : (
-              <div className="flex items-center justify-between">
-                <div className="text-sm">
-                  <span className="font-medium">Value LLM:</span>{' '}
-                  <span className="text-muted-foreground">
-                    {LLM_PROVIDER_NAMES[value.valueProvider as LLMProviderKey]} / {value.valueModel}
-                    {value.valueTemperature !== 0 && ` (temp: ${value.valueTemperature})`}
-                  </span>
-                </div>
-                <Button variant="ghost" size="sm" onClick={() => setEditingValueLlm(true)}>Edit</Button>
+            <Label className="text-sm font-medium">Value Extraction LLM</Label>
+            <div className="space-y-2">
+              <div className="space-y-1">
+                <Label className="text-xs">Provider</Label>
+                <Select
+                  value={value.valueProvider}
+                  onValueChange={(provider) => onChange({ valueProvider: provider, valueModel: getDefaultModelForProvider(provider as LLMProviderKey) })}
+                >
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {providers.map((provider) => (
+                      <SelectItem key={provider} value={provider}>{LLM_PROVIDER_NAMES[provider]}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
-            )}
+              <div className="space-y-1">
+                <Label className="text-xs">Model</Label>
+                <ModelSelector
+                  provider={value.valueProvider as LLMProviderKey}
+                  value={value.valueModel}
+                  onChange={(modelId) => onChange({ valueModel: modelId })}
+                  showDetails
+                />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Temperature</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={2}
+                  step={0.1}
+                  value={value.valueTemperature}
+                  onChange={(e) => onChange({ valueTemperature: parseFloat(e.target.value) || 0 })}
+                />
+              </div>
+            </div>
           </div>
         </>
       )}


### PR DESCRIPTION
## Problem
Model selection in the New Project screen was gated on allow_llm_config (hardwired to DEVELOPER_MODE) and hidden for normal users; enforce_release_llm_config overrode the chosen model outside developer mode; and the selectors sat behind a confusing Edit/Done toggle. No explicit log recorded the resolved model.

## Solution
- config.py: add _env_flag helper; ALLOW_LLM_CONFIG defaults to true and folds in DEVELOPER_MODE, so it is on for everyone (set ALLOW_LLM_CONFIG=false to lock to release models).
- llm_factory.py: enforce_release_llm_config returns the user's config when ALLOW_LLM_CONFIG is set and logs 'LLM config (role): provider=... model=... (user-selected|release-enforced)' once.
- AdvancedSettingsFields.tsx: remove the Edit/Done toggle; the Schema/Value LLM Provider/Model/Temperature are always visible. Drop the now-unused state and imports.

## Verify
- ( cd frontend && npx tsc --noEmit ) passes; py_compile on both backend files passes.
- New Project advanced settings show the always-open Schema/Value LLM selectors (below 'Observation Unit'); switching a model is used and logged.

## Note
Defaulting on removes the release model lock for everyone (cost implications). Set ALLOW_LLM_CONFIG=false to restore locking.