### PR TITLE
fix(api): report unreadable table data as 503 instead of an empty table

### DIFF
--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -20,6 +20,7 @@ from app.models.upload import (
     ColumnMappingRequest, CompatibilityCheck
 )
 from app.services.file_parser import FileParser, format_column_header, is_system_file
+from app.services.pipeline.data_query import session_data_read_failed
 from app.services import session_manager, websocket_manager, concurrency_limiter
 from app.services.upload_document_processor import UploadDocumentProcessor
 from app.storage import get_storage
@@ -361,8 +362,28 @@ async def get_data_with_filters(
             document_filter=document_filter
         )
 
+        # An empty payload that contradicts the session's own row count means the
+        # data could not be read, not that the table is empty. Reporting it as a
+        # retryable error keeps clients from rendering an empty table (and, for
+        # schema-driven grids, bare column headers) over data that still exists.
+        if await session_data_read_failed(session_id, data, session):
+            logger.error(
+                "Session %s: data read returned 0 rows while statistics record %s — "
+                "no local data file and the rows are present in storage",
+                session_id,
+                session.statistics.total_rows,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail="Table data could not be loaded right now. Please retry in a moment.",
+            )
+
         return data
 
+    except HTTPException:
+        # Preserve intended status codes (404 for a missing session, 503 above);
+        # the generic handler below would otherwise report them all as 500.
+        raise
     except Exception as e:
         logger.error(f"Exception in get_data_with_filters: {e}")
         import traceback

--- a/backend/app/api/routes/schematiq.py
+++ b/backend/app/api/routes/schematiq.py
@@ -17,6 +17,7 @@ from fastapi.responses import StreamingResponse
 from app.models.session import VisualizationSession, SessionType, SessionStatus, SessionMetadata, FilterSortRequest
 from app.models.schematiq import ScheMatiQConfig, ScheMatiQStatus, CostEstimate, CostEstimateRequest, PhaseEstimate, DocumentStats
 from app.services.schematiq_runner import ScheMatiQRunner
+from app.services.pipeline.data_query import session_data_read_failed
 from app.services.data_editor import DataEditor
 from app.services import websocket_manager, session_manager, concurrency_limiter, data_collection_service
 from app.core.exceptions import CapacityExceededError
@@ -452,8 +453,28 @@ async def get_schematiq_data_with_filters(
             document_filter=document_filter
         )
 
+        # An empty payload that contradicts the session's own row count means the
+        # data could not be read, not that the table is empty. Reporting it as a
+        # retryable error keeps clients from rendering an empty table (and, for
+        # schema-driven grids, bare column headers) over data that still exists.
+        if await session_data_read_failed(session_id, data, session):
+            logger.error(
+                "Session %s: data read returned 0 rows while statistics record %s — "
+                "no local data file and the rows are present in storage",
+                session_id,
+                session.statistics.total_rows,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail="Table data could not be loaded right now. Please retry in a moment.",
+            )
+
         return data
 
+    except HTTPException:
+        # Preserve intended status codes (404 for a missing session, 503 above);
+        # the generic handler below would otherwise report them all as 500.
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/app/services/pipeline/data_query.py
+++ b/backend/app/services/pipeline/data_query.py
@@ -237,6 +237,53 @@ async def get_schema(session_id: str, session_manager, work_dir: Path) -> Dict[s
     return {"query": "", "schema": []}
 
 
+async def session_data_read_failed(
+    session_id: str,
+    data: PaginatedData,
+    session,
+) -> bool:
+    """Return True when an empty result means "could not read" rather than "no rows".
+
+    ``get_data`` reports zero rows for two very different situations: a session
+    that genuinely has no rows, and one whose data files could not be read — the
+    local file is gone after a redeploy and hydration from storage failed. That
+    failure is swallowed in ``ensure_session_data_file_local``, which returns
+    False and logs at debug level, so the caller receives HTTP 200 with an empty
+    table and nothing explains why. Callers that draw their columns from the
+    schema then render column headers with no data underneath.
+
+    Four conditions, cheapest first, all required:
+
+    * the read produced no rows at all — not a filter that matched nothing and
+      not a page past the end, since ``total_count`` is the unfiltered count in
+      both branches of ``get_data``;
+    * the session's own statistics record rows. This is an independent record,
+      cleared only when the pipeline resets a session for rediscovery;
+    * no data file resolved locally. A table whose rows were all deleted keeps
+      its (now empty) file, so this is what separates "emptied" from "missing";
+    * the rows do exist in remote storage, i.e. hydration is what failed.
+
+    Only the last condition costs a storage round-trip, and it is reached only
+    for a session that should have rows but has no local file at all.
+    """
+    from app.services.data_utils import (
+        enumerate_session_data_files,
+        session_has_stored_data,
+    )
+
+    if data.total_count > 0:
+        return False
+
+    statistics = getattr(session, "statistics", None)
+    if not statistics or (statistics.total_rows or 0) <= 0:
+        return False
+
+    if enumerate_session_data_files(session_id):
+        return False
+
+    return await session_has_stored_data(session_id)
+
+
 async def get_data(
     session_id: str,
     work_dir: Path,


### PR DESCRIPTION
## Problem

`GET /data/{session_id}` returns HTTP 200 with zero rows both for a session that genuinely has no rows and for one whose data files could not be read. `ensure_session_data_file_local` swallows a storage download failure (returns False, logs at debug), so after a redeploy with a cold local disk a populated project reports an empty table and nothing above debug level explains why. Clients that draw columns from the schema render bare column headers.

Separately, both data routes raise `HTTPException(404)` for a missing session inside a `try` whose generic `except Exception` re-raises everything as 500 — so a missing session currently answers 500 with detail "404: Session not found".

## Solution

- New `session_data_read_failed` predicate in `data_query.py`. Four conditions, cheapest first, all required: the read produced no rows at all (`total_count`, so a filter matching nothing or a page past the end never qualifies); the session's own statistics record rows; no data file resolved locally; the rows do exist in storage. Only the last costs a storage round-trip, reached only for a session that should have rows and has no local file.
- The third condition is what separates "emptied" from "missing": deleting every row leaves an empty file behind, and `remove-bulk` does not update statistics, so without it a fully emptied table would report 503.
- Both routes now return 503 with a retryable message and log at error level with the session id and expected row count.
- Added `except HTTPException: raise` ahead of the generic handler in both routes, matching the pattern already used in `stop_schematiq`. This also restores the intended 404.

## Verify

- Clean clone of main at `9d2d772`: `git apply --ignore-whitespace --check` passes; `python -m py_compile` passes on all three files.
- Predicate unit-checked over six cases: rows present, no statistics (new session), statistics report zero rows, all rows deleted (empty file present), file missing but stored, file missing and not stored. Only the fifth returns True, and the storage probe fires in two of the six.
- Applies cleanly alongside `fix/workspace-table-blanking` in either order (no file overlap).