### PR TITLE
feat(chat): cap chat messages per workspace session

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -164,6 +164,16 @@ LLM_USAGE_SYNC_TTL_SECONDS = float(os.environ.get("LLM_USAGE_SYNC_TTL_SECONDS", 
 # limit" warning email (e.g. 0.8 = warn at 80%). Set to 0 to disable the warning.
 LLM_CALL_WARN_THRESHOLD = float(os.environ.get("LLM_CALL_WARN_THRESHOLD", "0.8"))
 
+# ── Chat Message Cap ─────────────────────────────────────────────
+# Maximum number of user chat messages accepted per workspace session.
+# Bounds how much of the global LLM quota any single project can consume,
+# independently of what the messages are about. Counted per workspace
+# session (not per conversation), in memory, and bypassed in developer mode.
+# Set to 0 to disable the cap.
+CHAT_MAX_MESSAGES_PER_SESSION = int(
+    os.environ.get("CHAT_MAX_MESSAGES_PER_SESSION", "250")
+)
+
 # ── Quota Alert Email ────────────────────────────────────────────
 # Send an email when the LLM quota is exceeded.
 # Uses the same Google OAuth credentials as Google Sheets (no extra passwords).

--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -9,11 +9,20 @@ import time
 import uuid
 from typing import Any, Optional
 
-from app.core.config import DEVELOPER_MODE, LLM_CALL_GLOBAL_LIMIT
+from app.core.config import (
+    CHAT_MAX_MESSAGES_PER_SESSION,
+    DEVELOPER_MODE,
+    LLM_CALL_GLOBAL_LIMIT,
+)
 from schematiq.core.llm_call_tracker import LLMCallTracker, QuotaExceededError
 
 from .deps import CHAT_MODEL, get_gemini_api_key, schematiq_runner
-from .session_store import ChatSessionState, PendingToolCall, chat_session_store
+from .session_store import (
+    ChatSessionState,
+    PendingToolCall,
+    chat_session_store,
+    session_message_counter,
+)
 from .tool_executor import tool_executor
 from .tool_registry import (
     TOOL_BY_NAME,
@@ -53,6 +62,13 @@ QUOTA_EXCEEDED_CHAT_MESSAGE = (
     "right now. Please contact us to restore access."
 )
 
+MESSAGE_CAP_CHAT_MESSAGE = (
+    "This project has reached its chat message limit "
+    f"({CHAT_MAX_MESSAGES_PER_SESSION} messages). The table and documents are "
+    "unaffected and remain editable. Please contact us if you need the limit "
+    "raised."
+)
+
 
 class ChatAgentService:
     def __init__(self) -> None:
@@ -74,6 +90,18 @@ class ChatAgentService:
         await asyncio.to_thread(
             schematiq_runner.check_global_quota, LLM_CALL_GLOBAL_LIMIT
         )
+
+    @staticmethod
+    def _message_cap_reached(session_id: str) -> bool:
+        """Return True when this workspace session is out of chat messages.
+
+        Read-only: the counter is only incremented once a turn is actually
+        going to run, so a capped request does not keep pushing the count up.
+        Bypassed in developer mode and when the cap is set to 0.
+        """
+        if DEVELOPER_MODE or CHAT_MAX_MESSAGES_PER_SESSION <= 0:
+            return False
+        return session_message_counter.count(session_id) >= CHAT_MAX_MESSAGES_PER_SESSION
 
     @staticmethod
     async def _flush_llm_usage(state: ChatSessionState) -> None:
@@ -111,6 +139,17 @@ class ChatAgentService:
     ) -> dict[str, Any]:
         state = self._get_or_create_session(session_id, session_mode, chat_id, model)
         outbound_messages: list[dict[str, Any]] = []
+        # Enforced before the pending-action handling and the quota check, so a
+        # capped session does no Gemini work at all. Creating the chat session
+        # above is local to the SDK and costs no API call.
+        if self._message_cap_reached(session_id):
+            outbound_messages.append(self._text_message(MESSAGE_CAP_CHAT_MESSAGE))
+            return {
+                "chat_id": state.chat_id,
+                "status": "complete",
+                "messages": outbound_messages,
+            }
+        session_message_counter.increment(session_id)
         if state.pending:
             abort_messages, new_pending = await self._abort_pending(
                 state,

--- a/backend/app/services/chat/session_store.py
+++ b/backend/app/services/chat/session_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import uuid
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -43,4 +44,35 @@ class ChatSessionStore:
         self._sessions.pop(chat_id, None)
 
 
+class SessionMessageCounter:
+    """Counts user chat messages per workspace session.
+
+    Keyed on the *workspace* session id rather than the chat id. A chat id is
+    minted per conversation and ``ChatSessionStore.delete`` drops it on stale
+    chat recovery, so counting there would let a caller reset the cap simply by
+    starting a new conversation.
+
+    In-memory only: the counts reset when the process restarts, the same
+    tradeoff as the local ``global_llm_usage.json`` runtime state. This is a
+    soft cap meant to bound a single project's quota consumption, not a durable
+    entitlement. Making it survive redeploys means persisting it to the storage
+    backend, which is deliberately out of scope here.
+    """
+
+    def __init__(self) -> None:
+        self._counts: dict[str, int] = {}
+        self._lock = threading.Lock()
+
+    def count(self, session_id: str) -> int:
+        with self._lock:
+            return self._counts.get(session_id, 0)
+
+    def increment(self, session_id: str) -> int:
+        with self._lock:
+            total = self._counts.get(session_id, 0) + 1
+            self._counts[session_id] = total
+            return total
+
+
 chat_session_store = ChatSessionStore()
+session_message_counter = SessionMessageCounter()


### PR DESCRIPTION
## Problem
Nothing bounds how many chat turns a single project can run. One message can trigger up to MAX_TOOL_ITERATIONS (10) Gemini calls, and LLM_CALL_GLOBAL_LIMIT defaults to 1000 calls, so a single session can exhaust the global quota for everyone.

## Solution
Add `CHAT_MAX_MESSAGES_PER_SESSION` (env var, default 250, 0 disables) and a `SessionMessageCounter` keyed on the workspace session id. `send_message` refuses past the cap with a plain assistant message, mirroring the existing QUOTA_EXCEEDED path, and returns before any Gemini work.

Keyed on the workspace session rather than the chat id on purpose: chat ids are minted per conversation and dropped on stale-chat recovery, so counting there would let a user reset the cap by starting a new conversation. Bypassed in DEVELOPER_MODE, like the global quota.

## Verify
- Set CHAT_MAX_MESSAGES_PER_SESSION=2, send three messages: the third returns the cap message with status "complete" and no Gemini call.
- A second session is unaffected; starting a new conversation in the capped session does not reset it.
- Counter is thread-safe: 8 threads x 1000 increments yields exactly 8000.
- `python -m pytest tests/test_chat_agent_safety.py tests/test_quota_warning.py`