### PR TITLE
fix(workspace): stop the data grid blanking to headers-only during refresh

### DIFF
--- a/backend/app/services/atomic_jsonl.py
+++ b/backend/app/services/atomic_jsonl.py
@@ -1,0 +1,59 @@
+"""Atomic rewrite helper for session data JSONL files.
+
+Rewriting a data file with ``open(path, "w")`` truncates it before the new rows
+are written, so any concurrent reader — ``GET /data/{session_id}`` on a
+background poll, the unit view, statistics — can observe an empty or partially
+written file and report zero rows. In the Workspace grid that surfaces as
+column headers with no data underneath, because the columns come from the
+schema while the rows come from the data file.
+
+Writing to a sibling temporary file and swapping it in with ``os.replace``
+makes the update atomic: a reader sees either the old file or the new one, never
+a truncated one. The temp file is created in the same directory so the rename
+stays on one filesystem, and is dot-prefixed with a ``.tmp`` suffix so the data
+file enumeration in ``data_utils`` (which matches exact filenames) ignores it.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+logger = logging.getLogger(__name__)
+
+
+def write_jsonl_atomic(
+    path: Path,
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    ensure_ascii: bool = True,
+) -> None:
+    """Rewrite *path* with *rows*, one JSON object per line, atomically.
+
+    ``ensure_ascii`` mirrors the ``json.dumps`` default so call sites keep the
+    exact on-disk encoding they had before switching to this helper.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            for row in rows:
+                handle.write(json.dumps(row, ensure_ascii=ensure_ascii) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            logger.debug("Could not remove temp file %s", tmp_path)
+        raise

--- a/backend/app/services/data_editor.py
+++ b/backend/app/services/data_editor.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from app.core.config import DEFAULT_DATA_DIR, DEFAULT_SCHEMATIQ_WORK_DIR
+from app.services.atomic_jsonl import write_jsonl_atomic
 from app.services.data_utils import (
     resolve_session_data_files,
     persist_session_data_file,
@@ -180,9 +181,7 @@ class DataEditor:
                         break
 
                 if file_updated:
-                    with open(data_file, "w", encoding="utf-8") as f:
-                        for row in rows:
-                            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+                    write_jsonl_atomic(data_file, rows, ensure_ascii=False)
                     persisted_files.append(data_file)
 
                 # An index identity is unique to one row; once matched, stop.
@@ -343,9 +342,7 @@ class DataEditor:
                 if rename_column_keys_in_row(row, old_name, new_name):
                     file_rows_updated += 1
 
-            with open(data_file, "w", encoding="utf-8") as f:
-                for row in rows:
-                    f.write(json.dumps(row, ensure_ascii=False) + "\n")
+            write_jsonl_atomic(data_file, rows, ensure_ascii=False)
 
             await persist_session_data_file(session_id, data_file)
             files_updated += 1

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -19,6 +19,7 @@ from app.models.session import (
 from app.services.websocket_manager import WebSocketManager
 from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
+from app.services.atomic_jsonl import write_jsonl_atomic
 from app.services import schematiq_thread_pool, concurrency_limiter, llm_call_tracker_lock
 from app.services.data_utils import row_name_of
 from app.storage.factory import get_storage
@@ -750,9 +751,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
             import shutil
             shutil.copy2(data_file, backup_file)
 
-            with open(data_file, 'w') as f:
-                for row in rows:
-                    f.write(json.dumps(row) + '\n')
+            write_jsonl_atomic(data_file, rows)
 
     async def download_cloud_papers(
         self,
@@ -1716,9 +1715,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 new_rows_added += 1
                 matched_extracted_keys.add(ext_key)
 
-            with open(schematiq_extracted_file, "w") as f:
-                for row in updated_rows:
-                    f.write(json.dumps(row, ensure_ascii=False) + "\n")
+            write_jsonl_atomic(schematiq_extracted_file, updated_rows, ensure_ascii=False)
             logger.info(
                 "Wrote %s with %d rows (%d updated, %d new)",
                 schematiq_extracted_file,
@@ -1818,9 +1815,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 if new_rows_added > 0:
                     logger.info(f"Appended {new_rows_added} new rows to {data_file.name}")
 
-            with open(data_file, 'w') as f:
-                for row in updated_rows:
-                    f.write(json.dumps(row) + '\n')
+            write_jsonl_atomic(data_file, updated_rows)
 
             await persist_session_data_file(session_id, data_file)
 

--- a/backend/app/services/schema_manager.py
+++ b/backend/app/services/schema_manager.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from datetime import datetime
 
 from app.models.session import ColumnInfo
+from app.services.atomic_jsonl import write_jsonl_atomic
 from app.services.websocket_manager import WebSocketManager
 from app.services.session_manager import SessionManager
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
@@ -322,9 +323,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
                 updated_rows.append(row_data)
             
             # Write back updated data
-            with open(data_file, 'w') as f:
-                for row in updated_rows:
-                    f.write(json.dumps(row) + '\n')
+            write_jsonl_atomic(data_file, updated_rows)
             
             logger.info(f"Successfully removed columns {columns_to_remove} from {columns_removed_count} rows")
             
@@ -561,9 +560,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
                         updated_rows.append(row_data)
             
             # Write back updated data
-            with open(data_file, 'w') as f:
-                for row in updated_rows:
-                    f.write(json.dumps(row) + '\n')
+            write_jsonl_atomic(data_file, updated_rows)
 
             await self.broadcast_completion(
                 session_id,
@@ -684,9 +681,7 @@ class SchemaManager(WebSocketBroadcasterMixin):
                 updated_rows.append(row_data)
 
         # Write back updated data
-        with open(data_file, 'w') as f:
-            for row in updated_rows:
-                f.write(json.dumps(row) + '\n')
+        write_jsonl_atomic(data_file, updated_rows)
     
     async def _add_new_column_data(self, session_id: str, column_name: str, extraction_file: Path):
         """Add data for a new column to existing records across ALL data files."""

--- a/frontend/src/pages/Workspace/constants.ts
+++ b/frontend/src/pages/Workspace/constants.ts
@@ -91,6 +91,11 @@ export const emptyData: PaginatedData = {
   page_size: 500,
   has_more: false,
 };
+// Delay before re-checking a zero-row data response that arrived while the grid
+// was showing rows. Long enough for an in-flight backend data-file rewrite to
+// finish, short enough that a genuinely emptied table clears without a visible
+// wait. See applyData in index.tsx.
+export const EMPTY_DATA_RECHECK_MS = 900;
 export const WORKSPACE_DEFAULT_ADVANCED: AdvancedSettingsValue = {
   ...DEFAULT_ADVANCED_SETTINGS,
   schemaProvider: DEFAULT_PROVIDER,

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -60,7 +60,7 @@ import type {
 import type { DocumentListResponse } from '@/types/unit';
 
 import { ChatPanel } from './chat/ChatPanel';
-import { emptyData, SHEETS, cellFormatKey } from './constants';
+import { emptyData, EMPTY_DATA_RECHECK_MS, SHEETS, cellFormatKey } from './constants';
 import {
   buildExportFilename,
   dataEquals,
@@ -90,6 +90,14 @@ import type {
 } from './types';
 
 import './Workspace.css';
+
+type RefreshDataOptions = {
+  silent?: boolean;
+  force?: boolean;
+  // Set only by the automatic re-check in applyData: accept a zero-row payload
+  // even when the grid is currently showing rows.
+  acceptEmpty?: boolean;
+};
 
 async function downloadAs(path: string, filename: string): Promise<void> {
   const response = await api.get(path, { responseType: 'blob' });
@@ -186,6 +194,20 @@ function Workspace() {
 
   const deferredDataRef = useRef<PaginatedData | null>(null);
   const cancelChatPendingRef = useRef<(() => Promise<boolean>) | null>(null);
+  // Row count of the payload currently rendered in the grid. Written eagerly on
+  // every commit and re-synced from state below, so a refresh can tell "the
+  // table really is empty" apart from "this response came back empty while the
+  // grid is showing rows".
+  const dataRowCountRef = useRef(0);
+  const unitDataRowCountRef = useRef(0);
+  const emptyRecheckTimerRef = useRef<number | null>(null);
+  const refreshDataRef = useRef<((options?: RefreshDataOptions) => Promise<void>) | null>(null);
+
+  const clearEmptyRecheck = useCallback(() => {
+    if (emptyRecheckTimerRef.current == null) return;
+    window.clearTimeout(emptyRecheckTimerRef.current);
+    emptyRecheckTimerRef.current = null;
+  }, []);
 
   const cancelChatPendingIfAny = useCallback(async (): Promise<boolean> => {
     if (!cancelChatPendingRef.current) return true;
@@ -197,8 +219,31 @@ function Workspace() {
     return Boolean(editor?.isOpened?.());
   }, []);
 
+  const commitData = useCallback((nextData: PaginatedData) => {
+    dataRowCountRef.current = nextData.rows.length;
+    setData((current) => (dataEquals(current, nextData) ? current : nextData));
+    setDataServerVersion((v) => v + 1);
+  }, []);
+
+  // A zero-row payload arriving while the grid is showing rows is almost always
+  // transient rather than a real empty table: the backend rewrites a session's
+  // JSONL data file in place (truncate, then write), so a fetch landing inside
+  // that window reads a half-written file and returns 200 with zero rows. The
+  // grid takes its columns from the schema and its rows from this payload, so
+  // applying it renders as "headers with no data". Keep the rows already on
+  // screen and re-check once; a table that really is empty is confirmed by the
+  // re-check and applied then. Nothing is committed on the skipped attempt, so
+  // dataServerVersion is not bumped and no By Unit refetch is triggered either.
+  const scheduleEmptyRecheck = useCallback(() => {
+    if (emptyRecheckTimerRef.current != null) return;
+    emptyRecheckTimerRef.current = window.setTimeout(() => {
+      emptyRecheckTimerRef.current = null;
+      void refreshDataRef.current?.({ silent: true, acceptEmpty: true });
+    }, EMPTY_DATA_RECHECK_MS);
+  }, []);
+
   const applyData = useCallback(
-    (nextData: PaginatedData, opts?: { silent?: boolean; force?: boolean }) => {
+    (nextData: PaginatedData, opts?: RefreshDataOptions) => {
       // Background polls defer while the inline editor is open so a mid-edit
       // fetch cannot clobber what the user is typing. Post-edit refreshes pass
       // force so the persisted value is always applied.
@@ -206,32 +251,49 @@ function Workspace() {
         deferredDataRef.current = nextData;
         return;
       }
+      if (!opts?.acceptEmpty && nextData.rows.length === 0 && dataRowCountRef.current > 0) {
+        deferredDataRef.current = null;
+        scheduleEmptyRecheck();
+        return;
+      }
       deferredDataRef.current = null;
-      setData((current) => (dataEquals(current, nextData) ? current : nextData));
-      setDataServerVersion((v) => v + 1);
+      commitData(nextData);
     },
-    [isCellEditorOpen],
+    [commitData, isCellEditorOpen, scheduleEmptyRecheck],
   );
 
   const flushDeferredData = useCallback(() => {
     const pending = deferredDataRef.current;
     if (!pending) return;
     deferredDataRef.current = null;
-    setData((current) => (dataEquals(current, pending) ? current : pending));
-    setDataServerVersion((v) => v + 1);
-  }, []);
+    if (pending.rows.length === 0 && dataRowCountRef.current > 0) {
+      scheduleEmptyRecheck();
+      return;
+    }
+    commitData(pending);
+  }, [commitData, scheduleEmptyRecheck]);
 
   // Fetch row data only — no status/schema/session churn. Used after cell edits
   // and for background polls so a refresh cannot re-render the grid from stale
   // React state while the network round-trip is still in flight.
-  const refreshData = useCallback(async (options?: { silent?: boolean; force?: boolean }) => {
+  const refreshData = useCallback(async (options?: RefreshDataOptions) => {
     if (!sessionId) return;
     const fetchData = sessionMode === 'load'
       ? () => loadAPI.getData(sessionId, 0, 500)
       : () => schematiqAPI.getData(sessionId, 0, 500);
-    const nextData = await fetchData().catch(() => emptyData);
+    // Keep the rows already on screen when the fetch fails instead of blanking
+    // the grid. The columns come from the schema, so falling back to emptyData
+    // here is exactly what leaves the user looking at headers with no data.
+    const nextData = await fetchData().catch(() => null);
+    if (!nextData) return;
     applyData(nextData, options);
   }, [applyData, sessionId, sessionMode]);
+
+  // The re-check scheduled by applyData needs the current refreshData without
+  // making applyData depend on it (they are mutually recursive by design).
+  useEffect(() => {
+    refreshDataRef.current = refreshData;
+  }, [refreshData]);
 
   const refreshAfterEdit = useCallback(() => refreshData({ silent: true, force: true }), [refreshData]);
 
@@ -460,7 +522,21 @@ function Workspace() {
     setSession(null);
     setDataView('by_document');
     setUnitData(emptyData);
-  }, [sessionId]);
+    // Drop refresh bookkeeping tied to the session we are leaving, so a pending
+    // re-check cannot apply the previous session's rows to the new one.
+    dataRowCountRef.current = 0;
+    unitDataRowCountRef.current = 0;
+    deferredDataRef.current = null;
+    clearEmptyRecheck();
+  }, [clearEmptyRecheck, sessionId]);
+
+  useEffect(() => clearEmptyRecheck, [clearEmptyRecheck]);
+
+  // Belt-and-braces re-sync: every commit writes dataRowCountRef eagerly, this
+  // keeps it correct for the paths that set `data` directly (optimistic edits).
+  useEffect(() => {
+    dataRowCountRef.current = data.rows.length;
+  }, [data]);
 
   // Lazily fetch the observation-unit-grouped data when the Data sheet is in
   // "By Unit" mode. Same schema columns as the by-document view; only the row
@@ -477,8 +553,19 @@ function Workspace() {
     const timer = window.setTimeout(() => {
       unitsAPI
         .getData(sessionId, { page: 0, pageSize: 500 })
-        .then((res) => { if (!cancelled) setUnitData(res); })
-        .catch(() => { if (!cancelled) setUnitData(emptyData); });
+        .then((res) => {
+          if (cancelled) return;
+          // Same transient-empty guard as the by-document view: both views read
+          // the same session data file, so a rewrite in flight blanks this one
+          // too. An empty by-unit payload is only believed once the by-document
+          // rows are gone as well (a real reset), since By Unit is a regrouping
+          // of them. Read from the ref, not `data`, so this effect keeps keying
+          // its refetch off dataServerVersion only.
+          if (res.rows.length === 0 && unitDataRowCountRef.current > 0 && dataRowCountRef.current > 0) return;
+          unitDataRowCountRef.current = res.rows.length;
+          setUnitData(res);
+        })
+        .catch(() => { /* keep the rows already on screen on a transient error */ });
     }, 200);
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Problem

The Workspace data grid intermittently renders column headers with no rows underneath. Columns come from the schema and rows from the data payload, so any refresh yielding zero rows produces exactly that state. Two independent causes, both verified:

1. `refreshData` mapped a failed fetch to `emptyData`, blanking the grid on any transient network error. `loadHeavy` in the same file already avoids this deliberately; the other path was missed.
2. The backend rewrites session JSONL data files with `open(path, 'w')`, truncating before writing. `GET /data` landing inside that window reads a partially written file and returns HTTP 200 with zero rows. Reproduced: 300 legacy rewrites observed by a concurrent reader exposed both zero-row and partial reads.

Polling makes it likely — the socket hook refreshes on cell/row/progress events and polls while disconnected, i.e. most frequently while those files are being rewritten. An existing comment in `SpreadsheetSurface` already noted the same race for the column-delete path.

## Solution

Frontend (`Workspace/index.tsx`, `constants.ts`):
- A failed data fetch keeps the rows already on screen instead of falling back to `emptyData`.
- A zero-row payload arriving while the grid shows rows is not applied; it schedules one re-check (900ms) passing `acceptEmpty`. A genuinely emptied table is confirmed and applied then, so rediscovery/reset still clears. Skipped attempts commit nothing, so `dataServerVersion` is not bumped and no By Unit refetch fires. Same guard on the deferred-edit flush and the By Unit fetch (reading the row-count ref, so the effect keeps keying off `dataServerVersion` only). Refresh bookkeeping resets on session change.

Backend (`atomic_jsonl.py`, new):
- `write_jsonl_atomic` writes to a sibling temp file and `os.replace`s it in, so a reader sees either the old file or the new one. Applied to the six session-data rewrite sites that run while a populated table is on screen: cell update, column rename, column delete, column merge, add-column data, and the re-extraction merge.

## Verify

- Clean clone of main at `9d2d772`: `git apply --ignore-whitespace --check` passes.
- `npx tsc --noEmit` exits 0; `python -m py_compile` passes on all four backend files.
- Atomic writer under contention: 300 rewrites with a concurrent reader, 11,517 reads, every read saw the full row count; no leftover temp files; non-ASCII preserved on the `ensure_ascii=False` sites.
- Manual: run a re-extraction on a populated project and watch the grid through progress updates — rows stay put. Edit a cell repeatedly; no blank frame between the PUT and the refresh.