### PR TITLE
fix(workspace): refresh status and stats on run completion

### DIFF
--- a/frontend/src/pages/Workspace/hooks/useWorkspaceSocket.ts
+++ b/frontend/src/pages/Workspace/hooks/useWorkspaceSocket.ts
@@ -130,13 +130,25 @@ export function useWorkspaceSocket({
         return;
       }
 
+      // Terminal completion events change the session's status and statistics —
+      // progress reaches 100%, the run leaves the "processing" state, and the
+      // skipped-documents list is finalized. refreshSilent only re-fetches row
+      // data ("no status/schema/session churn"), so routing completion through
+      // it leaves the bar stuck at the last processing value (50%) and never
+      // surfaces the skipped-documents banner. Use the full refresh here.
+      if (
+        message.type === 'completed' ||
+        message.type === 'reprocessing_completed'
+      ) {
+        void refresh({ silent: true });
+        return;
+      }
+
       if (
         message.type === 'progress' ||
-        message.type === 'completed' ||
         message.type === 'cell_extracted' ||
         message.type === 'row_completed' ||
-        message.type === 'reprocessing_progress' ||
-        message.type === 'reprocessing_completed'
+        message.type === 'reprocessing_progress'
       ) {
         void refreshSilent();
         return;


### PR DESCRIPTION
## Problem
After a run finished, the Workspace stayed stuck at 50% and the skipped-documents banner never appeared, even though the backend completed the run, set the session to COMPLETED, broadcast `completed`, and recorded the skipped documents in statistics.

Root cause: in `useWorkspaceSocket`, the `completed` event was handled by `refreshSilent()`, i.e. `refreshData({silent:true})`, which only re-fetches row data and deliberately skips status/schema/session. So the workspace never re-fetched `getStatus` (progress stays at the processing value 0.5 → 50%) or `getSession` (`statistics.skipped_documents` stays empty → `SkippedDocumentsBanner` never renders). The full `refresh` that updates status + session only ran for schema/reextraction events, never for `completed`.

## Solution
Route terminal completion events (`completed`, `reprocessing_completed`) through the full `refresh({ silent: true })` so `status` and `session.statistics` update. Keep the high-frequency events (`progress`, `row_completed`, `cell_extracted`, `reprocessing_progress`) on the rows-only `refreshSilent` to avoid re-introducing per-row status/schema/session churn.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone: passes
- `( cd frontend && npx tsc --noEmit )`: passes
- Repro: run with 2 documents where one has no observation unit. Before: bar stuck at 50%, no skipped banner. After: bar reaches 100% and the skipped-documents banner shows the skipped file.