### PR TITLE
fix(workspace): restore Ctrl/Cmd+B/I/U by registering shortcuts after mount

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -532,10 +532,19 @@ export function SpreadsheetSurface({
   // context, so they fire only when the grid is focused and NOT while a cell
   // editor is open (typing "b" into a cell must not bold it). Ctrl+B/I/U are not
   // Handsontable defaults, so this adds no conflict with copy/undo/select-all.
-  // Registered per instance at afterInit; the grid remounts on sheet/view
-  // changes, giving each instance its own fresh context (no accumulation).
-  const registerFormatShortcuts = useCallback(() => {
-    const hot = hotTableRef.current?.hotInstance;
+  // Registered per instance; the grid remounts on sheet/view changes, giving
+  // each instance its own fresh context (no accumulation).
+  //
+  // Registration is driven by the effect below rather than by `afterInit`.
+  // `afterInit` runs from inside Handsontable's constructor, before
+  // @handsontable/react has assigned `hotInstance` onto the ref, so reading the
+  // ref there yields undefined and the registration silently no-ops -- which is
+  // why Ctrl/Cmd+B/I/U stopped firing while Handsontable's own grid shortcuts
+  // (arrows, Ctrl+A) kept working. The other afterInit callees survived this
+  // because they are also invoked from later hooks and effects; this one had
+  // afterInit as its only caller.
+  const registerFormatShortcuts = useCallback((instance?: HotTableClass['hotInstance']) => {
+    const hot = instance ?? hotTableRef.current?.hotInstance;
     if (!hot) return;
     try {
       const context = hot.getShortcutManager().getContext('grid');
@@ -556,6 +565,19 @@ export function SpreadsheetSurface({
       }
     } catch { /* instance may be mid-teardown or context unavailable */ }
   }, [hotTableRef]);
+
+  // Runs after every render, but the identity guard makes it a no-op except on
+  // the first render after a new grid instance appears. Deliberately without a
+  // dependency array: the grid remounts on `key` changes (sheet/view) and the
+  // ref is populated by the wrapper after mount, so there is no dependency that
+  // reliably marks "a new instance now exists".
+  const shortcutInstanceRef = useRef<HotTableClass['hotInstance'] | null>(null);
+  useEffect(() => {
+    const hot = hotTableRef.current?.hotInstance;
+    if (!hot || shortcutInstanceRef.current === hot) return;
+    shortcutInstanceRef.current = hot;
+    registerFormatShortcuts(hot);
+  });
 
   const markFilterSettingsInitOnly = useCallback(() => {
     const hot = hotTableRef.current?.hotInstance;
@@ -1456,7 +1478,6 @@ export function SpreadsheetSurface({
           syncHotTableDimensions();
           applyGroupMerges();
           markFilterSettingsInitOnly();
-          registerFormatShortcuts();
           syncHeaderOverlayScroll();
         }}
         // Runs after Handsontable has drawn and (mis)clamped the header overlay's


### PR DESCRIPTION
## Problem

Ctrl/Cmd+B/I/U do nothing. The toolbar buttons work. Measured on a live session, on an editable data cell:

| action | computed fontWeight | localStorage `workspace.cellFormats` |
|---|---|---|
| initial | 400 | empty |
| Ctrl+B | 400 | empty |
| toolbar B | 600 | `{"data:0:3":{"bold":true}}` |

Not a focus problem: Handsontable's own grid-context shortcuts fire normally on the same selection — ArrowDown moves the cursor (0,4 to 1,4) and Ctrl+A selects 36 cells, with `document.activeElement` inside the grid. The ShortcutManager and its `grid` context are live; only our registration is missing.

`registerFormatShortcuts` was called only from `afterInit`. `afterInit` runs from inside Handsontable's constructor, before `@handsontable/react` assigns `hotInstance` onto the ref, so `hotTableRef.current?.hotInstance` is undefined and the function returns early without registering. The other `afterInit` callees are unaffected because each is also invoked from later hooks and effects (`syncHotTableDimensions` from four sites, `applyGroupMerges` from six, `markFilterSettingsInitOnly` from three). This one had `afterInit` as its only caller, so its silent failure was permanent.

## Solution

Registration moves out of `afterInit` into an effect that runs after mount, once the wrapper has populated the ref. An instance-identity ref makes it register exactly once per Handsontable instance, so a remount on sheet/view change re-registers and nothing accumulates. `registerFormatShortcuts` now takes the instance directly, so it no longer depends on ref timing at all.

The effect intentionally has no dependency array: the grid remounts via its `key` and the ref is populated after mount, so no dependency reliably signals "a new instance exists". The identity guard makes every other render a no-op.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.
- Manually: select an editable data cell, press Ctrl+B, confirm the cell renders bold and `localStorage.workspace.cellFormats` gains an entry. Switch sheets (Data to Schema and back) and confirm the shortcut still fires after the remount.
- Not verified by running: `craco build` did not complete in the review environment, so this was validated by measurement of the broken behaviour plus typecheck, not by executing the fix.