### PR TITLE
fix(workspace): honest menu bar, dark-mode sheet pane, and menu clipping

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetChrome.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetChrome.tsx
@@ -12,10 +12,8 @@ import {
   RotateCw,
   Save,
   Search,
-  Sigma,
   Sparkles,
   Strikethrough,
-  Type,
   Underline,
 } from 'lucide-react';
 
@@ -27,7 +25,12 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 import { TABLE_FONT_OPTIONS, TABLE_FONT_SIZE_OPTIONS, WORKSPACE_MENUS } from './constants';
-import type { TableDisplayOptions, TableTextAlign } from './types';
+import type {
+  TableDisplayOptions,
+  TableTextAlign,
+  WorkspaceMenuAction,
+  WorkspaceMenuItem,
+} from './types';
 
 export function SpreadsheetChrome({
   projectTitle,
@@ -45,6 +48,8 @@ export function SpreadsheetChrome({
   onSaveProjectWithDocs,
   onHome,
   onSearch,
+  onUndo,
+  onRedo,
   onEstimateCost,
   onShowSheet,
   onShowChat,
@@ -70,6 +75,8 @@ export function SpreadsheetChrome({
   onSaveProjectWithDocs: () => void;
   onHome: () => void;
   onSearch: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
   onEstimateCost: () => void;
   onShowSheet: () => void;
   onShowChat: () => void;
@@ -80,41 +87,35 @@ export function SpreadsheetChrome({
   onReportIssue: () => void;
   rerunDisabled: boolean;
 }) {
-  const runMenuItem = (label: string) => {
-    if (label === 'New project') onNewProject();
-    if (label === 'Import project') onImportProject();
-    if (label === 'Open classic visualizer') onOpenClassic();
-    if (label === 'Download table (.csv)') onExport();
-    if (label === 'Save project (.schematiq.json)') onSaveProject();
-    if (label === 'Save project with documents (.zip)') onSaveProjectWithDocs();
-    if (label === 'Project details') onProjectDetails();
-    if (label === 'Refresh project') onRefresh();
-    if (label === 'Estimate cost') onEstimateCost();
-    if (label === 'Show sheet full screen') onShowSheet();
-    if (label === 'Show chat full screen') onShowChat();
-    if (label === 'Split view') onSplitView();
-    if (label === 'Re-extract table') onRunPendingEdits();
-    if (label === 'Add documents') onAddDocuments();
-    if (label === 'Report an issue') onReportIssue();
+  // Exhaustive by construction: Record<WorkspaceMenuAction, ...> makes TypeScript
+  // reject a new menu action that has no handler, which is what previously let
+  // ~19 menu entries render as clickable no-ops.
+  const menuActions: Record<WorkspaceMenuAction, () => void> = {
+    newProject: onNewProject,
+    importProject: onImportProject,
+    openClassic: onOpenClassic,
+    exportCsv: onExport,
+    saveProject: onSaveProject,
+    saveProjectWithDocs: onSaveProjectWithDocs,
+    undo: onUndo,
+    redo: onRedo,
+    find: onSearch,
+    showSheet: onShowSheet,
+    showChat: onShowChat,
+    splitView: onSplitView,
+    projectDetails: onProjectDetails,
+    reextract: onRunPendingEdits,
+    addDocuments: onAddDocuments,
+    estimateCost: onEstimateCost,
+    refreshProject: onRefresh,
+    reportIssue: onReportIssue,
   };
 
-  const isDisabled = (label: string) => {
-    if (label === 'New project' || label === 'Import project') return false;
-    if (label === 'Re-extract table') return rerunDisabled;
-    return !canUseProjectActions && [
-      'Open classic visualizer',
-      'Download table (.csv)',
-      'Save project (.schematiq.json)',
-      'Save project with documents (.zip)',
-      'Project details',
-      'Refresh project',
-      'Estimate cost',
-      'Show sheet full screen',
-      'Show chat full screen',
-      'Split view',
-      'Re-extract table',
-      'Add documents',
-    ].includes(label);
+  const isDisabled = (item: WorkspaceMenuItem) => {
+    // Re-extract has its own gating (no session, nothing pending, or already
+    // starting), which already covers the no-project case.
+    if (item.action === 'reextract') return rerunDisabled;
+    return Boolean(item.requiresProject) && !canUseProjectActions;
   };
 
   return (
@@ -145,11 +146,11 @@ export function SpreadsheetChrome({
               <DropdownMenuContent align="start" className="workspace-menu-content w-56">
                 {menu.items.map((item) => (
                   <DropdownMenuItem
-                    key={item}
+                    key={item.action}
                     disabled={isDisabled(item)}
-                    onClick={() => runMenuItem(item)}
+                    onClick={menuActions[item.action]}
                   >
-                    {item}
+                    {item.label}
                   </DropdownMenuItem>
                 ))}
               </DropdownMenuContent>
@@ -295,9 +296,6 @@ export function SpreadsheetChrome({
 
         <span className="workspace-toolbar-separator" />
 
-        <button className="workspace-toolbar-icon" type="button" title="Text color">
-          <Type className="h-3.5 w-3.5" />
-        </button>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button className="workspace-toolbar-icon" type="button" title="Align">
@@ -312,10 +310,7 @@ export function SpreadsheetChrome({
             ))}
           </DropdownMenuContent>
         </DropdownMenu>
-        <button className="workspace-toolbar-icon" type="button" title="Functions">
-          <Sigma className="h-3.5 w-3.5" />
-        </button>
-        <button className="workspace-toolbar-icon" type="button" onClick={onSearch} title="Search">
+        <button className="workspace-toolbar-icon" type="button" onClick={onSearch} title="Find in workspace">
           <Search className="h-3.5 w-3.5" />
         </button>
 

--- a/frontend/src/pages/Workspace/Workspace.css
+++ b/frontend/src/pages/Workspace/Workspace.css
@@ -24,7 +24,12 @@
 .workspace-chrome-titlebar {
   height: 38px;
   display: grid;
-  grid-template-columns: auto minmax(160px, 320px) minmax(0, 1fr) auto;
+  /* The project-title track must be allowed to shrink below its content. With a
+     160px floor it stole width from the menu row, which is overflow-x: auto with
+     a hidden scrollbar, so the last menus (Data/Tools/Help) scrolled out of view
+     with no visual affordance on ~1024-1150px viewports. The title already
+     ellipsises, so let it yield to the menus. */
+  grid-template-columns: auto minmax(0, 320px) minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
   padding: 6px 10px 2px;
@@ -159,6 +164,42 @@
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: none;
+}
+
+/* Second line of defence for the hidden-scrollbar clipping above: below 1180px
+   the menus take their own full-width row instead of competing with the title
+   and the Report an issue button. Kept separate from the 900px block, which
+   also stacks the chat under the sheet -- that layout change should not kick in
+   this early. */
+@media (min-width: 901px) and (max-width: 1180px) {
+  .workspace-chrome {
+    height: 100px;
+  }
+
+  .workspace-chrome-titlebar {
+    height: 62px;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-areas:
+      "mark title links"
+      "menus menus menus";
+    row-gap: 2px;
+  }
+
+  .workspace-file-mark {
+    grid-area: mark;
+  }
+
+  .workspace-file-title {
+    grid-area: title;
+  }
+
+  .workspace-chrome-links {
+    grid-area: links;
+  }
+
+  .workspace-menu-row {
+    grid-area: menus;
+  }
 }
 
 .workspace-menu-row::-webkit-scrollbar {
@@ -1293,6 +1334,45 @@
 
 .dark .workspace-hot .handsontable .ht_master .htCore tbody tr:nth-child(odd) > th {
   background: hsl(145 14% 15%);
+}
+
+/* Surfaces below were authored with literal light values and had no dark
+   counterpart, so on a dark theme the sheet pane rendered as a white slab
+   inside otherwise dark chrome (the workspace is the default route and hides
+   the app header, so a system-dark user could not switch away from it). */
+.dark .workspace-sheet-pane {
+  background: hsl(150 8% 8%);
+}
+
+.dark .workspace-loading-overlay {
+  background: hsl(150 8% 8% / 0.72);
+}
+
+.dark .workspace-loading-card {
+  background: hsl(150 9% 12%);
+  border-color: hsl(146 14% 24%);
+  color: hsl(var(--foreground));
+}
+
+.dark .workspace-data-loading-badge {
+  background: hsl(150 9% 12%);
+  border-color: hsl(146 14% 24%);
+  color: hsl(var(--foreground));
+}
+
+.dark .workspace-toolbar-separator {
+  background: hsl(146 14% 24%);
+}
+
+.dark .workspace-followup-banner {
+  background: hsl(38 32% 14%);
+  border-bottom-color: hsl(38 28% 26%);
+}
+
+.dark .workspace-sheet-tab[data-active="true"] {
+  border-color: hsl(142 45% 42%);
+  background: hsl(146 28% 16%);
+  color: hsl(142 52% 72%);
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/pages/Workspace/constants.ts
+++ b/frontend/src/pages/Workspace/constants.ts
@@ -4,7 +4,7 @@ import {
 } from '@/components/AdvancedSettings/AdvancedSettingsFields';
 import type { PaginatedData } from '@/types';
 
-import type { SheetId, TableFontFamily } from './types';
+import type { SheetId, TableFontFamily, WorkspaceMenu } from './types';
 
 // Shared constants for the Workspace page and its sub-components.
 
@@ -45,38 +45,63 @@ export const SHEETS: Array<{ id: SheetId; label: string; group: 'structure' | 'a
   { id: 'monitor', label: 'Monitor', group: 'analysis' },
 ];
 
-export const WORKSPACE_MENUS = [
+// Top menu bar. Every item carries the action it performs, and
+// SpreadsheetChrome resolves those actions through an exhaustive Record, so a
+// menu entry cannot exist without a handler behind it. Items that were purely
+// decorative (Insert, Format, Undo/Redo, Sort range, Validate schema, and so
+// on) are omitted rather than rendered as clickable no-ops; the formatting
+// toolbar below covers font/bold/align, and the column header dropdown covers
+// sorting and filtering.
+export const WORKSPACE_MENUS: WorkspaceMenu[] = [
   {
     label: 'File',
-    items: ['New project', 'Import project', 'Open classic visualizer', 'Download table (.csv)', 'Save project (.schematiq.json)', 'Save project with documents (.zip)'],
+    items: [
+      { label: 'New project', action: 'newProject' },
+      { label: 'Import project', action: 'importProject' },
+      { label: 'Open classic visualizer', action: 'openClassic', requiresProject: true },
+      { label: 'Download table (.csv)', action: 'exportCsv', requiresProject: true },
+      { label: 'Save project (.schematiq.json)', action: 'saveProject', requiresProject: true },
+      { label: 'Save project with documents (.zip)', action: 'saveProjectWithDocs', requiresProject: true },
+    ],
   },
   {
     label: 'Edit',
-    items: ['Undo', 'Redo', 'Find and replace', 'Delete values'],
+    items: [
+      // Handsontable's UndoRedo plugin is enabled on the grid, and edits made
+      // by it flow through the same afterChange -> updateCell path as typed
+      // ones, so these persist rather than only reverting the display.
+      { label: 'Undo', action: 'undo', requiresProject: true },
+      { label: 'Redo', action: 'redo', requiresProject: true },
+      // Browser find over the table. Not a replace, so it is not labelled one.
+      { label: 'Find in workspace', action: 'find' },
+    ],
   },
   {
     label: 'View',
-    items: ['Show sheet full screen', 'Show chat full screen', 'Split view', 'Project details'],
-  },
-  {
-    label: 'Insert',
-    items: ['Column', 'Observation unit', 'Schema field', 'Comment'],
-  },
-  {
-    label: 'Format',
-    items: ['Text wrapping', 'Bold headers', 'Alternating colors', 'Clear formatting'],
+    items: [
+      { label: 'Show sheet full screen', action: 'showSheet', requiresProject: true },
+      { label: 'Show chat full screen', action: 'showChat', requiresProject: true },
+      { label: 'Split view', action: 'splitView', requiresProject: true },
+      { label: 'Project details', action: 'projectDetails', requiresProject: true },
+    ],
   },
   {
     label: 'Data',
-    items: ['Sort range', 'Create filter', 'Re-extract table', 'Add documents', 'Validate schema'],
+    items: [
+      { label: 'Re-extract table', action: 'reextract', requiresProject: true },
+      { label: 'Add documents', action: 'addDocuments', requiresProject: true },
+    ],
   },
   {
     label: 'Tools',
-    items: ['Estimate cost', 'Refresh project', 'Schema suggestions', 'Merge units'],
+    items: [
+      { label: 'Estimate cost', action: 'estimateCost', requiresProject: true },
+      { label: 'Refresh project', action: 'refreshProject', requiresProject: true },
+    ],
   },
   {
     label: 'Help',
-    items: ['Keyboard shortcuts', 'About ScheMatiQ workspace', 'Report an issue'],
+    items: [{ label: 'Report an issue', action: 'reportIssue' }],
   },
 ];
 

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -813,6 +813,22 @@ function Workspace() {
   // reported nothing for the rest of the table -- on a 194-row sheet that is
   // most of it. The Search plugin queries the loaded dataset instead, so a hit
   // outside the viewport is found and scrolled to.
+  // Handsontable's UndoRedo plugin is enabled on the grid, so the instance
+  // exposes undo/redo directly. Reverted cells re-enter handleChanges with a
+  // 'UndoRedo.*' source, which the persistence path does not filter out, so the
+  // revert is written back rather than only shown.
+  // Reached through getPlugin rather than hot.undo(): the convenience methods
+  // are attached at runtime by the plugin and are not on the Handsontable type.
+  const undoEdit = useCallback(() => {
+    const plugin = hotTableRef.current?.hotInstance?.getPlugin('undoRedo');
+    if (plugin?.isUndoAvailable()) plugin.undo();
+  }, []);
+
+  const redoEdit = useCallback(() => {
+    const plugin = hotTableRef.current?.hotInstance?.getPlugin('undoRedo');
+    if (plugin?.isRedoAvailable()) plugin.redo();
+  }, []);
+
   const searchPage = useCallback(() => {
     const term = window.prompt('Find in table')?.trim();
     if (!term) return;
@@ -1036,6 +1052,8 @@ function Workspace() {
         onSaveProjectWithDocs={saveProjectWithDocuments}
         onHome={() => navigate('/workspace')}
         onSearch={searchPage}
+        onUndo={undoEdit}
+        onRedo={redoEdit}
         onEstimateCost={estimateCurrentCost}
         onShowSheet={() => setChatWidth(0)}
         onShowChat={() => setChatWidth(window.innerWidth)}

--- a/frontend/src/pages/Workspace/types.ts
+++ b/frontend/src/pages/Workspace/types.ts
@@ -1,6 +1,41 @@
 // Shared TypeScript types for the Workspace page and its sub-components.
 
 export type SheetId = 'data' | 'unit' | 'schema' | 'stats' | 'monitor' | 'documents';
+
+// Every action the top menu bar can perform. SpreadsheetChrome maps this union
+// to handlers via a Record, so adding a menu item without wiring it is a type
+// error rather than a menu entry that silently does nothing when clicked.
+export type WorkspaceMenuAction =
+  | 'newProject'
+  | 'importProject'
+  | 'openClassic'
+  | 'exportCsv'
+  | 'saveProject'
+  | 'saveProjectWithDocs'
+  | 'undo'
+  | 'redo'
+  | 'find'
+  | 'showSheet'
+  | 'showChat'
+  | 'splitView'
+  | 'projectDetails'
+  | 'reextract'
+  | 'addDocuments'
+  | 'estimateCost'
+  | 'refreshProject'
+  | 'reportIssue';
+
+export type WorkspaceMenuItem = {
+  label: string;
+  action: WorkspaceMenuAction;
+  // Acts on an open project; rendered disabled while none is open.
+  requiresProject?: boolean;
+};
+
+export type WorkspaceMenu = {
+  label: string;
+  items: WorkspaceMenuItem[];
+};
 export type WorkspaceSessionMode = 'schematiq' | 'load';
 export type PendingRerunKind = 'schema' | 'unit';
 


### PR DESCRIPTION
## Problem

1. **19 of 33 top-menu items were clickable no-ops.** `WORKSPACE_MENUS` listed 33 labels; `runMenuItem` handled 15. `isDisabled` was a label whitelist, so with no project open File and View greyed out correctly while Edit and Insert still looked live. Two toolbar buttons (Text color, Sigma) had no `onClick` at all.
2. **Dark mode rendered the sheet pane as a white slab.** `.workspace-sheet-pane` and six siblings were authored with literal light values and had no `.dark` counterpart. Measured on the live site: `rgb(247,251,247)` inside `rgb(2,8,23)`. The workspace hides `AppHeader`, where `ThemeToggle` lives, and `defaultTheme` is `system`, so a system-dark user has no way out.
3. **Data / Tools / Help disappeared between 900px and ~1180px.** The titlebar gave the title track a 160px floor, squeezing `.workspace-menu-row`, which is `overflow-x: auto` with `scrollbar-width: none` — scrollable with zero affordance. Measured at 1024px: only File, Edit, View, Insert, Format were within the row's visible bounds.

## Solution

- Menu items are declarative (`WorkspaceMenuItem { label, action, requiresProject? }`), resolved through `Record<WorkspaceMenuAction, () => void>`. An action without a handler is a compile error, so the dead-item class of bug cannot recur.
- Unimplemented items are removed rather than shipped as no-ops. Insert and Format are gone (the formatting toolbar covers font/bold/align; the column header dropdown covers sort and filter). Six menus remain, every item wired.
- **Undo and Redo are wired rather than dropped.** Handsontable's UndoRedo plugin is already enabled on the grid, so Ctrl+Z works today with no menu surface. Verified that reverts persist: `handleChanges` filters only `source === 'loadData'`, so `UndoRedo.*` edits go through the same `updateCell` path as typed ones. Reached via `getPlugin('undoRedo')` with the availability guards, since `hot.undo()` is attached at runtime and is not on the type.
- Edit's find is wired to the existing `onSearch`, previously reachable only from the magnifier icon, and labelled `Find in workspace` — it is a find, not a replace.
- Removed the two toolbar buttons with no handler.
- Added `.dark` overrides for the seven hard-coded light surfaces.
- Title grid track relaxed to `minmax(0, 320px)`, plus a `(min-width: 901px) and (max-width: 1180px)` block giving the menus their own full-width row. Kept separate from the 900px block, which also stacks the chat under the sheet.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.
- Exhaustiveness proven by temporarily adding an unwired action: `TS2741: Property 'probeUnwired' is missing ... but required in type 'Record<WorkspaceMenuAction, () => void>'`.
- Menu visibility measured with Playwright via `getBoundingClientRect` against the menu row bounds. Before at 1024px: File, Edit, View, Insert, Format. After: all six.
- Not verified by running: that Edit > Undo persists the revert. The plugin API typechecks and the persistence path was read, but the fixed build was not run. Worth checking manually — edit a cell, Undo, refresh, confirm the revert survived.
- Dark mode and layout screenshots were produced by injecting the CSS into the live app; `craco build` did not run in the review environment.