### PR TITLE
fix(workspace): stop refetching the data page on every WebSocket connect

### DIFF
--- a/frontend/src/pages/Workspace/hooks/useWorkspaceSocket.ts
+++ b/frontend/src/pages/Workspace/hooks/useWorkspaceSocket.ts
@@ -1,4 +1,4 @@
-import { type Dispatch, type SetStateAction, useEffect, useState } from 'react';
+import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from 'react';
 
 import { WS_DISCONNECTED_REFRESH_INTERVAL } from '@/constants';
 import webSocketService from '@/services/websocket';
@@ -37,9 +37,18 @@ export function useWorkspaceSocket({
   toast,
 }: UseWorkspaceSocketOptions) {
   const [wsConnected, setWsConnected] = useState(false);
+  // A 'connected' message only means "catch up on what you missed" when it
+  // follows a drop. The first connect of a session lands right after the
+  // initial load has already fetched everything, and the subscription below is
+  // re-registered whenever refresh/refreshSilent change identity during mount,
+  // so the service replays 'connected' to each new subscriber. Refreshing on
+  // every one of those made a single project open issue three identical
+  // POST /api/load/data requests for the same 500-row page.
+  const sawDisconnectRef = useRef(false);
 
   useEffect(() => {
     setWsConnected(false);
+    sawDisconnectRef.current = false;
   }, [sessionId]);
 
   useEffect(() => {
@@ -54,12 +63,16 @@ export function useWorkspaceSocket({
     const handler = (message: WebSocketMessage) => {
       if (message.type === 'connected') {
         setWsConnected(true);
-        void refreshSilent();
+        if (sawDisconnectRef.current) {
+          sawDisconnectRef.current = false;
+          void refreshSilent();
+        }
         return;
       }
 
       if (message.type === 'disconnected' || message.type === 'reconnecting') {
         setWsConnected(false);
+        sawDisconnectRef.current = true;
         return;
       }
 


### PR DESCRIPTION
## Problem

Opening a project issues three identical `POST /api/load/data/{id}?page=0&page_size=500` requests. Measured on production with a 194-row session:

```
0.00  GET  /api/load/sessions/...
0.23  WS   /ws/progress/...
1.15  POST /api/load/data/...
1.25  POST /api/load/data/...
1.25  POST /api/load/data/...
1.25  GET  /api/units/documents/...
```

`/api/load/data` has exactly two call sites: `refreshData` and `loadHeavy`. `loadHeavy` ran once (`/api/units/documents` is fetched alongside it in the same `Promise.all` and appears once), so `refreshData` ran twice. `scheduleEmptyRecheck` is ruled out — at 1.15s no rows were on screen yet, so its guard does not schedule. The 20s disconnected-poll interval is ruled out by timing. That leaves `refreshSilent`, called from the `connected` branch of the socket handler.

The subscribing effect depends on `refresh` and `refreshSilent`, whose identities both change during mount when `setSessionMode` settles. Each re-registration receives a replayed `connected` message, and each one refetches the full page.

Beyond the wasted backend work, the extra re-renders are the likely cause of the column header row painting blank for several seconds after load — the header text is present in the DOM the whole time.

## Solution

`connected` only means "catch up" when it follows a drop; the first connect of a session lands right after the initial load has already fetched everything. A `sawDisconnectRef` is set on `disconnected`/`reconnecting`, cleared on `connected` and on session change, and gates the refresh. Replayed `connected` messages become no-ops because no disconnect was seen. Reconnect-after-drop still re-syncs. No other message branch is touched.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.
- Open a project with the network tab filtered to `load/data` and confirm a single POST.
- Kill the backend, let the socket drop, restart it, and confirm the reconnect still triggers one silent refresh.
- Root cause established by elimination and request timing against production; the fixed build was not run in the review environment, so the post-fix request count is worth confirming locally.