### PR TITLE
perf(api): collapse concurrent /config requests onto one in-flight promise

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -134,17 +134,42 @@ export const supportAPI = {
 };
 
 // Config API (for public configuration)
+export type PublicConfig = {
+  max_documents: number;
+  developer_mode: boolean;
+  allow_llm_config: boolean;
+  data_collection_enabled: boolean;
+  release_config: Record<string, any>;
+  server_has_api_keys: boolean;
+};
+
+// Fourteen call sites across the app fetch /config independently, and several
+// of them mount together: opening a project issued two identical requests in
+// the same tick (Workspace's developer-mode check and LLMSelector). This
+// collapses concurrent callers onto one request.
+//
+// Deliberately in-flight only, with no TTL. /api/config is not static -- it
+// reports `active_sessions` from the concurrency limiter -- so caching a
+// resolved response would hand later callers a stale count. Nothing in the
+// frontend reads that field today, but a time-based cache would silently break
+// whatever does first. Callers that mount later still get fresh data.
+let inFlightConfig: Promise<PublicConfig> | null = null;
+
 export const configAPI = {
-  getConfig: async (): Promise<{
-    max_documents: number;
-    developer_mode: boolean;
-    allow_llm_config: boolean;
-    data_collection_enabled: boolean;
-    release_config: Record<string, any>;
-    server_has_api_keys: boolean;
-  }> => {
-    const response = await api.get('/config');
-    return response.data;
+  getConfig: async (): Promise<PublicConfig> => {
+    if (inFlightConfig) return inFlightConfig;
+    inFlightConfig = api
+      .get('/config')
+      .then((response) => response.data as PublicConfig)
+      .finally(() => {
+        inFlightConfig = null;
+      });
+    return inFlightConfig;
+  },
+
+  /** Drop any in-flight request so the next getConfig() starts a fresh one. */
+  invalidate: () => {
+    inFlightConfig = null;
   },
 };
 


### PR DESCRIPTION
## Problem

Fourteen call sites fetch `/api/config` independently, and several mount together. Measured on production, opening a project issues two identical `GET /api/config` requests in the same tick — Workspace's developer-mode check and LLMSelector — and other combinations fire elsewhere in the app.

## Solution

`configAPI.getConfig()` now shares a single in-flight promise: concurrent callers get the same request, and the slot clears once it settles. Adds `configAPI.invalidate()` and exports the response shape as `PublicConfig`. No call site changes.

Deliberately in-flight only, with no TTL. `/api/config` is not static — it returns `active_sessions` from the concurrency limiter — so caching a resolved response would hand later callers a stale count. Nothing in the frontend reads that field today, but a time-based cache would silently break whatever reads it first. Callers that mount later still get fresh data. The reasoning is recorded in a comment at the call site.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.
- Semantics checked in isolation: three concurrent callers produce one request and identical results; a later caller produces a second request; two consecutive failures produce two requests, so a transient network error is not cached and does not pin every caller to a rejected promise.
- In the app: open a project with the network tab filtered to `config` and confirm a single GET.
- Applies cleanly alongside the other five open workspace patches and typechecks combined.