### PR TITLE
feat(auth): add Supabase identity and session ownership, off by default

### DIFF
--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,0 +1,40 @@
+"""Auth introspection.
+
+Exists so the frontend (and a curl from a laptop) can confirm that a Supabase
+access token is being issued, sent, and verified correctly — before ownership
+enforcement is switched on and a misconfiguration would lock people out.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.core.auth import AuthenticatedUser, get_optional_user
+from app.core.config import AUTH_ENFORCED
+
+router = APIRouter(tags=["auth"])
+
+
+class AuthStatus(BaseModel):
+    authenticated: bool
+    user_id: Optional[str] = None
+    email: Optional[str] = None
+    # Lets the frontend know whether ownership is being enforced yet, so it can
+    # decide between prompting for sign-in and staying out of the way.
+    enforced: bool
+
+
+@router.get("/me", response_model=AuthStatus)
+async def read_current_user(
+    user: Optional[AuthenticatedUser] = Depends(get_optional_user),
+) -> AuthStatus:
+    """Report who the caller is, without requiring them to be anyone."""
+    if user is None:
+        return AuthStatus(authenticated=False, enforced=AUTH_ENFORCED)
+    return AuthStatus(
+        authenticated=True,
+        user_id=user.id,
+        email=user.email,
+        enforced=AUTH_ENFORCED,
+    )

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1,0 +1,170 @@
+"""Caller identity, derived from a Supabase Auth access token.
+
+Verification is local: the token's signature is checked against either the
+project's legacy shared secret (HS256) or a public key from the JWKS endpoint
+(ES256/RS256). No request is made to Supabase on the hot path, and PyJWKClient
+caches the public keys in memory.
+
+Supporting both algorithm families is not optional. Supabase projects created
+before JWT signing keys shipped are still on the shared secret, while newer
+projects and Supabase CLI >= 2.71.1 default to asymmetric keys. A backend that
+verifies against only one of them breaks on the other.
+
+Security note: the two verification paths are kept strictly separate. An
+asymmetric algorithm is only ever verified with a JWKS public key, and HS256 is
+only ever verified with the shared secret. Selecting the key material by the
+token's own `alg` header without that separation is the classic algorithm
+confusion attack, where a public key is passed as an HMAC secret.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import jwt
+from fastapi import Depends, HTTPException, Request
+from jwt import PyJWKClient
+
+from app.core.config import (
+    SUPABASE_JWKS_URL,
+    SUPABASE_JWT_AUDIENCE,
+    SUPABASE_JWT_SECRET,
+)
+
+logger = logging.getLogger(__name__)
+
+# Only these are ever accepted. Notably excludes "none".
+_ASYMMETRIC_ALGORITHMS = ("ES256", "RS256")
+_SYMMETRIC_ALGORITHMS = ("HS256",)
+
+_jwks_client: Optional[PyJWKClient] = None
+
+
+class AuthError(Exception):
+    """The presented token could not be verified."""
+
+
+@dataclass(frozen=True)
+class AuthenticatedUser:
+    """The verified subject of a Supabase access token."""
+
+    id: str
+    email: Optional[str] = None
+
+    @property
+    def short_id(self) -> str:
+        """For log lines, so full user ids don't end up in logs."""
+        return self.id[:8]
+
+
+def _get_jwks_client() -> PyJWKClient:
+    """Lazily build a cached JWKS client.
+
+    Built on first use rather than at import time so the module stays importable
+    with no Supabase configuration, which is how local development and the test
+    suite run.
+    """
+    global _jwks_client
+    if _jwks_client is None:
+        if not SUPABASE_JWKS_URL:
+            raise AuthError("no JWKS url configured")
+        # PyJWKClient keeps fetched keys in memory, so key rotation resolves on
+        # the next miss without a redeploy.
+        _jwks_client = PyJWKClient(SUPABASE_JWKS_URL, cache_keys=True)
+    return _jwks_client
+
+
+def reset_jwks_client_cache() -> None:
+    """Drop the cached JWKS client. Used by tests and after config changes."""
+    global _jwks_client
+    _jwks_client = None
+
+
+def verify_access_token(token: str) -> AuthenticatedUser:
+    """Verify a Supabase access token and return its subject.
+
+    Raises AuthError for anything that is not a valid, unexpired token for this
+    project.
+    """
+    if not token:
+        raise AuthError("empty token")
+
+    try:
+        header = jwt.get_unverified_header(token)
+    except jwt.PyJWTError as exc:
+        raise AuthError(f"malformed token header: {exc}") from exc
+
+    alg = header.get("alg")
+    if alg in _ASYMMETRIC_ALGORITHMS:
+        try:
+            signing_key = _get_jwks_client().get_signing_key_from_jwt(token)
+        except AuthError:
+            raise
+        except Exception as exc:
+            raise AuthError(f"no usable JWKS key: {exc}") from exc
+        key: Any = signing_key.key
+        algorithms = list(_ASYMMETRIC_ALGORITHMS)
+    elif alg in _SYMMETRIC_ALGORITHMS:
+        if not SUPABASE_JWT_SECRET:
+            raise AuthError("HS256 token presented but no JWT secret configured")
+        key = SUPABASE_JWT_SECRET
+        algorithms = list(_SYMMETRIC_ALGORITHMS)
+    else:
+        raise AuthError(f"unsupported token algorithm: {alg!r}")
+
+    try:
+        claims = jwt.decode(
+            token,
+            key,
+            algorithms=algorithms,
+            audience=SUPABASE_JWT_AUDIENCE,
+            options={"require": ["exp", "sub"]},
+        )
+    except jwt.PyJWTError as exc:
+        raise AuthError(f"token rejected: {exc}") from exc
+
+    subject = claims.get("sub")
+    if not subject:
+        raise AuthError("token has no subject")
+    return AuthenticatedUser(id=str(subject), email=claims.get("email"))
+
+
+def _bearer_token(request: Request) -> Optional[str]:
+    header = request.headers.get("authorization") or ""
+    scheme, _, value = header.partition(" ")
+    if scheme.lower() != "bearer" or not value.strip():
+        return None
+    return value.strip()
+
+
+async def get_optional_user(request: Request) -> Optional[AuthenticatedUser]:
+    """Identify the caller if it presented a valid token, else return None.
+
+    Never raises on a bad token: this is for endpoints that behave differently
+    for signed-in callers but stay reachable without one. An invalid token is
+    logged and treated as anonymous, so a stale token in a browser cannot make
+    the app unusable.
+    """
+    token = _bearer_token(request)
+    if not token:
+        return None
+    try:
+        return verify_access_token(token)
+    except AuthError as exc:
+        logger.info("ignoring unverifiable access token: %s", exc)
+        return None
+
+
+async def require_user(
+    user: Optional[AuthenticatedUser] = Depends(get_optional_user),
+) -> AuthenticatedUser:
+    """Identify the caller, or reject the request with 401."""
+    if user is None:
+        raise HTTPException(
+            status_code=401,
+            detail="Authentication required.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return user

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -92,6 +92,40 @@ STORAGE_BACKEND = os.environ.get("STORAGE_BACKEND", "local")
 SUPABASE_URL = os.environ.get("SUPABASE_URL", "")
 SUPABASE_KEY = os.environ.get("SUPABASE_KEY", "")
 
+# ── Authentication ───────────────────────────────────────────────
+# Identity comes from Supabase Auth. The backend verifies the access token
+# locally, so there is no round trip to Supabase on each request.
+#
+# Supabase signs session JWTs either with the project's legacy shared secret
+# (HS256) or with an asymmetric key published at the JWKS endpoint (ES256/RS256).
+# Newer projects and Supabase CLI >= 2.71.1 default to asymmetric, so both paths
+# are supported: set SUPABASE_JWT_SECRET for the legacy case, and the JWKS URL is
+# derived from SUPABASE_URL for the asymmetric case.
+SUPABASE_JWT_SECRET = os.environ.get("SUPABASE_JWT_SECRET", "")
+SUPABASE_JWKS_URL = os.environ.get(
+    "SUPABASE_JWKS_URL",
+    f"{SUPABASE_URL}/auth/v1/.well-known/jwks.json" if SUPABASE_URL else "",
+)
+# Expected `aud` claim on a Supabase user access token.
+SUPABASE_JWT_AUDIENCE = os.environ.get("SUPABASE_JWT_AUDIENCE", "authenticated")
+
+# Master switch for ownership enforcement. Deliberately OFF by default: this
+# release only adds the ability to identify a caller. Turning it on before the
+# frontend sends tokens, and before existing sessions have an owner, would lock
+# real users out of their own projects.
+AUTH_ENFORCED = os.environ.get("AUTH_ENFORCED", "false").lower() == "true"
+
+# What to do, once AUTH_ENFORCED is on, with sessions that still have no owner.
+# Sessions created before ownership existed start unowned, and an authenticated
+# caller claims them on first access, so in practice only sessions nobody has
+# opened since sign-in shipped are still here.
+#   "allow" — anonymous callers may still reach them (each access is logged).
+#             Safe for continuity, but keeps the old open behaviour for those
+#             sessions, so it is a grace period and not an end state.
+#   "deny"  — unowned sessions are unreachable without ownership. Safe by
+#             default, but will 404 any project nobody has claimed yet.
+AUTH_LEGACY_SESSION_POLICY = os.environ.get("AUTH_LEGACY_SESSION_POLICY", "allow")
+
 # ── Release Mode vs Developer Mode ──────────────────────────────
 def _env_flag(name: str, *, default: bool = False) -> bool:
     """Read a boolean environment variable (accepts 1/true/yes, any case)."""

--- a/backend/app/core/session_access.py
+++ b/backend/app/core/session_access.py
@@ -1,0 +1,121 @@
+"""Ownership of workspace sessions.
+
+Applied as a router-level dependency, so one piece of code covers every
+session-scoped route instead of ~70 handlers each remembering to check. FastAPI
+resolves ``session_id`` from the path for routes that declare it and passes None
+for routes that don't, which makes the dependency safe to attach wholesale.
+
+Rollout is deliberately two-phase, because turning ownership on in one step on a
+live deployment locks real users out of their own projects:
+
+  Phase 1 — AUTH_ENFORCED off (the default). Nothing is denied. But an
+  authenticated caller reaching an unowned session *claims* it. Real users
+  signing in therefore backfill ownership of their own projects just by using
+  the app, with no manual mapping and no downtime.
+
+  Phase 2 — AUTH_ENFORCED on. Ownership is required. By then the sessions people
+  actually use already have owners from phase 1.
+
+AUTH_LEGACY_SESSION_POLICY decides what happens in phase 2 to sessions that
+still have no owner, which is the part worth thinking about before flipping the
+switch. See the constant's docstring in config.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from fastapi import Depends, HTTPException
+
+from app.core.auth import AuthenticatedUser, get_optional_user
+from app.core.config import AUTH_ENFORCED, AUTH_LEGACY_SESSION_POLICY
+from app.services import session_manager
+
+logger = logging.getLogger(__name__)
+
+# Returned instead of 403 when a caller asks for someone else's session. A 403
+# would confirm that the id exists, which is exactly the enumeration signal the
+# session listing endpoints used to hand out. 404 keeps "not yours" and "not
+# real" indistinguishable.
+_NOT_FOUND = HTTPException(status_code=404, detail="Session not found.")
+
+
+async def _claim(session, user: AuthenticatedUser) -> None:
+    """Record this user as the owner of a previously unowned session.
+
+    update_session writes through to storage synchronously, so it goes to a
+    thread. Best effort: a failed claim must not break the request. The next
+    access simply tries again.
+    """
+    try:
+        session.owner_id = user.id
+        await asyncio.to_thread(session_manager.update_session, session)
+        logger.info(
+            "session %s claimed by user %s", session.id, user.short_id
+        )
+    except Exception as exc:
+        logger.warning("could not claim session %s: %s", session.id, exc)
+
+
+async def require_session_access(
+    session_id: Optional[str] = None,
+    user: Optional[AuthenticatedUser] = Depends(get_optional_user),
+) -> None:
+    """Enforce (or, in phase 1, establish) ownership of a session.
+
+    Silent and permissive by design when there is nothing to decide: routes with
+    no session in the path, and sessions that don't exist, are left to the route
+    to handle so error semantics stay where they already are.
+    """
+    if session_id is None:
+        # Not a session-scoped route. Note that for such routes FastAPI would
+        # read `session_id` as a query parameter, so a caller can pass one — it
+        # is only ever used to check access, never to select data, so a bogus
+        # value can at worst produce a 404 on a route that ignores it.
+        return
+
+    session = session_manager.get_session(session_id)
+    if session is None:
+        # Let the route produce its own 404 (chat already does), and keep this
+        # dependency from becoming a second, subtly different not-found path.
+        return
+
+    owner_id = getattr(session, "owner_id", None)
+
+    if owner_id is None:
+        if user is not None:
+            await _claim(session, user)
+            return
+        # Unowned and anonymous.
+        if AUTH_ENFORCED and AUTH_LEGACY_SESSION_POLICY == "deny":
+            raise _NOT_FOUND
+        if AUTH_ENFORCED:
+            logger.warning(
+                "anonymous access to unowned session %s allowed by "
+                "AUTH_LEGACY_SESSION_POLICY=%s",
+                session_id,
+                AUTH_LEGACY_SESSION_POLICY,
+            )
+        return
+
+    if not AUTH_ENFORCED:
+        # Ownership is recorded but not yet load-bearing.
+        return
+
+    if user is None:
+        raise HTTPException(
+            status_code=401,
+            detail="Authentication required.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if owner_id != user.id:
+        logger.warning(
+            "user %s denied access to session %s owned by %s",
+            user.short_id,
+            session_id,
+            owner_id[:8],
+        )
+        raise _NOT_FOUND

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,7 +34,7 @@ for _handler in logging.root.handlers:
 # Suppress noisy uvicorn access logs (frontend polling every ~3s floods Railway logs)
 logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.routes.load import router as load_router
@@ -45,6 +45,8 @@ from app.api.routes.cloud_data import router as cloud_data_router
 from app.api.routes.observation_unit import router as observation_unit_router
 from app.api.routes.units import router as units_router
 from app.api.routes.feedback import router as feedback_router
+from app.api.routes.auth import router as auth_router
+from app.core.session_access import require_session_access
 from app.api.routes.chat import router as chat_router
 from app.api.routes.reference import router as reference_router
 from app.api.routes.support import router as support_router
@@ -113,17 +115,23 @@ app.add_middleware(
     expose_headers=["Content-Disposition"],  # Allow frontend to read download filename
 )
 
+# Session ownership, applied once per session-scoped router rather than in each
+# handler. The websocket router and the auth/feedback/support routers are not
+# session-scoped in the same way and are covered separately.
+_owns_session = Depends(require_session_access)
+
 # Include routers
-app.include_router(load_router, prefix="/api/load", tags=["load"])
-app.include_router(schematiq_router, prefix="/api/schematiq", tags=["schematiq"])
-app.include_router(schema_router, prefix="/api/schema", tags=["schema"])
+app.include_router(load_router, prefix="/api/load", tags=["load"], dependencies=[_owns_session])
+app.include_router(schematiq_router, prefix="/api/schematiq", tags=["schematiq"], dependencies=[_owns_session])
+app.include_router(schema_router, prefix="/api/schema", tags=["schema"], dependencies=[_owns_session])
 app.include_router(websocket_router, prefix="/ws", tags=["websocket"])
-app.include_router(cloud_data_router, prefix="/api", tags=["cloud-data"])
-app.include_router(observation_unit_router, prefix="/api/observation-unit", tags=["observation-unit"])
-app.include_router(units_router, prefix="/api/units", tags=["units"])
+app.include_router(cloud_data_router, prefix="/api", tags=["cloud-data"], dependencies=[_owns_session])
+app.include_router(observation_unit_router, prefix="/api/observation-unit", tags=["observation-unit"], dependencies=[_owns_session])
+app.include_router(units_router, prefix="/api/units", tags=["units"], dependencies=[_owns_session])
 app.include_router(feedback_router, prefix="/api/feedback", tags=["feedback"])
-app.include_router(chat_router, prefix="/api/chat", tags=["chat"])
-app.include_router(reference_router, prefix="/api/reference", tags=["reference"])
+app.include_router(chat_router, prefix="/api/chat", tags=["chat"], dependencies=[_owns_session])
+app.include_router(auth_router, prefix="/api/auth", tags=["auth"])
+app.include_router(reference_router, prefix="/api/reference", tags=["reference"], dependencies=[_owns_session])
 app.include_router(support_router, prefix="/api/support", tags=["support"])
 
 logger = logging.getLogger(__name__)

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -204,6 +204,9 @@ class VisualizationSession(BaseModel):
     # External reference documents (supplementary lookup material, not row sources)
     reference_documents: List[ReferenceDocument] = Field(default_factory=list)
     # Privacy / data collection
+    # Owning Supabase Auth user id. None means the session predates ownership
+    # (or was created while AUTH_ENFORCED was off) and is treated as legacy.
+    owner_id: Optional[str] = None
     opt_out_data_collection: bool = False  # User opted out of research data archival
     write_artifacts: Optional[bool] = None  # If True, write debug artifacts like skip rationales
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -32,6 +32,7 @@ tqdm>=4.65.0
 
 # Cloud Storage
 supabase>=2.0.0
+PyJWT[crypto]>=2.8.0
 
 # Google Drive/Sheets (optional, for research data collection)
 google-api-python-client>=2.100.0

--- a/backend/tests/test_auth_route.py
+++ b/backend/tests/test_auth_route.py
@@ -1,0 +1,130 @@
+"""Tests for /api/auth/me and the two identity dependencies.
+
+The route functions are called directly rather than through a TestClient so the
+whole app (and its ML imports) stays out of the way.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+import pytest
+from fastapi import HTTPException
+
+from app.api.routes import auth as auth_route
+from app.core import auth as auth_module
+from app.core.auth import AuthenticatedUser, get_optional_user, require_user
+
+SECRET = "test-jwt-secret-value-long-enough-for-sha256"
+
+
+class _Request:
+    """Minimal stand-in for starlette's Request: only headers are read."""
+
+    def __init__(self, authorization: str | None = None) -> None:
+        self.headers = {"authorization": authorization} if authorization else {}
+
+
+@pytest.fixture(autouse=True)
+def configured(monkeypatch):
+    monkeypatch.setattr(auth_module, "SUPABASE_JWT_SECRET", SECRET, raising=True)
+    monkeypatch.setattr(auth_module, "SUPABASE_JWT_AUDIENCE", "authenticated", raising=True)
+    monkeypatch.setattr(auth_module, "SUPABASE_JWKS_URL", "", raising=True)
+    auth_module.reset_jwks_client_cache()
+
+
+def _token(**overrides) -> str:
+    claims = {
+        "sub": "user-uuid-1234",
+        "email": "eliya@example.org",
+        "aud": "authenticated",
+        "exp": int(time.time()) + 3600,
+    }
+    claims.update(overrides)
+    return jwt.encode(claims, SECRET, algorithm="HS256")
+
+
+# --- get_optional_user ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_header_is_anonymous():
+    assert await get_optional_user(_Request()) is None
+
+
+@pytest.mark.asyncio
+async def test_valid_bearer_token_identifies_the_caller():
+    user = await get_optional_user(_Request(f"Bearer {_token()}"))
+    assert user is not None and user.id == "user-uuid-1234"
+
+
+@pytest.mark.asyncio
+async def test_bearer_scheme_is_case_insensitive():
+    user = await get_optional_user(_Request(f"bearer {_token()}"))
+    assert user is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Basic dXNlcjpwYXNz",  # wrong scheme
+        "Bearer ",  # empty credential
+        "Bearer not-a-token",  # unparseable
+        "justatokenwithnoscheme",
+    ],
+)
+async def test_bad_headers_are_treated_as_anonymous(header):
+    """A stale or malformed token must not make the app unusable."""
+    assert await get_optional_user(_Request(header)) is None
+
+
+@pytest.mark.asyncio
+async def test_expired_token_is_anonymous():
+    assert await get_optional_user(_Request(f"Bearer {_token(exp=1)}")) is None
+
+
+# --- require_user ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_require_user_rejects_anonymous():
+    with pytest.raises(HTTPException) as exc:
+        await require_user(user=None)
+    assert exc.value.status_code == 401
+    assert exc.value.headers["WWW-Authenticate"] == "Bearer"
+
+
+@pytest.mark.asyncio
+async def test_require_user_passes_through_a_known_caller():
+    user = AuthenticatedUser(id="abc", email="a@b.c")
+    assert await require_user(user=user) is user
+
+
+# --- the route ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_me_reports_anonymous_without_a_token(monkeypatch):
+    monkeypatch.setattr(auth_route, "AUTH_ENFORCED", False, raising=True)
+    status = await auth_route.read_current_user(user=None)
+    assert status.authenticated is False
+    assert status.user_id is None
+    assert status.enforced is False
+
+
+@pytest.mark.asyncio
+async def test_me_reports_the_caller_and_the_enforcement_flag(monkeypatch):
+    monkeypatch.setattr(auth_route, "AUTH_ENFORCED", True, raising=True)
+    status = await auth_route.read_current_user(
+        user=AuthenticatedUser(id="user-uuid-1234", email="eliya@example.org")
+    )
+    assert status.authenticated is True
+    assert status.user_id == "user-uuid-1234"
+    assert status.email == "eliya@example.org"
+    assert status.enforced is True
+
+
+def test_short_id_does_not_leak_the_full_user_id():
+    assert AuthenticatedUser(id="0123456789abcdef").short_id == "01234567"

--- a/backend/tests/test_auth_token_verification.py
+++ b/backend/tests/test_auth_token_verification.py
@@ -1,0 +1,204 @@
+"""Tests for Supabase access token verification.
+
+Tokens are minted locally with keys generated in-test, so nothing here talks to
+Supabase. Both signing schemes are covered because real projects use both: the
+legacy shared secret (HS256) and asymmetric signing keys (ES256/RS256), which
+newer projects and Supabase CLI >= 2.71.1 default to.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from app.core import auth as auth_module
+from app.core.auth import AuthError, verify_access_token
+
+SECRET = "test-jwt-secret-value-long-enough-for-sha256"
+AUDIENCE = "authenticated"
+
+
+@pytest.fixture(autouse=True)
+def configured(monkeypatch):
+    """Point the module at the test secret and audience, no JWKS by default."""
+    monkeypatch.setattr(auth_module, "SUPABASE_JWT_SECRET", SECRET, raising=True)
+    monkeypatch.setattr(auth_module, "SUPABASE_JWT_AUDIENCE", AUDIENCE, raising=True)
+    monkeypatch.setattr(auth_module, "SUPABASE_JWKS_URL", "", raising=True)
+    auth_module.reset_jwks_client_cache()
+    yield
+    auth_module.reset_jwks_client_cache()
+
+
+def _claims(**overrides):
+    base = {
+        "sub": "user-uuid-1234",
+        "email": "eliya@example.org",
+        "aud": AUDIENCE,
+        "exp": int(time.time()) + 3600,
+    }
+    base.update(overrides)
+    return base
+
+
+def _hs256(**overrides) -> str:
+    return jwt.encode(_claims(**overrides), SECRET, algorithm="HS256")
+
+
+@pytest.fixture
+def ec_key():
+    return ec.generate_private_key(ec.SECP256R1())
+
+
+def _es256(private_key, **overrides) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return jwt.encode(_claims(**overrides), pem, algorithm="ES256")
+
+
+def _install_jwks(monkeypatch, private_key):
+    """Serve the matching public key the way PyJWKClient would."""
+
+    class _Key:
+        key = private_key.public_key()
+
+    class _Client:
+        def get_signing_key_from_jwt(self, token):
+            return _Key()
+
+    monkeypatch.setattr(auth_module, "SUPABASE_JWKS_URL", "https://x/jwks", raising=True)
+    monkeypatch.setattr(auth_module, "_jwks_client", _Client(), raising=False)
+
+
+# --- HS256 (legacy shared secret) ----------------------------------------
+
+
+def test_valid_hs256_token_is_accepted():
+    user = verify_access_token(_hs256())
+    assert user.id == "user-uuid-1234"
+    assert user.email == "eliya@example.org"
+
+
+def test_hs256_signed_with_the_wrong_secret_is_rejected():
+    token = jwt.encode(_claims(), "some-other-secret", algorithm="HS256")
+    with pytest.raises(AuthError):
+        verify_access_token(token)
+
+
+def test_hs256_is_rejected_when_no_secret_is_configured(monkeypatch):
+    monkeypatch.setattr(auth_module, "SUPABASE_JWT_SECRET", "", raising=True)
+    with pytest.raises(AuthError, match="no JWT secret"):
+        verify_access_token(_hs256())
+
+
+# --- ES256 (asymmetric signing keys) -------------------------------------
+
+
+def test_valid_es256_token_is_accepted(monkeypatch, ec_key):
+    _install_jwks(monkeypatch, ec_key)
+    user = verify_access_token(_es256(ec_key))
+    assert user.id == "user-uuid-1234"
+
+
+def test_es256_signed_by_a_different_key_is_rejected(monkeypatch, ec_key):
+    _install_jwks(monkeypatch, ec_key)
+    impostor = ec.generate_private_key(ec.SECP256R1())
+    with pytest.raises(AuthError):
+        verify_access_token(_es256(impostor))
+
+
+def test_es256_is_rejected_when_no_jwks_is_configured(ec_key):
+    with pytest.raises(AuthError, match="JWKS"):
+        verify_access_token(_es256(ec_key))
+
+
+# --- claim validation -----------------------------------------------------
+
+
+def test_expired_token_is_rejected():
+    with pytest.raises(AuthError):
+        verify_access_token(_hs256(exp=int(time.time()) - 60))
+
+
+def test_token_for_another_audience_is_rejected():
+    with pytest.raises(AuthError):
+        verify_access_token(_hs256(aud="some-other-service"))
+
+
+def test_token_without_a_subject_is_rejected():
+    claims = _claims()
+    del claims["sub"]
+    token = jwt.encode(claims, SECRET, algorithm="HS256")
+    with pytest.raises(AuthError):
+        verify_access_token(token)
+
+
+def test_token_without_an_expiry_is_rejected():
+    claims = _claims()
+    del claims["exp"]
+    token = jwt.encode(claims, SECRET, algorithm="HS256")
+    with pytest.raises(AuthError):
+        verify_access_token(token)
+
+
+# --- algorithm handling ---------------------------------------------------
+
+
+def test_unsigned_token_is_rejected():
+    """alg=none must never be honoured."""
+    token = jwt.encode(_claims(), key="", algorithm="none")
+    with pytest.raises(AuthError, match="unsupported token algorithm"):
+        verify_access_token(token)
+
+
+def test_algorithm_confusion_is_rejected(monkeypatch, ec_key):
+    """A public key must never be usable as an HMAC secret.
+
+    The attack: take the project's published ES256 public key, sign a token with
+    it as an HS256 secret, and hope the backend picks key material by the token's
+    own alg header. The two verification paths are separate, so the HS256 branch
+    only ever reaches for SUPABASE_JWT_SECRET.
+
+    The token is assembled by hand because PyJWT's own encode() refuses to use an
+    asymmetric key as an HMAC secret, so a real attacker's token cannot be
+    produced through the library.
+    """
+    import base64
+    import hashlib
+    import hmac
+    import json
+
+    from cryptography.hazmat.primitives import serialization
+
+    public_pem = ec_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    _install_jwks(monkeypatch, ec_key)
+
+    def b64(raw: bytes) -> bytes:
+        return base64.urlsafe_b64encode(raw).rstrip(b"=")
+
+    signing_input = (
+        b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+        + b"."
+        + b64(json.dumps(_claims()).encode())
+    )
+    signature = hmac.new(public_pem, signing_input, hashlib.sha256).digest()
+    forged = (signing_input + b"." + b64(signature)).decode()
+
+    with pytest.raises(AuthError):
+        verify_access_token(forged)
+
+
+def test_garbage_is_rejected():
+    for value in ("", "not-a-token", "a.b.c"):
+        with pytest.raises(AuthError):
+            verify_access_token(value)

--- a/backend/tests/test_session_access.py
+++ b/backend/tests/test_session_access.py
@@ -1,0 +1,258 @@
+"""Tests for session ownership enforcement.
+
+Covers both rollout phases: AUTH_ENFORCED off (record ownership, deny nothing)
+and AUTH_ENFORCED on (ownership required), plus the legacy-session policy that
+decides what happens to sessions nobody has claimed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.core import session_access as access_module
+from app.core.auth import AuthenticatedUser
+from app.core.session_access import require_session_access
+
+OWNER = AuthenticatedUser(id="owner-uuid-aaaa", email="owner@example.org")
+STRANGER = AuthenticatedUser(id="stranger-uuid-bbbb", email="stranger@example.org")
+
+
+class _Session:
+    def __init__(self, session_id: str, owner_id: str | None = None) -> None:
+        self.id = session_id
+        self.owner_id = owner_id
+
+
+@pytest.fixture
+def store(monkeypatch):
+    """Stand-in session store that records writes, so claims are observable."""
+    sessions: dict[str, _Session] = {}
+    writes: list[str] = []
+
+    def _get_session(session_id: str):
+        return sessions.get(session_id)
+
+    def _update_session(session):
+        writes.append(session.id)
+
+    monkeypatch.setattr(
+        access_module.session_manager, "get_session", _get_session, raising=True
+    )
+    monkeypatch.setattr(
+        access_module.session_manager, "update_session", _update_session, raising=True
+    )
+    return type("Store", (), {"sessions": sessions, "writes": writes})()
+
+
+def _mode(monkeypatch, *, enforced: bool, legacy: str = "allow") -> None:
+    monkeypatch.setattr(access_module, "AUTH_ENFORCED", enforced, raising=True)
+    monkeypatch.setattr(
+        access_module, "AUTH_LEGACY_SESSION_POLICY", legacy, raising=True
+    )
+
+
+# --- nothing to decide ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_routes_without_a_session_are_untouched(store, monkeypatch):
+    _mode(monkeypatch, enforced=True)
+    assert await require_session_access(session_id=None, user=None) is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_session_is_left_to_the_route(store, monkeypatch):
+    """The route already 404s; this must not become a second not-found path."""
+    _mode(monkeypatch, enforced=True)
+    assert await require_session_access(session_id="ghost", user=OWNER) is None
+
+
+# --- phase 1: AUTH_ENFORCED off ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_authenticated_caller_claims_an_unowned_session(store, monkeypatch):
+    """This is the migration: real users backfill ownership just by using the app."""
+    _mode(monkeypatch, enforced=False)
+    store.sessions["s1"] = _Session("s1", owner_id=None)
+
+    await require_session_access(session_id="s1", user=OWNER)
+
+    assert store.sessions["s1"].owner_id == OWNER.id
+    assert store.writes == ["s1"], "the claim must be persisted"
+
+
+@pytest.mark.asyncio
+async def test_claiming_happens_even_before_enforcement(store, monkeypatch):
+    _mode(monkeypatch, enforced=False)
+    store.sessions["s1"] = _Session("s1", owner_id=None)
+    await require_session_access(session_id="s1", user=OWNER)
+    assert store.sessions["s1"].owner_id == OWNER.id
+
+
+@pytest.mark.asyncio
+async def test_a_stranger_is_not_denied_while_enforcement_is_off(store, monkeypatch):
+    _mode(monkeypatch, enforced=False)
+    store.sessions["s1"] = _Session("s1", owner_id=OWNER.id)
+    assert await require_session_access(session_id="s1", user=STRANGER) is None
+
+
+@pytest.mark.asyncio
+async def test_anonymous_is_not_denied_while_enforcement_is_off(store, monkeypatch):
+    _mode(monkeypatch, enforced=False)
+    store.sessions["s1"] = _Session("s1", owner_id=OWNER.id)
+    assert await require_session_access(session_id="s1", user=None) is None
+
+
+@pytest.mark.asyncio
+async def test_an_owned_session_is_not_reclaimed(store, monkeypatch):
+    _mode(monkeypatch, enforced=False)
+    store.sessions["s1"] = _Session("s1", owner_id=OWNER.id)
+    await require_session_access(session_id="s1", user=STRANGER)
+    assert store.sessions["s1"].owner_id == OWNER.id
+    assert store.writes == []
+
+
+@pytest.mark.asyncio
+async def test_a_failed_claim_does_not_break_the_request(store, monkeypatch):
+    _mode(monkeypatch, enforced=False)
+    store.sessions["s1"] = _Session("s1", owner_id=None)
+
+    def _boom(session):
+        raise RuntimeError("storage down")
+
+    monkeypatch.setattr(
+        access_module.session_manager, "update_session", _boom, raising=True
+    )
+    assert await require_session_access(session_id="s1", user=OWNER) is None
+
+
+# --- phase 2: AUTH_ENFORCED on -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_owner_is_allowed(store, monkeypatch):
+    _mode(monkeypatch, enforced=True)
+    store.sessions["s1"] = _Session("s1", owner_id=OWNER.id)
+    assert await require_session_access(session_id="s1", user=OWNER) is None
+
+
+@pytest.mark.asyncio
+async def test_stranger_gets_404_not_403(store, monkeypatch):
+    """403 would confirm the id exists, which is the enumeration signal we removed."""
+    _mode(monkeypatch, enforced=True)
+    store.sessions["s1"] = _Session("s1", owner_id=OWNER.id)
+    with pytest.raises(HTTPException) as exc:
+        await require_session_access(session_id="s1", user=STRANGER)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_anonymous_gets_401_on_an_owned_session(store, monkeypatch):
+    _mode(monkeypatch, enforced=True)
+    store.sessions["s1"] = _Session("s1", owner_id=OWNER.id)
+    with pytest.raises(HTTPException) as exc:
+        await require_session_access(session_id="s1", user=None)
+    assert exc.value.status_code == 401
+    assert exc.value.headers["WWW-Authenticate"] == "Bearer"
+
+
+# --- legacy sessions under enforcement -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_deny_blocks_anonymous_access_to_unowned(store, monkeypatch):
+    _mode(monkeypatch, enforced=True, legacy="deny")
+    store.sessions["s1"] = _Session("s1", owner_id=None)
+    with pytest.raises(HTTPException) as exc:
+        await require_session_access(session_id="s1", user=None)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_legacy_allow_permits_anonymous_access_to_unowned(store, monkeypatch):
+    _mode(monkeypatch, enforced=True, legacy="allow")
+    store.sessions["s1"] = _Session("s1", owner_id=None)
+    assert await require_session_access(session_id="s1", user=None) is None
+
+
+@pytest.mark.asyncio
+async def test_authenticated_caller_still_claims_under_enforcement(store, monkeypatch):
+    _mode(monkeypatch, enforced=True, legacy="deny")
+    store.sessions["s1"] = _Session("s1", owner_id=None)
+    await require_session_access(session_id="s1", user=OWNER)
+    assert store.sessions["s1"].owner_id == OWNER.id
+
+
+@pytest.mark.asyncio
+async def test_a_claimed_legacy_session_then_excludes_others(store, monkeypatch):
+    """End to end: claim under phase 1, then enforce and lock others out."""
+    _mode(monkeypatch, enforced=False)
+    store.sessions["s1"] = _Session("s1", owner_id=None)
+    await require_session_access(session_id="s1", user=OWNER)
+
+    _mode(monkeypatch, enforced=True)
+    assert await require_session_access(session_id="s1", user=OWNER) is None
+    with pytest.raises(HTTPException) as exc:
+        await require_session_access(session_id="s1", user=STRANGER)
+    assert exc.value.status_code == 404
+
+
+# --- the model default ----------------------------------------------------
+
+
+def test_new_sessions_default_to_unowned():
+    from app.models.session import SessionMetadata, SessionType, VisualizationSession
+
+    session = VisualizationSession(
+        id="s1", type=SessionType.UPLOAD, metadata=SessionMetadata(source="test")
+    )
+    assert session.owner_id is None
+
+
+# --- the wiring in main.py -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_dependency_is_actually_wired_to_session_routes(monkeypatch):
+    """Unit tests above prove the rule; this proves it is attached to the app.
+
+    Goes through the real ASGI app so a missing `dependencies=[...]` on an
+    include_router call cannot pass unnoticed.
+    """
+    import time
+
+    import jwt
+    from fastapi.testclient import TestClient
+
+    import app.main as main_module
+    from app.core import auth as auth_module
+
+    secret = "test-jwt-secret-value-long-enough-for-sha256"
+    monkeypatch.setattr(auth_module, "SUPABASE_JWT_SECRET", secret, raising=True)
+    monkeypatch.setattr(auth_module, "SUPABASE_JWT_AUDIENCE", "authenticated", raising=True)
+    monkeypatch.setattr(auth_module, "SUPABASE_JWKS_URL", "", raising=True)
+
+    sessions = {"proj-1": _Session("proj-1", owner_id=OWNER.id)}
+    monkeypatch.setattr(
+        access_module.session_manager, "get_session", lambda sid: sessions.get(sid),
+        raising=True,
+    )
+    _mode(monkeypatch, enforced=True, legacy="deny")
+
+    def token(subject: str) -> str:
+        return jwt.encode(
+            {"sub": subject, "aud": "authenticated", "exp": int(time.time()) + 600},
+            secret,
+            algorithm="HS256",
+        )
+
+    client = TestClient(main_module.app, raise_server_exceptions=False)
+    url = "/api/load/sessions/proj-1"
+
+    assert client.get(url).status_code == 401
+    stranger = client.get(url, headers={"Authorization": f"Bearer {token(STRANGER.id)}"})
+    assert stranger.status_code == 404, "must not reveal that the id exists"
+    owner = client.get(url, headers={"Authorization": f"Bearer {token(OWNER.id)}"})
+    assert owner.status_code not in (401, 404), "the owner must get past the guard"


### PR DESCRIPTION
## Problem
There is no user model. session_id is a de facto bearer token: anyone holding one — from a shared link, browser history, or an email — can read a project's data, documents and chat. PR #372 closed enumeration, but did not establish ownership.

## Solution
Two pieces, both inert until AUTH_ENFORCED=true.

**Identity.** app/core/auth.py verifies a Supabase access token locally. Both signing schemes are supported: the legacy shared secret (HS256) and asymmetric signing keys via JWKS (ES256/RS256), which newer projects and Supabase CLI >= 2.71.1 default to. The two paths never share key material, so a published public key cannot be replayed as an HMAC secret. GET /api/auth/me reports the caller so the frontend can confirm wiring before anything is enforced.

**Ownership.** VisualizationSession gains owner_id. Enforcement is a single router-level dependency attached to the 8 session-scoped routers, rather than a check repeated in ~70 handlers; FastAPI resolves session_id from the path where it exists and passes None elsewhere.

Rollout is two-phase, because enforcing ownership in one step would lock existing users out of their own projects:
- Phase 1 (AUTH_ENFORCED=false, the default): nothing is denied, but an authenticated caller claims an unowned session. Real users backfill ownership by using the app.
- Phase 2 (AUTH_ENFORCED=true): ownership required. A stranger gets 404, not 403, so the response does not confirm that an id exists.

AUTH_LEGACY_SESSION_POLICY decides what happens to still-unowned sessions in phase 2: 'allow' (grace period, each access logged) or 'deny'.

## Out of scope, deliberately
- The websocket router is not covered. Data still flows over /ws/{session_id} without ownership checks; HTTPException semantics do not carry over to websockets, so it needs its own handling.
- The 4 session-creation sites do not stamp owner_id. Claim-on-access covers a new session on its very next request, so this stays a smaller change.
- No frontend yet: until it sends tokens, every caller is anonymous.

## Verify
- `python -m pytest tests/` -> 215 passed (172 before, 43 new).
- Default posture asserted: AUTH_ENFORCED is False, so merging changes no behaviour.
- A real ASGI test pins the wiring: GET /api/load/sessions/{id} under enforcement returns 401 anonymous, 404 for a stranger, and passes the guard for the owner. A missing dependencies=[...] on an include_router call cannot go unnoticed.
- Token tests mint HS256 and ES256 tokens from keys generated in-test: wrong secret, wrong key, expired, wrong audience, missing sub, missing exp, alg=none, and a hand-assembled algorithm-confusion token are all rejected.