### PR TITLE
fix(workspace): keep the table feedback card off the chat composer

### DIFF
--- a/frontend/src/components/TableFeedbackWidget/TableFeedbackWidget.tsx
+++ b/frontend/src/components/TableFeedbackWidget/TableFeedbackWidget.tsx
@@ -11,6 +11,10 @@ interface TableFeedbackWidgetProps {
   activeTab: string;
   tableRowCount: number;
   tableColumnCount: number;
+  // Placement of the fixed anchor. The default bottom-right corner is free on
+  // the classic Visualize page, but in the Workspace it is exactly where the
+  // chat composer sits, so the card covered the attach and send buttons.
+  anchorClassName?: string;
 }
 
 type WidgetState = 'hidden' | 'expanded' | 'submitted';
@@ -23,6 +27,7 @@ const TableFeedbackWidget: React.FC<TableFeedbackWidgetProps> = ({
   activeTab,
   tableRowCount,
   tableColumnCount,
+  anchorClassName = 'fixed bottom-6 right-6 z-50',
 }) => {
   const [widgetState, setWidgetState] = useState<WidgetState>('hidden');
   const [rating, setRating] = useState<'positive' | 'negative' | null>(null);
@@ -172,7 +177,7 @@ const TableFeedbackWidget: React.FC<TableFeedbackWidgetProps> = ({
   if (widgetState === 'hidden') return null;
 
   return (
-    <div className="fixed bottom-6 right-6 z-50">
+    <div className={anchorClassName}>
       {/* Submitted state: small checkmark */}
       {widgetState === 'submitted' && (
         <div

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -1444,6 +1444,9 @@ function Workspace() {
           activeTab={activeSheet}
           tableRowCount={data?.total_count || 0}
           tableColumnCount={session?.columns?.length || 0}
+          // Sheet side, clear of the 52px bottombar, so it never lands on the
+          // chat composer in the bottom-right of the workspace.
+          anchorClassName="fixed bottom-20 left-6 z-50"
         />
       )}
     </div>


### PR DESCRIPTION
## Problem

`TableFeedbackWidget` anchors itself with a hard-coded `fixed bottom-6 right-6 z-50`. On the classic Visualize page that corner is empty. In the Workspace it is exactly where the chat composer sits, so the feedback card covers the attach and send buttons. Measured at 1440x900: composer at x1068-1432 y722-800, card at roughly x1080-1400 y756-830.

## Solution

An optional `anchorClassName` prop, defaulting to the current value so Visualize is unchanged. The Workspace passes `fixed bottom-20 left-6 z-50` — sheet side, clear of the 52px bottombar.

`TableFeedbackWidget.tsx` is a CRLF file; it was edited at byte level. After `git apply` on a clean clone it is 279 CRLF lines with zero bare LF lines.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.
- Line endings asserted post-apply as above.
- Open a completed project, wait out the 10s delay, and confirm the card sits over the sheet and the composer stays usable. Confirm Visualize is unchanged.