### PR TITLE
fix(cost-estimator): stop 500 when model missing from pricing config

### DIFF
--- a/schematiq-lib/schematiq/core/cost_estimator.py
+++ b/schematiq-lib/schematiq/core/cost_estimator.py
@@ -42,6 +42,17 @@ except Exception:
 # Pricing config will be loaded on first use
 _pricing_config: Optional[Dict[str, Any]] = None
 
+# Fallback pricing (per 1M tokens) for models absent from pricing_config.json.
+# Mirrors the config's ``defaults.unknown_model`` block and the implicit 1.0/3.0
+# defaults in ``calculate_cost``. Ensures cost estimation degrades to an
+# approximate estimate instead of raising when a newly-introduced model has not
+# yet been added to the pricing config.
+_DEFAULT_MODEL_PRICING: Dict[str, float] = {
+    "input": 1.0,
+    "output": 3.0,
+    "context_window": 1048576,
+}
+
 # ============================================================================
 # MEASURED PROMPT TOKEN COUNTS (from actual prompts in prompts.py)
 # These are computed once at module load to ensure accuracy
@@ -219,8 +230,10 @@ def get_model_pricing(provider: str, model: str) -> Dict[str, float]:
             if model_key.lower() in model.lower() or model.lower() in model_key.lower():
                 return pricing
     
-    # Return default pricing for unknown models
-    return config["defaults"]["unknown_model"]
+    # Return default pricing for unknown models. Never raise: an unpriced model
+    # should degrade to an approximate estimate, not a 500 error.
+    defaults = config.get("defaults") or {}
+    return defaults.get("unknown_model", _DEFAULT_MODEL_PRICING)
 
 
 def get_estimation_constants() -> Dict[str, int]:

--- a/schematiq-lib/schematiq/core/pricing_config.json
+++ b/schematiq-lib/schematiq/core/pricing_config.json
@@ -60,6 +60,11 @@
           "output": 9.00,
           "context_window": 1048576
         },
+        "gemini-3.6-flash": {
+          "input": 1.50,
+          "output": 9.00,
+          "context_window": 1048576
+        },
         "gemini-3.1-pro-preview": {
           "input": 2.00,
           "output": 12.00,
@@ -82,6 +87,13 @@
           "output": 0.18,
           "context_window": 131072
         }
+    }
+  },
+  "defaults": {
+    "unknown_model": {
+      "input": 1.00,
+      "output": 3.00,
+      "context_window": 1048576
     }
   },
   "estimation_constants": {


### PR DESCRIPTION
## Problem
`/schematiq/estimate-cost-preview` returned 500 with detail `'defaults'` (a `KeyError: 'defaults'`). `get_model_pricing` fell through to `config["defaults"]["unknown_model"]`, but `pricing_config.json` never had a `defaults` key, so any unpriced model crashed. The current default schema model `gemini-3.6-flash` is absent from the config and matches nothing, so every new project triggered it.

## Solution
- Harden `get_model_pricing` to degrade gracefully instead of raising: `.get("defaults", {}).get("unknown_model", _DEFAULT_MODEL_PRICING)`.
- Add the missing `defaults.unknown_model` block to `pricing_config.json`.
- Add `gemini-3.6-flash` pricing (mirrors `gemini-3.5-flash`) so the default flow returns an accurate estimate.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone: passes
- `python -m py_compile schematiq-lib/schematiq/core/cost_estimator.py`: passes
- JSON validates
- Repro: `get_model_pricing('gemini','gemini-3.6-flash')` now returns pricing; previously raised `KeyError('defaults')`. Unknown providers/models fall back instead of 500-ing.

## Note
`gemini-3.6-flash` pricing and the `unknown_model` fallback use placeholder values (mirroring gemini-3.5-flash and the existing 1.0/3.0 defaults). Confirm against real pricing when convenient.