### PR TITLE
fix(workspace): search the whole table and reset the recent-projects loader

### DIFF
--- a/frontend/src/pages/Workspace/RecentProjects.tsx
+++ b/frontend/src/pages/Workspace/RecentProjects.tsx
@@ -81,28 +81,37 @@ export function RecentProjects({
       return;
     }
     let cancelled = false;
+    // Drop the previous result so reopening the window shows the loader rather
+    // than the last visit's list while the refetch is in flight.
+    setSessions(null);
     setLoading(true);
     (async () => {
-      // Fetch each remembered project by id. The backend resolves a session by
-      // id regardless of type, so one endpoint covers both load and schematiq
-      // projects; the returned `type` drives navigation mode.
-      const results = await Promise.all(
-        ids.map((id) =>
-          loadAPI.getSession(id).then(
-            (session) => ({ id, session: session as VisualizationSession | null }),
-            () => ({ id, session: null as VisualizationSession | null }),
+      try {
+        // Fetch each remembered project by id. The backend resolves a session by
+        // id regardless of type, so one endpoint covers both load and schematiq
+        // projects; the returned `type` drives navigation mode.
+        const results = await Promise.all(
+          ids.map((id) =>
+            loadAPI.getSession(id).then(
+              (session) => ({ id, session: session as VisualizationSession | null }),
+              () => ({ id, session: null as VisualizationSession | null }),
+            ),
           ),
-        ),
-      );
-      if (cancelled) return;
-      const missing = results.filter((r) => r.session === null).map((r) => r.id);
-      if (missing.length > 0) forgetProjects(missing);
-      const found = results
-        .map((r) => r.session)
-        .filter((s): s is VisualizationSession => s !== null)
-        .sort((a, b) => sessionTime(b) - sessionTime(a));
-      setSessions(found);
-      setLoading(false);
+        );
+        if (cancelled) return;
+        const missing = results.filter((r) => r.session === null).map((r) => r.id);
+        if (missing.length > 0) forgetProjects(missing);
+        const found = results
+          .map((r) => r.session)
+          .filter((s): s is VisualizationSession => s !== null)
+          .sort((a, b) => sessionTime(b) - sessionTime(a));
+        setSessions(found);
+      } finally {
+        // Always reset, including on the cancelled path. Returning early from
+        // inside the async body left `loading` stuck at true, so the next open
+        // rendered a stale list with no loading indicator.
+        setLoading(false);
+      }
     })();
     return () => {
       cancelled = true;

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -806,11 +806,29 @@ function Workspace() {
     }
   }, [sessionId, sessionMode, schema, config, toast]);
 
+  // window.find only sees painted DOM text. Handsontable virtualises rows and
+  // columns, so it searched whatever happened to be in the viewport and quietly
+  // reported nothing for the rest of the table -- on a 194-row sheet that is
+  // most of it. The Search plugin queries the loaded dataset instead, so a hit
+  // outside the viewport is found and scrolled to.
   const searchPage = useCallback(() => {
-    const term = window.prompt('Find in visible workspace');
-    const findInPage = (window as Window & { find?: (text: string) => boolean }).find;
-    if (term && findInPage) findInPage(term);
-  }, []);
+    const term = window.prompt('Find in table')?.trim();
+    if (!term) return;
+    const hot = hotTableRef.current?.hotInstance;
+    if (!hot) return;
+    const results = hot.getPlugin('search').query(term);
+    hot.render();
+    if (results.length === 0) {
+      toast({ title: 'No matches', description: `Nothing in this sheet matches "${term}".` });
+      return;
+    }
+    const [first] = results;
+    hot.selectCell(first.row, first.col);
+    toast({
+      title: results.length === 1 ? '1 match' : `${results.length} matches`,
+      description: 'Jumped to the first one.',
+    });
+  }, [toast]);
 
   const importExistingProject = useCallback(async (file: File) => {
     setImportingProject(true);


### PR DESCRIPTION
## Problem

**Search missed most of the table.** `searchPage` used `window.prompt` plus `window.find`, which only matches painted DOM text. Handsontable virtualises rows and columns, so the search covered whatever was in the viewport and silently found nothing for everything else. On the 194-row session that is most of the sheet, and the failure is indistinguishable from a genuine no-match.

**The recent-projects loader could stick.** In `RecentProjects`, closing the window mid-fetch hits `if (cancelled) return` before `setLoading(false)`, so `loading` stays true. Reopening then renders the previous visit's list with no loading indicator.

## Solution

`hotTableRef` already lives in index.tsx, so searchPage has the Handsontable instance directly. It now uses the Search plugin: `query()` runs against the loaded dataset rather than the DOM, so an off-screen hit is found; the first match is selected and scrolled to, and a toast reports the match count instead of failing silently.

`RecentProjects` wraps the async body in try/finally so `setLoading(false)` runs on the cancelled path too, and clears `sessions` on open so a refetch shows the loader rather than stale rows.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean, which also confirms the Search plugin signature.
- Open a project, scroll so a known value is off-screen, run Find, and confirm it selects the right cell.
- Open Recent projects, close it while it is still loading, reopen, and confirm the loader appears.
- Not verified: whether the yellow match highlight paints. Handsontable flags matches through cell meta and the renderer applies `htSearchResult`; this sheet uses custom column renderers that may not forward it. The jump and the count work regardless, so the behaviour degrades rather than breaks.