### PR TITLE
feat(workspace): Ctrl/Cmd+B/I/U formatting shortcuts

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -60,6 +60,7 @@ export function SpreadsheetSurface({
   onOptimisticCellEdit,
   onEditFollowUp,
   onEditEnd,
+  onToggleFormatShortcut,
   layoutRevision,
   dataView,
 }: {
@@ -95,6 +96,9 @@ export function SpreadsheetSurface({
   ) => void;
   onEditFollowUp: (kind: PendingRerunKind, columns?: string[]) => void;
   onEditEnd: () => void;
+  // Toggle a text format (bold/italic/underline) on the current selection,
+  // invoked by the Ctrl/Cmd+B/I/U keyboard shortcuts registered below.
+  onToggleFormatShortcut?: (key: 'bold' | 'italic' | 'underline') => void;
   layoutRevision: string;
   // Current Data-sheet grouping. Drives the visual cell-merge of the leftmost
   // grouping column: 'by_unit' merges unit_name, 'by_document' merges the
@@ -510,6 +514,41 @@ export function SpreadsheetSurface({
   // skips re-pushing any init-only prop whose value is unchanged, so the plugin
   // is configured once and never torn down on subsequent renders. The list is
   // wrapper-facing metadata that Handsontable's core never reads at runtime.
+  // Latest-value ref so the shortcut callback (registered once at afterInit) is
+  // never stale, without re-registering on every render. Mirrors menuActionsRef.
+  const formatShortcutRef = useRef(onToggleFormatShortcut);
+  formatShortcutRef.current = onToggleFormatShortcut;
+
+  // Register Ctrl/Cmd+B/I/U through Handsontable's built-in ShortcutManager
+  // rather than a hand-rolled keydown handler. The shortcuts live in the 'grid'
+  // context, so they fire only when the grid is focused and NOT while a cell
+  // editor is open (typing "b" into a cell must not bold it). Ctrl+B/I/U are not
+  // Handsontable defaults, so this adds no conflict with copy/undo/select-all.
+  // Registered per instance at afterInit; the grid remounts on sheet/view
+  // changes, giving each instance its own fresh context (no accumulation).
+  const registerFormatShortcuts = useCallback(() => {
+    const hot = hotTableRef.current?.hotInstance;
+    if (!hot) return;
+    try {
+      const context = hot.getShortcutManager().getContext('grid');
+      if (!context) return;
+      const bindings: [string, 'bold' | 'italic' | 'underline'][] = [
+        ['b', 'bold'],
+        ['i', 'italic'],
+        ['u', 'underline'],
+      ];
+      for (const [letter, format] of bindings) {
+        context.addShortcut({
+          keys: [['control', letter], ['meta', letter]],
+          callback: () => { formatShortcutRef.current?.(format); },
+          preventDefault: true,
+          stopPropagation: true,
+          group: 'schematiq:formatting',
+        });
+      }
+    } catch { /* instance may be mid-teardown or context unavailable */ }
+  }, [hotTableRef]);
+
   const markFilterSettingsInitOnly = useCallback(() => {
     const hot = hotTableRef.current?.hotInstance;
     if (!hot) return;
@@ -1393,6 +1432,7 @@ export function SpreadsheetSurface({
           syncHotTableDimensions();
           applyGroupMerges();
           markFilterSettingsInitOnly();
+          registerFormatShortcuts();
           syncHeaderOverlayScroll();
         }}
         // Runs after Handsontable has drawn and (mis)clamped the header overlay's

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -735,6 +735,16 @@ function Workspace() {
     return { ...tableDisplay, ...selectedFormat };
   }, [activeSheet, cellFormats, sheetSelection, tableDisplay]);
 
+  // Keyboard shortcut entry point (Ctrl/Cmd+B/I/U). Toggles relative to the
+  // current selection's format, exactly like the toolbar buttons, and reuses
+  // applyTableFormat so cell-level vs sheet-level fallback stays identical.
+  const handleFormatShortcut = useCallback(
+    (key: 'bold' | 'italic' | 'underline') => {
+      applyTableFormat({ [key]: !selectedDisplayOptions[key] });
+    },
+    [applyTableFormat, selectedDisplayOptions],
+  );
+
   const printWorkspace = useCallback(() => {
     window.print();
   }, []);
@@ -944,6 +954,7 @@ function Workspace() {
         onOptimisticCellEdit={applyOptimisticCellEdits}
         onEditFollowUp={notifyEditFollowUp}
         onEditEnd={flushDeferredData}
+        onToggleFormatShortcut={handleFormatShortcut}
         layoutRevision={gridLayoutRevision}
         dataView={dataView}
       />


### PR DESCRIPTION
## Problem
Bold/italic/underline were only reachable from the toolbar; Ctrl+B/I/U did nothing. Handsontable has no native text-format shortcuts (it's a data grid).

## Solution
Register Ctrl/Cmd+B/I/U through Handsontable's built-in ShortcutManager (grid context) instead of a hand-rolled keydown handler, wired to the existing applyTableFormat. The shortcut toggles relative to the selection's current format, mirroring the toolbar buttons exactly, and reuses the same cell-level vs sheet-level fallback. Registered once per instance at afterInit via a latest-value ref (no stale closure, no re-registration). Shortcuts live in the grid context, so they don't fire while a cell editor is open, and Ctrl+B/I/U don't collide with Handsontable's copy/undo/select-all defaults.

## Verify
- ( cd frontend && npx tsc --noEmit ) passes; no new eslint warnings.
- Select cells, press Ctrl+B (Cmd+B on Mac): bold toggles; press again to remove. Same for Ctrl+I / Ctrl+U.
- While typing inside a cell editor, Ctrl+B does not format (editor context).
- Works on Data (both views) and Schema sheets; with no selection it toggles the sheet-wide display like the toolbar.