### PR TITLE
feat(workspace): search highlighting, compact rows, and a keyboard shortcuts reference

### DIFF
--- a/frontend/src/pages/Workspace/KeyboardShortcutsDialog.tsx
+++ b/frontend/src/pages/Workspace/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,113 @@
+// Read-only reference for the shortcuts that work inside the sheet.
+// Parent: Workspace (index.tsx).
+//
+// Every entry below is a shortcut the grid actually handles: the formatting
+// three are registered by SpreadsheetSurface against Handsontable's
+// ShortcutManager 'grid' context, the rest are Handsontable built-ins enabled by
+// the copyPaste/undo/columnSorting settings on the table, plus the
+// column-header Delete handled by beforeKeyDown. Nothing aspirational is
+// listed -- an inaccurate reference is worse than none.
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+type Shortcut = { keys: string[]; label: string };
+
+const GROUPS: { title: string; items: Shortcut[] }[] = [
+  {
+    title: 'Formatting',
+    items: [
+      { keys: ['Mod', 'B'], label: 'Bold the selected cells' },
+      { keys: ['Mod', 'I'], label: 'Italicise the selected cells' },
+      { keys: ['Mod', 'U'], label: 'Underline the selected cells' },
+    ],
+  },
+  {
+    title: 'Editing',
+    items: [
+      { keys: ['Mod', 'Z'], label: 'Undo' },
+      { keys: ['Mod', 'Y'], label: 'Redo' },
+      { keys: ['Mod', 'C'], label: 'Copy' },
+      { keys: ['Mod', 'X'], label: 'Cut' },
+      { keys: ['Mod', 'V'], label: 'Paste' },
+      { keys: ['Enter'], label: 'Edit the selected cell' },
+      { keys: ['Esc'], label: 'Cancel the current edit' },
+      { keys: ['Delete'], label: 'Clear the selected cells' },
+      { keys: ['Delete'], label: 'Delete the columns, when whole columns are selected by their headers' },
+    ],
+  },
+  {
+    title: 'Selection',
+    items: [
+      { keys: ['Mod', 'A'], label: 'Select the whole sheet' },
+      { keys: ['↑', '↓', '←', '→'], label: 'Move between cells' },
+      { keys: ['Tab'], label: 'Move to the next cell' },
+      { keys: ['Shift', 'Tab'], label: 'Move to the previous cell' },
+    ],
+  },
+];
+
+function Keys({ keys, isMac }: { keys: string[]; isMac: boolean }) {
+  return (
+    <span className="flex shrink-0 items-center gap-1">
+      {keys.map((key, index) => (
+        <span key={`${key}-${index}`} className="flex items-center gap-1">
+          {index > 0 && <span className="text-muted-foreground">+</span>}
+          <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-[11px] leading-none">
+            {key === 'Mod' ? (isMac ? '⌘' : 'Ctrl') : key}
+          </kbd>
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export function KeyboardShortcutsDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const isMac =
+    typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform || '');
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription>
+            These work while the sheet has focus. Click a cell first.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          {GROUPS.map((group) => (
+            <div key={group.title}>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {group.title}
+              </h3>
+              <ul className="space-y-1.5">
+                {group.items.map((item, index) => (
+                  <li
+                    key={`${group.title}-${index}`}
+                    className="flex items-start justify-between gap-4 text-sm"
+                  >
+                    <span className="text-muted-foreground">{item.label}</span>
+                    <Keys keys={item.keys} isMac={isMac} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/Workspace/SpreadsheetChrome.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetChrome.tsx
@@ -54,6 +54,8 @@ export function SpreadsheetChrome({
   onShowSheet,
   onShowChat,
   onSplitView,
+  onToggleCompactRows,
+  onKeyboardShortcuts,
   onRunPendingEdits,
   onAddDocuments,
   onApplyFormat,
@@ -81,6 +83,8 @@ export function SpreadsheetChrome({
   onShowSheet: () => void;
   onShowChat: () => void;
   onSplitView: () => void;
+  onToggleCompactRows: () => void;
+  onKeyboardShortcuts: () => void;
   onRunPendingEdits: () => void;
   onAddDocuments: () => void;
   onApplyFormat: (patch: Partial<TableDisplayOptions>) => void;
@@ -103,6 +107,8 @@ export function SpreadsheetChrome({
     showSheet: onShowSheet,
     showChat: onShowChat,
     splitView: onSplitView,
+    toggleCompactRows: onToggleCompactRows,
+    keyboardShortcuts: onKeyboardShortcuts,
     projectDetails: onProjectDetails,
     reextract: onRunPendingEdits,
     addDocuments: onAddDocuments,

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -25,6 +25,7 @@ import {
   EDITABLE_OBSERVATION_UNIT_FIELDS,
   SCHEMA_COLUMN_HEADER_TOOLTIPS,
   cellFormatKey,
+  COMPACT_ROW_HEIGHT,
 } from './constants';
 import {
   documentDisplayName,
@@ -64,6 +65,7 @@ export function SpreadsheetSurface({
   onToggleFormatShortcut,
   onNewProject,
   onImportProject,
+  compactRows,
   layoutRevision,
   dataView,
 }: {
@@ -107,6 +109,11 @@ export function SpreadsheetSurface({
   // itself unreachable on narrow viewports.
   onNewProject?: () => void;
   onImportProject?: () => void;
+  // Fixed row height instead of measured. AutoRowSize keeps a stable per-row
+  // height so rows do not drift while scrolling horizontally, but it sizes each
+  // row to its tallest cell across all columns, which on wide schemas left ~5
+  // of 194 rows on screen. Uniform heights avoid the drift the same way.
+  compactRows?: boolean;
   layoutRevision: string;
   // Current Data-sheet grouping. Drives the visual cell-merge of the leftmost
   // grouping column: 'by_unit' merges unit_name, 'by_document' merges the
@@ -1465,12 +1472,19 @@ export function SpreadsheetSurface({
         // out of place). AutoRowSize caches a stable per-row height from the
         // full row, so a row keeps its height at any scroll position. See
         // handsontable/handsontable#493, #1213, #5241.
-        autoRowSize={true}
+        autoRowSize={!compactRows}
+        {...(compactRows ? { rowHeights: COMPACT_ROW_HEIGHT } : {})}
         contextMenu={contextMenuConfig}
         filters
         dropdownMenu={dropdownMenuConfig}
         columnSorting={!hasMultiRowGroup}
         copyPaste
+        // Required for the highlight, not for the query. getPlugin('search')
+        // .query() sets `isSearchResult` on cell meta regardless, but the hook
+        // that turns that into the htSearchResult class is guarded by the
+        // plugin's isEnabled(), which reads this setting -- so without it, Find
+        // jumped to the match and reported the count while highlighting nothing.
+        search
         undo
         minSpareRows={sheet.minSpareRows || 0}
         licenseKey="non-commercial-and-evaluation"

--- a/frontend/src/pages/Workspace/constants.ts
+++ b/frontend/src/pages/Workspace/constants.ts
@@ -52,6 +52,10 @@ export const SHEETS: Array<{ id: SheetId; label: string; group: 'structure' | 'a
 // on) are omitted rather than rendered as clickable no-ops; the formatting
 // toolbar below covers font/bold/align, and the column header dropdown covers
 // sorting and filtering.
+// Row height used when compact rows are on. Matches the 12px table font with
+// single-line padding.
+export const COMPACT_ROW_HEIGHT = 28;
+
 export const WORKSPACE_MENUS: WorkspaceMenu[] = [
   {
     label: 'File',
@@ -82,6 +86,7 @@ export const WORKSPACE_MENUS: WorkspaceMenu[] = [
       { label: 'Show sheet full screen', action: 'showSheet', requiresProject: true },
       { label: 'Show chat full screen', action: 'showChat', requiresProject: true },
       { label: 'Split view', action: 'splitView', requiresProject: true },
+      { label: 'Toggle compact rows', action: 'toggleCompactRows', requiresProject: true },
       { label: 'Project details', action: 'projectDetails', requiresProject: true },
     ],
   },
@@ -101,7 +106,10 @@ export const WORKSPACE_MENUS: WorkspaceMenu[] = [
   },
   {
     label: 'Help',
-    items: [{ label: 'Report an issue', action: 'reportIssue' }],
+    items: [
+      { label: 'Keyboard shortcuts', action: 'keyboardShortcuts' },
+      { label: 'Report an issue', action: 'reportIssue' },
+    ],
   },
 ];
 

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -73,6 +73,7 @@ import {
 } from './helpers';
 import { NewProjectDialog } from './NewProjectDialog';
 import { PendingRerunBanner } from './PendingRerunBanner';
+import { KeyboardShortcutsDialog } from './KeyboardShortcutsDialog';
 import { ProjectDetailsDialog } from './ProjectDetailsDialog';
 import ReportIssueDialog from '@/components/ReportIssueDialog/ReportIssueDialog';
 import { SpreadsheetChrome } from './SpreadsheetChrome';
@@ -819,6 +820,19 @@ function Workspace() {
   // revert is written back rather than only shown.
   // Reached through getPlugin rather than hot.undo(): the convenience methods
   // are attached at runtime by the plugin and are not on the Handsontable type.
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [compactRows, setCompactRows] = useState<boolean>(() => {
+    try { return localStorage.getItem('workspace.compactRows') === '1'; } catch { return false; }
+  });
+
+  const toggleCompactRows = useCallback(() => {
+    setCompactRows((current) => {
+      const next = !current;
+      try { localStorage.setItem('workspace.compactRows', next ? '1' : '0'); } catch { /* private mode */ }
+      return next;
+    });
+  }, []);
+
   const undoEdit = useCallback(() => {
     const plugin = hotTableRef.current?.hotInstance?.getPlugin('undoRedo');
     if (plugin?.isUndoAvailable()) plugin.undo();
@@ -920,7 +934,7 @@ function Workspace() {
         : `minmax(0, 1fr) 8px ${chatWidth}px`;
   // Crossing the breakpoint resizes the grid without changing chatWidth, so the
   // revision has to carry it too or Handsontable keeps stale measurements.
-  const gridLayoutRevision = `${chatWidth}:${isStacked ? 'stacked' : 'split'}`;
+  const gridLayoutRevision = `${chatWidth}:${isStacked ? 'stacked' : 'split'}:${compactRows ? 'compact' : 'auto'}`;
   const reextractionPercent = Math.round((reextraction?.progress || 0) * 100);
   const bottombarStatus = reextraction
     ? `Re-extracting ${reextraction.columns.join(', ')} (${reextraction.processedDocuments}/${reextraction.totalDocuments || '?'} docs)`
@@ -1006,6 +1020,7 @@ function Workspace() {
         onToggleFormatShortcut={handleFormatShortcut}
         onNewProject={() => setProjectDialogOpen(true)}
         onImportProject={() => importInputRef.current?.click()}
+        compactRows={compactRows}
         layoutRevision={gridLayoutRevision}
         dataView={dataView}
       />
@@ -1052,6 +1067,8 @@ function Workspace() {
         onSaveProjectWithDocs={saveProjectWithDocuments}
         onHome={() => navigate('/workspace')}
         onSearch={searchPage}
+        onToggleCompactRows={toggleCompactRows}
+        onKeyboardShortcuts={() => setShortcutsOpen(true)}
         onUndo={undoEdit}
         onRedo={redoEdit}
         onEstimateCost={estimateCurrentCost}
@@ -1406,6 +1423,8 @@ function Workspace() {
           refresh();
         }}
       />
+
+      <KeyboardShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
 
       <ProjectDetailsDialog
         open={detailsDialogOpen}

--- a/frontend/src/pages/Workspace/types.ts
+++ b/frontend/src/pages/Workspace/types.ts
@@ -18,11 +18,13 @@ export type WorkspaceMenuAction =
   | 'showSheet'
   | 'showChat'
   | 'splitView'
+  | 'toggleCompactRows'
   | 'projectDetails'
   | 'reextract'
   | 'addDocuments'
   | 'estimateCost'
   | 'refreshProject'
+  | 'keyboardShortcuts'
   | 'reportIssue';
 
 export type WorkspaceMenuItem = {


### PR DESCRIPTION
## Problem

**Find highlighted nothing.** Measured on a live session: the jump and the count worked (`1 match | Jumped to the first one.`, cursor landed on the right cell) but `document.querySelectorAll('.htSearchResult').length` was 0. The cause is in Handsontable's search plugin, which guards the class it applies behind `this.isEnabled()`:

```js
if (this.isEnabled() && cellProperties.isSearchResult) { classArray.push(this.searchResultClass); }
```

`isEnabled()` reads the `search` table setting, which was never passed. `getPlugin('search').query()` still marks `isSearchResult` on cell meta, so the query half worked and the highlight half did not.

**Rows are too tall to scan.** Measured row heights of 109-209px, leaving about 5 of 194 rows on screen. `autoRowSize` is deliberate and documented — it keeps a stable per-row height so rows do not drift while scrolling horizontally (handsontable#493, #1213, #5241) — but it sizes each row to its tallest cell across all columns, which on a wide schema is very tall.

**Shortcuts are undiscoverable.** Ctrl/Cmd+B/I/U, undo/redo, and the column-header Delete have no surface anywhere in the UI.

## Solution

- Pass `search` to the table. One prop; the query path is unchanged.
- `View > Toggle compact rows`, persisted in localStorage. When on, `autoRowSize` is off and `rowHeights` is a fixed 28px. The default is unchanged. Uniform heights avoid the horizontal-scroll drift the same way `autoRowSize` does, so the tradeoff the original comment describes does not reappear. `compactRows` joins `gridLayoutRevision` so the measurement effect re-runs on toggle.
- `Help > Keyboard shortcuts`, a read-only dialog on the same pattern as `ProjectDetailsDialog`, showing the platform modifier.

Every shortcut listed is one the grid actually handles, verified rather than assumed: the formatting three come from the ShortcutManager registration in SpreadsheetSurface; Ctrl+A and the arrows were measured live (ArrowDown moved the cursor 0,4 to 1,4; Ctrl+A selected 36 cells); undo/redo/copy/cut/paste come from the `undo` and `copyPaste` table settings; the column-header Delete comes from `handleBeforeKeyDown`.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.
- Menu exhaustiveness still enforced — temporarily adding an unwired action gives `TS2741: Property 'probeX' is missing ... but required in type 'Record<WorkspaceMenuAction, () => void>'`.
- Manually: run Find and confirm matches are highlighted, not just selected. Toggle compact rows, confirm row count rises, switch sheets and back. Open Help > Keyboard shortcuts.
- Not verified by running: `craco build` did not complete in the review environment. The search root cause was measured on the live app before the fix, but none of the three was executed after it. `KeyboardShortcutsDialog` is a new component that has never rendered — the highest-risk part of this patch.