### PR TITLE
feat(workspace): undo/redo (Ctrl+Z / Ctrl+Y) for formats and cell edits

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,6 +42,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "handsontable": "^17.0.1",
+        "immer": "^11.1.16",
         "lucide-react": "^0.561.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -11067,9 +11068,10 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "version": "11.1.16",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.16.tgz",
+      "integrity": "sha512-Xs7H9rBc+kti1J6RueUvbEBkmOz7jqj11XYgf+YMXAYzu8EeE7hwZ9poLXdVfVnGmJu7QAf41T7H2KuF6QoK6Q==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -16509,6 +16511,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react-dev-utils/node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/react-dev-utils/node_modules/loader-utils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "handsontable": "^17.0.1",
+    "immer": "^11.1.16",
     "lucide-react": "^0.561.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -20,6 +20,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { observationUnitAPI, schemaAPI, schematiqAPI } from '@/services/api';
 import type { ColumnInfo, DataRow, PaginatedData, SchemaData } from '@/types';
 import { formatColumnName } from '@/utils/formatting';
+import type { EditCommand } from './hooks/useEditHistory';
 
 import {
   EDITABLE_OBSERVATION_UNIT_FIELDS,
@@ -63,6 +64,9 @@ export function SpreadsheetSurface({
   onEditFollowUp,
   onEditEnd,
   onToggleFormatShortcut,
+  onUndo,
+  onRedo,
+  onRecordEdit,
   onNewProject,
   onImportProject,
   compactRows,
@@ -104,6 +108,14 @@ export function SpreadsheetSurface({
   // Toggle a text format (bold/italic/underline) on the current selection,
   // invoked by the Ctrl/Cmd+B/I/U keyboard shortcuts registered below.
   onToggleFormatShortcut?: (key: 'bold' | 'italic' | 'underline') => void;
+  // Reverse / re-apply the last reversible edit (Ctrl/Cmd+Z, Ctrl/Cmd+Y or
+  // Ctrl/Cmd+Shift+Z), wired to the workspace undo/redo stack. Native
+  // Handsontable undo is disabled (undo={false}) because it only tracks in-grid
+  // changes and its stack is cleared whenever the controlled data prop reloads.
+  onUndo?: () => void;
+  onRedo?: () => void;
+  // Record an undoable command after a cell-value edit is applied.
+  onRecordEdit?: (command: EditCommand) => void;
   // Empty-state actions. Closing the New Project dialog previously left the
   // workbook as a dead end whose only way forward was the File menu, which is
   // itself unreachable on narrow viewports.
@@ -533,6 +545,10 @@ export function SpreadsheetSurface({
   // never stale, without re-registering on every render. Mirrors menuActionsRef.
   const formatShortcutRef = useRef(onToggleFormatShortcut);
   formatShortcutRef.current = onToggleFormatShortcut;
+  const undoRef = useRef(onUndo);
+  undoRef.current = onUndo;
+  const redoRef = useRef(onRedo);
+  redoRef.current = onRedo;
 
   // Register Ctrl/Cmd+B/I/U through Handsontable's built-in ShortcutManager
   // rather than a hand-rolled keydown handler. The shortcuts live in the 'grid'
@@ -570,6 +586,24 @@ export function SpreadsheetSurface({
           group: 'schematiq:formatting',
         });
       }
+      // Undo/redo drive the workspace edit-history stack (formats + cell-value
+      // edits). Live in the 'grid' context, so they do not fire while a cell
+      // editor is open, leaving the editor's own text undo intact. Native HT
+      // undo/redo is disabled (undo={false}) to avoid a double handler.
+      context.addShortcut({
+        keys: [['control', 'z'], ['meta', 'z']],
+        callback: () => { undoRef.current?.(); },
+        preventDefault: true,
+        stopPropagation: true,
+        group: 'schematiq:formatting',
+      });
+      context.addShortcut({
+        keys: [['control', 'y'], ['meta', 'y'], ['control', 'shift', 'z'], ['meta', 'shift', 'z']],
+        callback: () => { redoRef.current?.(); },
+        preventDefault: true,
+        stopPropagation: true,
+        group: 'schematiq:formatting',
+      });
     } catch { /* instance may be mid-teardown or context unavailable */ }
   }, [hotTableRef]);
 
@@ -874,6 +908,51 @@ export function SpreadsheetSurface({
     [flushEditToast],
   );
 
+  type CellUpdate = {
+    rowName: string;
+    sourceDocument?: string;
+    rowIndexId?: number;
+    column: string;
+    value: string;
+  };
+
+  // Apply a batch of cell writes through the standard edit pipeline: optimistic
+  // React update up front, the persisting PUTs, one summary toast, then a
+  // refresh. Shared by direct edits and by undo/redo (which replay the inverse
+  // or forward batch), so the paths can never drift.
+  const applyCellUpdates = useCallback((updates: CellUpdate[]) => {
+    if (!sessionId || updates.length === 0) return;
+
+    onOptimisticCellEdit(
+      updates.map((u) => ({
+        identity: { rowName: u.rowName, sourceDocument: u.sourceDocument, rowIndex: u.rowIndexId },
+        column: u.column,
+        value: u.value,
+      })),
+    );
+
+    const allCleared = updates.every((u) => u.value.trim() === '');
+
+    Promise.allSettled(
+      updates.map((u) =>
+        schematiqAPI.updateCell(sessionId, u.rowName, u.column, u.value, u.sourceDocument, u.rowIndexId),
+      ),
+    ).then((results) => {
+      const failed = results.filter((r) => r.status === 'rejected').length;
+      const succeeded = updates.length - failed;
+
+      let single: { cleared: boolean; label: string; column: string } | null = null;
+      if (updates.length === 1 && failed === 0) {
+        const u = updates[0];
+        const rowLabel = u.rowName || (u.rowIndexId != null ? `Row ${u.rowIndexId + 1}` : 'Row');
+        single = { cleared: allCleared, label: rowLabel, column: u.column };
+      }
+      queueEditToast({ succeeded, failed, allCleared, single });
+
+      onRefreshData();
+    });
+  }, [onOptimisticCellEdit, onRefreshData, queueEditToast, sessionId]);
+
   const handleChanges = useCallback((changes: any[] | null, source: string) => {
     if (!changes || source === 'loadData' || !sessionId) return;
 
@@ -893,14 +972,8 @@ export function SpreadsheetSurface({
       const toPhysicalRow = (visualRow: number): number =>
         hot && typeof hot.toPhysicalRow === 'function' ? hot.toPhysicalRow(visualRow) : visualRow;
 
-      type CellUpdate = {
-        rowName: string;
-        sourceDocument?: string;
-        rowIndexId?: number;
-        column: string;
-        value: string;
-      };
       const updates: CellUpdate[] = [];
+      const inverseUpdates: CellUpdate[] = [];
       let unidentified = 0;
 
       for (const change of changes) {
@@ -919,6 +992,7 @@ export function SpreadsheetSurface({
         }
 
         updates.push({ rowName, sourceDocument, rowIndexId, column: key, value: String(newValue ?? '') });
+        inverseUpdates.push({ rowName, sourceDocument, rowIndexId, column: key, value: String(oldValue ?? '') });
       }
 
       if (updates.length === 0) {
@@ -937,35 +1011,15 @@ export function SpreadsheetSurface({
       // the grid does not revert while the writes are in flight. A single call
       // (rather than one per cell) keeps a multi-cell clear from triggering a
       // render cascade inside Handsontable's synchronous afterChange.
-      onOptimisticCellEdit(
-        updates.map((u) => ({
-          identity: { rowName: u.rowName, sourceDocument: u.sourceDocument, rowIndex: u.rowIndexId },
-          column: u.column,
-          value: u.value,
-        })),
-      );
+      applyCellUpdates(updates);
 
-      const allCleared = updates.every((u) => u.value.trim() === '');
-
-      Promise.allSettled(
-        updates.map((u) =>
-          schematiqAPI.updateCell(sessionId, u.rowName, u.column, u.value, u.sourceDocument, u.rowIndexId),
-        ),
-      ).then((results) => {
-        const failed = results.filter((r) => r.status === 'rejected').length;
-        const succeeded = updates.length - failed;
-
-        let single: { cleared: boolean; label: string; column: string } | null = null;
-        if (updates.length === 1 && failed === 0) {
-          const u = updates[0];
-          const rowLabel = u.rowName || (u.rowIndexId != null ? `Row ${u.rowIndexId + 1}` : 'Row');
-          single = { cleared: allCleared, label: rowLabel, column: u.column };
-        }
-        // Accumulate; the debounced flush emits a single toast for the whole
-        // interaction even when Handsontable splits it across afterChange calls.
-        queueEditToast({ succeeded, failed, allCleared, single });
-
-        onRefreshData();
+      // Record the batch as one history entry: Ctrl/Cmd+Z restores the previous
+      // values, Ctrl/Cmd+Y (or Shift+Z) reapplies them, both through the same
+      // pipeline. Undo/redo replay via applyCellUpdates (which does not record),
+      // so they never stack a command.
+      onRecordEdit?.({
+        undo: () => applyCellUpdates(inverseUpdates),
+        redo: () => applyCellUpdates(updates),
       });
 
       return;
@@ -1111,7 +1165,7 @@ export function SpreadsheetSurface({
           });
       }
     }
-  }, [activeSheet, data.rows, hotTableRef, observationUnitRows, onEditFollowUp, onOptimisticCellEdit, onRefresh, onRefreshData, queueEditToast, schemaColumns, sessionId, toast]);
+  }, [activeSheet, applyCellUpdates, data.rows, hotTableRef, observationUnitRows, onEditFollowUp, onRecordEdit, onRefresh, onRefreshData, schemaColumns, sessionId, toast]);
 
   const handleBeforeRemoveRow = useCallback(
     (_index: number, _amount: number, physicalRows: number[], _source?: string): boolean | void => {
@@ -1485,7 +1539,7 @@ export function SpreadsheetSurface({
         // plugin's isEnabled(), which reads this setting -- so without it, Find
         // jumped to the match and reported the count while highlighting nothing.
         search
-        undo
+        undo={false}
         minSpareRows={sheet.minSpareRows || 0}
         licenseKey="non-commercial-and-evaluation"
         afterInit={() => {

--- a/frontend/src/pages/Workspace/hooks/useEditHistory.ts
+++ b/frontend/src/pages/Workspace/hooks/useEditHistory.ts
@@ -1,0 +1,74 @@
+import { useCallback, useMemo, useRef } from 'react';
+
+/**
+ * A single reversible action, following the Command pattern: it carries whatever
+ * it needs to reverse and to re-apply itself. Both may be async because
+ * value-edit commands round-trip to the server; format commands run
+ * synchronously against client state.
+ */
+export interface EditCommand {
+  undo: () => void | Promise<void>;
+  redo: () => void | Promise<void>;
+}
+
+export interface EditHistory {
+  /** Record a command after its forward action has been applied. Clears redo. */
+  push: (command: EditCommand) => void;
+  /** Reverse the most recent command (LIFO). Returns false if nothing to undo. */
+  undo: () => boolean;
+  /** Re-apply the most recently undone command. Returns false if nothing to redo. */
+  redo: () => boolean;
+  /** Drop both stacks (e.g. when the underlying data is replaced). */
+  clear: () => void;
+}
+
+const DEFAULT_LIMIT = 100;
+
+/**
+ * Minimal, headless undo/redo stack. Both stacks live in refs so recording,
+ * undoing, or redoing never triggers a re-render; the feature is driven purely
+ * from the Ctrl/Cmd+Z and Ctrl/Cmd+Y (or Ctrl/Cmd+Shift+Z) shortcuts, so no
+ * reactive "can undo" state is needed.
+ *
+ * Deliberately generic: it knows nothing about formats, cells, or the grid.
+ * Each command owns its own inverse and forward action, so heterogeneous
+ * actions (client-only format changes and server-backed value edits) share one
+ * ordered history.
+ */
+export function useEditHistory(limit: number = DEFAULT_LIMIT): EditHistory {
+  const undoRef = useRef<EditCommand[]>([]);
+  const redoRef = useRef<EditCommand[]>([]);
+
+  const push = useCallback((command: EditCommand) => {
+    undoRef.current.push(command);
+    if (undoRef.current.length > limit) {
+      undoRef.current.shift();
+    }
+    // A fresh action invalidates the redo branch, matching every editor's
+    // behaviour (you cannot redo once you have diverged).
+    redoRef.current = [];
+  }, [limit]);
+
+  const undo = useCallback(() => {
+    const command = undoRef.current.pop();
+    if (!command) return false;
+    redoRef.current.push(command);
+    void command.undo();
+    return true;
+  }, []);
+
+  const redo = useCallback(() => {
+    const command = redoRef.current.pop();
+    if (!command) return false;
+    undoRef.current.push(command);
+    void command.redo();
+    return true;
+  }, []);
+
+  const clear = useCallback(() => {
+    undoRef.current = [];
+    redoRef.current = [];
+  }, []);
+
+  return useMemo(() => ({ push, undo, redo, clear }), [push, undo, redo, clear]);
+}

--- a/frontend/src/pages/Workspace/hooks/useWorkspaceSocket.ts
+++ b/frontend/src/pages/Workspace/hooks/useWorkspaceSocket.ts
@@ -24,6 +24,9 @@ type UseWorkspaceSocketOptions = {
     variant?: 'default' | 'destructive';
     duration?: number;
   }) => void;
+  // Called when a background operation is about to rewrite existing cell values
+  // (e.g. re-extraction), so the caller can drop now-stale undo history.
+  onExternalRewrite?: () => void;
 };
 
 // Owns WebSocket connection lifecycle, message routing, and disconnected polling.
@@ -35,6 +38,7 @@ export function useWorkspaceSocket({
   setActiveSheet,
   setReextraction,
   toast,
+  onExternalRewrite,
 }: UseWorkspaceSocketOptions) {
   const [wsConnected, setWsConnected] = useState(false);
   // A 'connected' message only means "catch up on what you missed" when it
@@ -90,6 +94,9 @@ export function useWorkspaceSocket({
           totalDocuments: payload.total_documents || 0,
         });
         setActiveSheet('data');
+        // A re-extraction overwrites existing cell values, so any recorded undo
+        // of a manual edit would now restore a value the model has replaced.
+        onExternalRewrite?.();
         void refresh({ silent: true });
         return;
       }
@@ -185,7 +192,7 @@ export function useWorkspaceSocket({
       webSocketService.disconnect();
       setWsConnected(false);
     };
-  }, [refresh, refreshSilent, sessionId, setActiveSheet, setReextraction, toast]);
+  }, [refresh, refreshSilent, sessionId, setActiveSheet, setReextraction, toast, onExternalRewrite]);
 
   return { wsConnected };
 }

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -59,8 +59,11 @@ import type {
 } from '@/types';
 import type { DocumentListResponse } from '@/types/unit';
 
+import { applyPatches, enablePatches, produceWithPatches } from 'immer';
+
 import { ChatPanel } from './chat/ChatPanel';
 import { emptyData, EMPTY_DATA_RECHECK_MS, SHEETS, cellFormatKey } from './constants';
+import { useEditHistory } from './hooks/useEditHistory';
 import {
   buildExportFilename,
   dataEquals,
@@ -91,6 +94,9 @@ import type {
 } from './types';
 
 import './Workspace.css';
+
+// immer's patch APIs are opt-in and must be enabled once before use (undo stack).
+enablePatches();
 
 type RefreshDataOptions = {
   silent?: boolean;
@@ -167,6 +173,9 @@ function Workspace() {
     return {};
   });
   const [formatVersion, setFormatVersion] = useState(0);
+  // Undo/redo stack for reversible edits (formatting + cell-value edits),
+  // following the Command pattern; each entry owns its inverse and forward.
+  const editHistory = useEditHistory();
   // Bumped only when authoritative server data is applied (applyData /
   // flushDeferredData), never on an optimistic cell edit. The By Unit view keys
   // its refetch off this instead of `data` so an optimistic edit, which mutates
@@ -482,6 +491,7 @@ function Workspace() {
     setActiveSheet,
     setReextraction,
     toast,
+    onExternalRewrite: editHistory.clear,
   });
 
   useEffect(() => {
@@ -525,13 +535,15 @@ function Workspace() {
     setSession(null);
     setDataView('by_document');
     setUnitData(emptyData);
+    // The undo stack belongs to the session we are leaving.
+    editHistory.clear();
     // Drop refresh bookkeeping tied to the session we are leaving, so a pending
     // re-check cannot apply the previous session's rows to the new one.
     dataRowCountRef.current = 0;
     unitDataRowCountRef.current = 0;
     deferredDataRef.current = null;
     clearEmptyRecheck();
-  }, [clearEmptyRecheck, sessionId]);
+  }, [clearEmptyRecheck, editHistory, sessionId]);
 
   useEffect(() => clearEmptyRecheck, [clearEmptyRecheck]);
 
@@ -713,24 +725,47 @@ function Workspace() {
       : liveSelection;
 
     if (!activeSelection || activeSelection.sheet !== activeSheet) {
+      // No cell selection: this toggles the sheet-wide display. Snapshot both
+      // sides so undo/redo restore them exactly.
+      const prevDisplay = tableDisplay;
       const nextDisplay = { ...tableDisplay, ...patch };
       updateTableDisplay(nextDisplay);
+      editHistory.push({
+        undo: () => updateTableDisplay(prevDisplay),
+        redo: () => updateTableDisplay(nextDisplay),
+      });
       return;
     }
 
-    setCellFormats((current) => {
-      const next = { ...current };
+    // Compute the next formats and immer's forward/inverse patches up front (in
+    // the event handler, not inside a setState updater, so there is no
+    // double-run in StrictMode). The patches target only the touched keys, so
+    // undo/redo in LIFO order restore exactly what this command changed.
+    const [nextFormats, forwardPatches, inversePatches] = produceWithPatches(cellFormats, (draft) => {
       for (let row = activeSelection.fromRow; row <= activeSelection.toRow; row += 1) {
         for (let col = activeSelection.fromCol; col <= activeSelection.toCol; col += 1) {
           const key = cellFormatKey(activeSheet, row, col);
-          next[key] = { ...next[key], ...patch };
+          draft[key] = { ...draft[key], ...patch };
         }
       }
-      localStorage.setItem('workspace.cellFormats', JSON.stringify(next));
-      return next;
     });
+    setCellFormats(nextFormats);
+    localStorage.setItem('workspace.cellFormats', JSON.stringify(nextFormats));
     setFormatVersion((current) => current + 1);
-  }, [activeSheet, sheetSelection, tableDisplay, updateTableDisplay]);
+
+    const applyFormatPatches = (patches: typeof forwardPatches) => {
+      setCellFormats((cur) => {
+        const nextValue = applyPatches(cur, patches);
+        localStorage.setItem('workspace.cellFormats', JSON.stringify(nextValue));
+        return nextValue;
+      });
+      setFormatVersion((current) => current + 1);
+    };
+    editHistory.push({
+      undo: () => applyFormatPatches(inversePatches),
+      redo: () => applyFormatPatches(forwardPatches),
+    });
+  }, [activeSheet, cellFormats, editHistory, sheetSelection, tableDisplay, updateTableDisplay]);
 
   const selectedDisplayOptions = useMemo(() => {
     if (!sheetSelection || sheetSelection.sheet !== activeSheet) return tableDisplay;
@@ -1018,6 +1053,9 @@ function Workspace() {
         onEditFollowUp={notifyEditFollowUp}
         onEditEnd={flushDeferredData}
         onToggleFormatShortcut={handleFormatShortcut}
+        onUndo={() => { editHistory.undo(); }}
+        onRedo={() => { editHistory.redo(); }}
+        onRecordEdit={editHistory.push}
         onNewProject={() => setProjectDialogOpen(true)}
         onImportProject={() => importInputRef.current?.click()}
         compactRows={compactRows}


### PR DESCRIPTION
## Summary
Workspace-wide undo/redo via the Command pattern: a headless useEditHistory stack whose entries each own their inverse and forward action, plus immer inverse/forward patches for client-only format state. Handsontable's native undo can't serve this (ignores programmatic/controlled-data changes; stack cleared on data reload), so it is disabled.

## Covers
- Formatting (bold/italic/underline, cell-level + sheet-wide): immer produceWithPatches.
- Cell-value edits: the edit pipeline is extracted into applyCellUpdates, shared by edits/undo/redo so they never drift. Multi-cell edit = one entry.
- Shortcuts via Handsontable ShortcutManager: Ctrl/Cmd+Z, Ctrl/Cmd+Y, Ctrl/Cmd+Shift+Z (grid context, so inert mid cell-edit).
- Stack clears on re-extraction start and session switch.

## Out of scope
Schema-sheet edits; keystroke grouping (each cell edit is already atomic).

## Adds dependency
immer ^11.

## Verify
- npm install then npx tsc --noEmit passes; no new eslint warnings.
- Format + edit a cell: Ctrl+Z reverses value then format; Ctrl+Y / Ctrl+Shift+Z reapplies. New action clears redo. Multi-cell clear is one step. Re-extraction/project switch clear the stack.