### PR TITLE
fix(workspace): repair the stacked layout below 900px and add empty-state actions

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -15,6 +15,7 @@ import {
   type CellGrounding,
 } from '@/components/DataTable/utils/excerptUtils';
 import ContentModal from '@/components/ContentModal/ContentModal';
+import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import { observationUnitAPI, schemaAPI, schematiqAPI } from '@/services/api';
 import type { ColumnInfo, DataRow, PaginatedData, SchemaData } from '@/types';
@@ -61,6 +62,8 @@ export function SpreadsheetSurface({
   onEditFollowUp,
   onEditEnd,
   onToggleFormatShortcut,
+  onNewProject,
+  onImportProject,
   layoutRevision,
   dataView,
 }: {
@@ -99,6 +102,11 @@ export function SpreadsheetSurface({
   // Toggle a text format (bold/italic/underline) on the current selection,
   // invoked by the Ctrl/Cmd+B/I/U keyboard shortcuts registered below.
   onToggleFormatShortcut?: (key: 'bold' | 'italic' | 'underline') => void;
+  // Empty-state actions. Closing the New Project dialog previously left the
+  // workbook as a dead end whose only way forward was the File menu, which is
+  // itself unreachable on narrow viewports.
+  onNewProject?: () => void;
+  onImportProject?: () => void;
   layoutRevision: string;
   // Current Data-sheet grouping. Drives the visual cell-merge of the leftmost
   // grouping column: 'by_unit' merges unit_name, 'by_document' merges the
@@ -1367,8 +1375,24 @@ export function SpreadsheetSurface({
 
   if (!sessionId) {
     return (
-      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-        Start or open a project to populate the workbook.
+      <div className="flex h-full flex-col items-center justify-center gap-4 p-6 text-center">
+        <p className="text-sm text-muted-foreground">
+          Start or open a project to populate the workbook.
+        </p>
+        {(onNewProject || onImportProject) && (
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            {onNewProject && (
+              <Button size="sm" onClick={onNewProject}>
+                New project
+              </Button>
+            )}
+            {onImportProject && (
+              <Button size="sm" variant="outline" onClick={onImportProject}>
+                Import project
+              </Button>
+            )}
+          </div>
+        )}
       </div>
     );
   }

--- a/frontend/src/pages/Workspace/Workspace.css
+++ b/frontend/src/pages/Workspace/Workspace.css
@@ -305,6 +305,29 @@
   display: none;
 }
 
+/* The four fixed tracks below overflowed on phone widths, where the research
+   question collapsed to a couple of pixels and its clipped text painted on top
+   of the status label. The question is decorative here (it is also the tab
+   tooltip), so drop it and give the space to the sheet tabs. */
+@media (max-width: 720px) {
+  .workspace-bottombar {
+    grid-template-columns: minmax(0, 1fr) auto 36px;
+    gap: 8px;
+    padding: 0 8px;
+  }
+
+  .workspace-topbar-question {
+    display: none;
+  }
+
+  /* "No status" is a placeholder for an empty region; collapsing it lets the
+     tabs use the full row instead of being clipped mid-label against it. A real
+     progress bar still gets its space. */
+  .workspace-topbar-status-empty {
+    display: none;
+  }
+}
+
 .workspace-topbar-question {
   min-width: 0;
   width: 100%;
@@ -1308,8 +1331,18 @@
     border-bottom: 1px solid hsl(var(--border));
   }
 
+  /* The divider only makes sense for a side-by-side split. Workspace/index.tsx
+     stops deriving the collapsed-pane flags from chatWidth at this breakpoint,
+     so neither pane can arrive here marked hidden; the reset is a guard in case
+     a stale flag survives a resize mid-drag. */
   .workspace-resizer {
     display: none;
+  }
+
+  .workspace-sheet-pane[data-hidden="true"],
+  .workspace-chat-pane[data-hidden="true"] {
+    visibility: visible;
+    pointer-events: auto;
   }
 }
 

--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -335,7 +335,7 @@ export function ChatPanel({
         {
           id: `${Date.now()}-no-session`,
           role: 'assistant',
-          content: 'Open > New Project or Import Project to get started. Once a project exists I can inspect and edit it.',
+          content: 'Use File > New project or File > Import project to get started. Once a project exists I can inspect and edit it.',
         },
       ]);
       return;

--- a/frontend/src/pages/Workspace/hooks/useWorkspaceLayout.ts
+++ b/frontend/src/pages/Workspace/hooks/useWorkspaceLayout.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 // Owns chat-panel width and the pointer-driven divider drag interaction.
 // Parent: Workspace (index.tsx).
@@ -9,6 +9,12 @@ const DEFAULT_CHAT_WIDTH = 380;
 // sessions, but never *restore* a fully collapsed side: reopening a workspace
 // always lands in split view so the user can't get stuck with one pane hidden.
 const MIN_SPLIT_WIDTH = 56;
+
+// Must match the `max-width: 900px` breakpoint in Workspace.css, where the body
+// stops being a sheet|chat split and stacks the two panes vertically. Below it
+// the pixel chat width is meaningless, so the collapse thresholds derived from
+// it have to be switched off.
+const STACKED_QUERY = '(max-width: 900px)';
 
 export function useWorkspaceLayout() {
   const [chatWidth, setChatWidth] = useState(() => {
@@ -21,6 +27,28 @@ export function useWorkspaceLayout() {
     return saved;
   });
   const [isDraggingDivider, setIsDraggingDivider] = useState(false);
+  // The collapse thresholds below compare chatWidth against the viewport, so
+  // they need the viewport as reactive state. Reading window.innerWidth during
+  // render left them stale until an unrelated state change forced a re-render.
+  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
+  const [isStacked, setIsStacked] = useState(
+    () => window.matchMedia(STACKED_QUERY).matches,
+  );
+
+  useEffect(() => {
+    const media = window.matchMedia(STACKED_QUERY);
+    const sync = () => {
+      setViewportWidth(window.innerWidth);
+      setIsStacked(media.matches);
+    };
+    sync();
+    window.addEventListener('resize', sync);
+    media.addEventListener('change', sync);
+    return () => {
+      window.removeEventListener('resize', sync);
+      media.removeEventListener('change', sync);
+    };
+  }, []);
 
   const startDividerDrag = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -50,5 +78,7 @@ export function useWorkspaceLayout() {
     setChatWidth,
     isDraggingDivider,
     startDividerDrag,
+    viewportWidth,
+    isStacked,
   };
 }

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -190,6 +190,8 @@ function Workspace() {
     setChatWidth,
     isDraggingDivider,
     startDividerDrag,
+    viewportWidth,
+    isStacked,
   } = useWorkspaceLayout();
 
   const deferredDataRef = useRef<PaginatedData | null>(null);
@@ -864,14 +866,27 @@ function Workspace() {
     if (colCount > 0) parts.push(`${colCount} ${colCount === 1 ? 'column' : 'columns'}`);
     return parts.join(' · ');
   }, [sessionId, loading, status, sessionMode, data.total_count, schema]);
-  const isSheetHidden = chatWidth >= window.innerWidth - 80;
-  const isChatHidden = chatWidth <= 24;
-  const bodyGridColumns = isSheetHidden
-    ? '0px 8px minmax(0, 1fr)'
-    : isChatHidden
-      ? 'minmax(0, 1fr) 8px 0px'
-      : `minmax(0, 1fr) 8px ${chatWidth}px`;
-  const gridLayoutRevision = String(chatWidth);
+  // Below the stacked breakpoint the panes sit one above the other and the
+  // divider is display:none, so a chat width measured in pixels no longer says
+  // anything about whether a pane is collapsed. Left live, the default 380px
+  // chat satisfied `chatWidth >= innerWidth - 80` on any viewport under 460px,
+  // which hid the sheet and -- with the divider removed from the grid flow --
+  // dropped the chat into the 8px divider track, rendering an empty workspace.
+  const isSheetHidden = !isStacked && chatWidth >= viewportWidth - 80;
+  const isChatHidden = !isStacked && chatWidth <= 24;
+  // Undefined while stacked so the inline style does not outrank the
+  // `max-width: 900px` rule in Workspace.css, which is what silently defeated
+  // the responsive layout before.
+  const bodyGridColumns = isStacked
+    ? undefined
+    : isSheetHidden
+      ? '0px 8px minmax(0, 1fr)'
+      : isChatHidden
+        ? 'minmax(0, 1fr) 8px 0px'
+        : `minmax(0, 1fr) 8px ${chatWidth}px`;
+  // Crossing the breakpoint resizes the grid without changing chatWidth, so the
+  // revision has to carry it too or Handsontable keeps stale measurements.
+  const gridLayoutRevision = `${chatWidth}:${isStacked ? 'stacked' : 'split'}`;
   const reextractionPercent = Math.round((reextraction?.progress || 0) * 100);
   const bottombarStatus = reextraction
     ? `Re-extracting ${reextraction.columns.join(', ')} (${reextraction.processedDocuments}/${reextraction.totalDocuments || '?'} docs)`
@@ -955,6 +970,8 @@ function Workspace() {
         onEditFollowUp={notifyEditFollowUp}
         onEditEnd={flushDeferredData}
         onToggleFormatShortcut={handleFormatShortcut}
+        onNewProject={() => setProjectDialogOpen(true)}
+        onImportProject={() => importInputRef.current?.click()}
         layoutRevision={gridLayoutRevision}
         dataView={dataView}
       />


### PR DESCRIPTION
## Problem

**The workspace renders nothing below ~460px viewport width.** Measured on the live site at 390px: the sheet pane is 0px wide and the chat pane is 8px wide.

Three defects compound:

1. `index.tsx` sets `gridTemplateColumns` as an inline style, which outranks every stylesheet rule. The `@media (max-width: 900px)` block in Workspace.css that stacks the panes has therefore been dead. Measured: `inlineCols: '0px 8px minmax(0px, 1fr)'`.
2. `isSheetHidden = chatWidth >= window.innerWidth - 80`. The default chatWidth is 380, so any viewport under 460px marks the sheet hidden. With `.workspace-resizer { display: none }` at the same breakpoint the divider leaves the grid flow, auto-placement shifts, and the chat pane lands in the 8px divider track.
3. `window.innerWidth` is read during render with no resize subscription, so the flag stays stale on desktop window resize until an unrelated state change forces a re-render.

Separately: the bottombar's four fixed tracks overflow on phone widths, painting the clipped research question on top of the status label ("N‌No status"), and the empty workbook is a dead end — after dismissing the New Project dialog the only way forward is the File menu, which is itself unreachable at narrow widths.

## Solution

- `useWorkspaceLayout` now owns `viewportWidth` and `isStacked` as reactive state, from `matchMedia('(max-width: 900px)')` plus a resize listener. The constant is documented as coupled to the CSS breakpoint.
- While stacked, `bodyGridColumns` is `undefined` so the inline style disappears and the media query applies, and both collapsed-pane flags are forced off. `gridLayoutRevision` carries `isStacked` so Handsontable re-measures when the breakpoint is crossed.
- CSS: a `[data-hidden]` reset inside the media query as a guard against a flag stuck mid-drag; below 720px the bottombar drops to three tracks and hides both the research question (already the tab tooltip) and the "No status" placeholder.
- The empty workbook gets New project / Import project buttons via optional props.
- `ChatPanel` no-session copy said "Open > New Project"; there is no Open menu. Now "File > New project".

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.
- Applies cleanly on top of the workspace-chrome-fixes branch as well, and typechecks combined — the two can merge in either order.
- Pane geometry measured with Playwright against the live site, before vs after the change:
  - 390px: sheet 0x356 -> 390x356, chat 8x356 -> 390x340
  - 768px: sheet 380x536 -> 768x536, chat 8x536 -> 768x340
- Screenshots were produced by injecting the CSS and simulating the TSX change in the DOM; a full `craco build` did not run in the review environment. Worth a local `npm start` pass in DevTools responsive mode, particularly for Handsontable's behaviour when crossing the breakpoint.