### PR TITLE
feat(chat): persist the per-session message cap across restarts

### DIFF
--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -206,6 +206,9 @@ class VisualizationSession(BaseModel):
     # Privacy / data collection
     opt_out_data_collection: bool = False  # User opted out of research data archival
     write_artifacts: Optional[bool] = None  # If True, write debug artifacts like skip rationales
+    # Chat usage, persisted so CHAT_MAX_MESSAGES_PER_SESSION survives a redeploy.
+    # Defaults to 0, so sessions stored before this field existed load fine.
+    chat_messages_used: int = 0
 
 class DataRow(BaseModel):
     """A single row of data."""

--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -16,13 +16,8 @@ from app.core.config import (
 )
 from schematiq.core.llm_call_tracker import LLMCallTracker, QuotaExceededError
 
-from .deps import CHAT_MODEL, get_gemini_api_key, schematiq_runner
-from .session_store import (
-    ChatSessionState,
-    PendingToolCall,
-    chat_session_store,
-    session_message_counter,
-)
+from .deps import CHAT_MODEL, get_gemini_api_key, schematiq_runner, session_manager
+from .session_store import ChatSessionState, PendingToolCall, chat_session_store
 from .tool_executor import tool_executor
 from .tool_registry import (
     TOOL_BY_NAME,
@@ -95,13 +90,47 @@ class ChatAgentService:
     def _message_cap_reached(session_id: str) -> bool:
         """Return True when this workspace session is out of chat messages.
 
-        Read-only: the counter is only incremented once a turn is actually
-        going to run, so a capped request does not keep pushing the count up.
-        Bypassed in developer mode and when the cap is set to 0.
+        Reads the count off the persisted session record, so the cap survives a
+        redeploy — an in-memory counter reset on every Railway deploy, which on
+        an actively developed backend is often enough to make the cap porous.
+
+        get_session only touches SessionManager's in-memory dict, so this is
+        cheap; only the increment pays for a write.
+
+        Read-only: the count is bumped once a turn is actually going to run, so
+        a capped request does not keep pushing it up. Bypassed in developer mode
+        and when the cap is set to 0.
         """
         if DEVELOPER_MODE or CHAT_MAX_MESSAGES_PER_SESSION <= 0:
             return False
-        return session_message_counter.count(session_id) >= CHAT_MAX_MESSAGES_PER_SESSION
+        session = session_manager.get_session(session_id)
+        if session is None:
+            # The route layer rejects unknown sessions before reaching this, so
+            # this is only hit in tests or by a direct service call. Don't cap
+            # something we cannot count.
+            return False
+        return session.chat_messages_used >= CHAT_MAX_MESSAGES_PER_SESSION
+
+    @staticmethod
+    async def _record_message_used(session_id: str) -> None:
+        """Persist one more consumed chat message for this workspace session.
+
+        update_session writes through to the storage backend synchronously, so it
+        goes to a thread — matching how the other services record LLM usage.
+        Best effort: failing to bill a message must not fail the user's turn.
+        """
+        if DEVELOPER_MODE or CHAT_MAX_MESSAGES_PER_SESSION <= 0:
+            return
+        try:
+            session = session_manager.get_session(session_id)
+            if session is None:
+                return
+            session.chat_messages_used += 1
+            await asyncio.to_thread(session_manager.update_session, session)
+        except Exception as exc:
+            logger.warning(
+                "could not record chat message use for session %s: %s", session_id, exc
+            )
 
     @staticmethod
     async def _flush_llm_usage(state: ChatSessionState) -> None:
@@ -143,13 +172,20 @@ class ChatAgentService:
         # capped session does no Gemini work at all. Creating the chat session
         # above is local to the SDK and costs no API call.
         if self._message_cap_reached(session_id):
+            # Logged so a project hitting the ceiling is visible in the Railway
+            # logs; there is no admin surface for this yet.
+            logger.warning(
+                "chat message cap reached for session %s (limit %d)",
+                session_id,
+                CHAT_MAX_MESSAGES_PER_SESSION,
+            )
             outbound_messages.append(self._text_message(MESSAGE_CAP_CHAT_MESSAGE))
             return {
                 "chat_id": state.chat_id,
                 "status": "complete",
                 "messages": outbound_messages,
             }
-        session_message_counter.increment(session_id)
+        await self._record_message_used(session_id)
         if state.pending:
             abort_messages, new_pending = await self._abort_pending(
                 state,

--- a/backend/app/services/chat/session_store.py
+++ b/backend/app/services/chat/session_store.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import threading
 import uuid
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -44,35 +43,4 @@ class ChatSessionStore:
         self._sessions.pop(chat_id, None)
 
 
-class SessionMessageCounter:
-    """Counts user chat messages per workspace session.
-
-    Keyed on the *workspace* session id rather than the chat id. A chat id is
-    minted per conversation and ``ChatSessionStore.delete`` drops it on stale
-    chat recovery, so counting there would let a caller reset the cap simply by
-    starting a new conversation.
-
-    In-memory only: the counts reset when the process restarts, the same
-    tradeoff as the local ``global_llm_usage.json`` runtime state. This is a
-    soft cap meant to bound a single project's quota consumption, not a durable
-    entitlement. Making it survive redeploys means persisting it to the storage
-    backend, which is deliberately out of scope here.
-    """
-
-    def __init__(self) -> None:
-        self._counts: dict[str, int] = {}
-        self._lock = threading.Lock()
-
-    def count(self, session_id: str) -> int:
-        with self._lock:
-            return self._counts.get(session_id, 0)
-
-    def increment(self, session_id: str) -> int:
-        with self._lock:
-            total = self._counts.get(session_id, 0) + 1
-            self._counts[session_id] = total
-            return total
-
-
 chat_session_store = ChatSessionStore()
-session_message_counter = SessionMessageCounter()

--- a/backend/tests/test_chat_message_cap.py
+++ b/backend/tests/test_chat_message_cap.py
@@ -1,8 +1,9 @@
 """Tests for the per-workspace-session chat message cap.
 
 The contract: once a workspace session has used its allowance, send_message
-returns a plain refusal and performs no Gemini work at all — and the allowance
-cannot be reset by starting a new conversation.
+returns a plain refusal and performs no Gemini work at all. The allowance is
+held on the persisted session record, so it survives both a new conversation
+and a process restart.
 
 Uses a fake Gemini chat, so no real LLM or network call happens.
 """
@@ -16,11 +17,7 @@ from app.services.chat.agent_service import (
     MESSAGE_CAP_CHAT_MESSAGE,
     ChatAgentService,
 )
-from app.services.chat.session_store import (
-    ChatSessionState,
-    SessionMessageCounter,
-    chat_session_store,
-)
+from app.services.chat.session_store import chat_session_store
 
 
 class _FakeResponse:
@@ -37,6 +34,39 @@ class _FakeChat:
     async def send_message(self, content):
         self.sent.append(content)
         return _FakeResponse()
+
+
+class _FakeSession:
+    """Stand-in for VisualizationSession, with the persisted counter field."""
+
+    def __init__(self, session_id: str) -> None:
+        self.id = session_id
+        self.chat_messages_used = 0
+
+
+@pytest.fixture
+def store(monkeypatch):
+    """An in-test stand-in for the persisted session store.
+
+    Records every update_session call so tests can prove the count is written
+    through to storage rather than only held in memory.
+    """
+    sessions: dict[str, _FakeSession] = {}
+    writes: list[str] = []
+
+    def _get_session(session_id: str):
+        return sessions.setdefault(session_id, _FakeSession(session_id))
+
+    def _update_session(session):
+        writes.append(session.id)
+
+    monkeypatch.setattr(
+        agent_module.session_manager, "get_session", _get_session, raising=True
+    )
+    monkeypatch.setattr(
+        agent_module.session_manager, "update_session", _update_session, raising=True
+    )
+    return type("Store", (), {"sessions": sessions, "writes": writes})()
 
 
 @pytest.fixture
@@ -62,19 +92,10 @@ def service(monkeypatch):
     monkeypatch.setattr(svc, "_create_gemini_chat", _fake_create, raising=True)
     monkeypatch.setattr(svc, "_ensure_quota_available", _no_quota, raising=True)
     monkeypatch.setattr(svc, "_flush_llm_usage", _no_flush, raising=True)
-    svc._test_chats = chats  # type: ignore[attr-defined]
     svc._test_turns = lambda sid: sum(  # type: ignore[attr-defined]
         len(c.sent) for c in chats.get(sid, [])
     )
     return svc
-
-
-@pytest.fixture
-def fresh_counter(monkeypatch):
-    """Isolate the module-level counter so tests don't leak into each other."""
-    counter = SessionMessageCounter()
-    monkeypatch.setattr(agent_module, "session_message_counter", counter, raising=True)
-    return counter
 
 
 def _set_cap(monkeypatch, value: int) -> None:
@@ -85,51 +106,34 @@ def _set_cap(monkeypatch, value: int) -> None:
     monkeypatch.setattr(agent_module, "DEVELOPER_MODE", False, raising=True)
 
 
-# --- counter semantics ----------------------------------------------------
-
-
-def test_counter_is_per_workspace_session():
-    counter = SessionMessageCounter()
-    counter.increment("sess-a")
-    counter.increment("sess-a")
-    counter.increment("sess-b")
-    assert counter.count("sess-a") == 2
-    assert counter.count("sess-b") == 1
-    assert counter.count("sess-never-seen") == 0
-
-
-def test_counter_increments_are_thread_safe():
-    import threading
-
-    counter = SessionMessageCounter()
-
-    def bump():
-        for _ in range(500):
-            counter.increment("sess")
-
-    threads = [threading.Thread(target=bump) for _ in range(8)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-    assert counter.count("sess") == 4000
+def _texts(result) -> list[str]:
+    return [m["content"] for m in result["messages"]]
 
 
 # --- enforcement ----------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_messages_under_the_cap_reach_gemini(service, fresh_counter, monkeypatch):
+async def test_messages_under_the_cap_reach_gemini(service, store, monkeypatch):
     _set_cap(monkeypatch, 2)
     result = await service.send_message("sess-1", "add a rationale", "schematiq")
     assert result["status"] == "complete"
     assert service._test_turns("sess-1") == 1, "turn should have reached Gemini"
-    assert fresh_counter.count("sess-1") == 1
+    assert store.sessions["sess-1"].chat_messages_used == 1
+
+
+@pytest.mark.asyncio
+async def test_the_count_is_written_through_to_storage(service, store, monkeypatch):
+    """The whole point of moving off an in-memory counter."""
+    _set_cap(monkeypatch, 5)
+    await service.send_message("sess-1", "one", "schematiq")
+    await service.send_message("sess-1", "two", "schematiq")
+    assert store.writes == ["sess-1", "sess-1"]
 
 
 @pytest.mark.asyncio
 async def test_capped_session_refuses_and_makes_no_gemini_call(
-    service, fresh_counter, monkeypatch
+    service, store, monkeypatch
 ):
     _set_cap(monkeypatch, 2)
     await service.send_message("sess-1", "one", "schematiq")
@@ -140,17 +144,35 @@ async def test_capped_session_refuses_and_makes_no_gemini_call(
     result = await service.send_message("sess-1", "three", "schematiq")
 
     assert result["status"] == "complete"
-    assert [m["content"] for m in result["messages"]] == [MESSAGE_CAP_CHAT_MESSAGE]
+    assert _texts(result) == [MESSAGE_CAP_CHAT_MESSAGE]
     assert service._test_turns("sess-1") == turns_before, (
         "a capped turn must not reach Gemini"
     )
-    # The refused turn must not push the counter further up.
-    assert fresh_counter.count("sess-1") == 2
+    # The refused turn must not push the count further up.
+    assert store.sessions["sess-1"].chat_messages_used == 2
+
+
+@pytest.mark.asyncio
+async def test_cap_survives_a_process_restart(service, store, monkeypatch):
+    """A fresh service instance still sees the count: it lives on the session."""
+    _set_cap(monkeypatch, 1)
+    await service.send_message("sess-1", "one", "schematiq")
+
+    restarted = ChatAgentService()
+    monkeypatch.setattr(
+        restarted,
+        "_create_gemini_chat",
+        lambda sid, mode, model=None: (object(), _FakeChat()),
+        raising=True,
+    )
+    result = await restarted.send_message("sess-1", "two", "schematiq")
+
+    assert _texts(result) == [MESSAGE_CAP_CHAT_MESSAGE]
 
 
 @pytest.mark.asyncio
 async def test_cap_is_not_reset_by_starting_a_new_conversation(
-    service, fresh_counter, monkeypatch
+    service, store, monkeypatch
 ):
     _set_cap(monkeypatch, 1)
     first = await service.send_message("sess-1", "one", "schematiq")
@@ -160,38 +182,47 @@ async def test_cap_is_not_reset_by_starting_a_new_conversation(
 
     result = await service.send_message("sess-1", "two", "schematiq", chat_id=None)
 
-    assert [m["content"] for m in result["messages"]] == [MESSAGE_CAP_CHAT_MESSAGE]
+    assert _texts(result) == [MESSAGE_CAP_CHAT_MESSAGE]
 
 
 @pytest.mark.asyncio
-async def test_other_sessions_are_unaffected(service, fresh_counter, monkeypatch):
+async def test_other_sessions_are_unaffected(service, store, monkeypatch):
     _set_cap(monkeypatch, 1)
     await service.send_message("sess-1", "one", "schematiq")
     capped = await service.send_message("sess-1", "two", "schematiq")
-    assert [m["content"] for m in capped["messages"]] == [MESSAGE_CAP_CHAT_MESSAGE]
+    assert _texts(capped) == [MESSAGE_CAP_CHAT_MESSAGE]
 
-    other = await service.send_message("sess-2", "one", "schematiq")
-    assert other["messages"] == [] or MESSAGE_CAP_CHAT_MESSAGE not in [
-        m["content"] for m in other["messages"]
-    ]
+    await service.send_message("sess-2", "one", "schematiq")
     assert service._test_turns("sess-2") == 1, "a different project keeps working"
+
+
+@pytest.mark.asyncio
+async def test_unknown_session_is_not_capped(service, monkeypatch):
+    """The route layer 404s these first; the service must not crash on them."""
+    _set_cap(monkeypatch, 1)
+    monkeypatch.setattr(
+        agent_module.session_manager, "get_session", lambda sid: None, raising=True
+    )
+    result = await service.send_message("ghost", "hi", "schematiq")
+    assert _texts(result) != [MESSAGE_CAP_CHAT_MESSAGE]
 
 
 # --- escape hatches -------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_cap_of_zero_disables_enforcement(service, fresh_counter, monkeypatch):
+async def test_cap_of_zero_disables_enforcement(service, store, monkeypatch):
     _set_cap(monkeypatch, 0)
     for _ in range(5):
         result = await service.send_message("sess-1", "hi", "schematiq")
-    assert MESSAGE_CAP_CHAT_MESSAGE not in [m["content"] for m in result["messages"]]
+    assert MESSAGE_CAP_CHAT_MESSAGE not in _texts(result)
+    assert store.writes == [], "disabled cap should not write to storage"
 
 
 @pytest.mark.asyncio
-async def test_developer_mode_bypasses_the_cap(service, fresh_counter, monkeypatch):
+async def test_developer_mode_bypasses_the_cap(service, store, monkeypatch):
     monkeypatch.setattr(agent_module, "CHAT_MAX_MESSAGES_PER_SESSION", 1, raising=True)
     monkeypatch.setattr(agent_module, "DEVELOPER_MODE", True, raising=True)
     await service.send_message("sess-1", "one", "schematiq")
     result = await service.send_message("sess-1", "two", "schematiq")
-    assert MESSAGE_CAP_CHAT_MESSAGE not in [m["content"] for m in result["messages"]]
+    assert MESSAGE_CAP_CHAT_MESSAGE not in _texts(result)


### PR DESCRIPTION
## Problem
CHAT_MAX_MESSAGES_PER_SESSION was enforced against an in-memory SessionMessageCounter, so every Railway redeploy reset every project's allowance to zero. On an actively deployed backend that makes the cap porous.

## Solution
Move the count onto the persisted session record as `chat_messages_used: int = 0`, which SessionManager already writes through to the storage backend. Sessions stored before this field existed load with 0.

- Reads are free: get_session only touches SessionManager's in-memory dict.
- Writes go through asyncio.to_thread, because update_session -> save_session_sync blocks — matching how the other services record LLM usage.
- The increment is best effort: failing to bill a message must not fail the user's turn.
- SessionMessageCounter is removed so there is a single source of truth.
- A cap hit now logs a warning; there is no admin surface for this yet.

## Verify
- `python -m pytest tests/` -> 173 passed.
- New tests pin write-through to storage and survival across a fresh ChatAgentService instance; both fail against the unpatched service.
- Set CHAT_MAX_MESSAGES_PER_SESSION=2, send 3 messages, redeploy, send another: still capped.