### PR TITLE
chore(frontend): drop dead session listing client methods

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -204,11 +204,6 @@ export const loadAPI = {
     return response.data;
   },
 
-  listSessions: async (): Promise<VisualizationSession[]> => {
-    const response = await api.get('/load/sessions');
-    return response.data;
-  },
-
   deleteSession: async (sessionId: string): Promise<void> => {
     await api.delete(`/load/sessions/${sessionId}`);
   },
@@ -345,11 +340,6 @@ export const schematiqAPI = {
     message: string;
   }> => {
     const response = await api.post(`/schematiq/stop/${sessionId}`);
-    return response.data;
-  },
-
-  listSessions: async (): Promise<VisualizationSession[]> => {
-    const response = await api.get('/schematiq/sessions');
     return response.data;
   },
 


### PR DESCRIPTION
## Problem
loadAPI.listSessions and schematiqAPI.listSessions still called GET /load/sessions and /schematiq/sessions, both removed as unauthenticated enumeration endpoints. Zero call sites, but they read as available API surface.

## Solution
Remove both methods. recentProjects.ts remains the per-browser project registry.

## Verify
- `( cd frontend && npx tsc --noEmit )` clean before and after.
- No remaining reference to listSessions anywhere in frontend/src or backend.