### PR TITLE
perf(cloud): cache the dataset listing instead of walking the bucket per page load

### DIFF
--- a/backend/app/api/routes/cloud_data.py
+++ b/backend/app/api/routes/cloud_data.py
@@ -1,10 +1,13 @@
 """Cloud data API endpoints for datasets, templates, and initial schemas."""
 
-from typing import List, Optional, Any, Dict
+import asyncio
+import time
+from typing import List, Optional, Any, Dict, Tuple
 from fastapi import APIRouter, HTTPException, UploadFile, File
 from pydantic import BaseModel
 
 from app.storage import get_storage
+from app.storage.interface import DatasetInfo
 
 router = APIRouter(prefix="/cloud", tags=["cloud-data"])
 
@@ -43,6 +46,57 @@ class TemplateResponse(BaseModel):
 # Dataset Endpoints
 # ==================
 
+# Every workspace page load calls GET /api/cloud/datasets to populate the
+# "Cloud dataset" picker, and the Supabase backend answers it by walking the
+# whole bucket: one list call for the root plus one per dataset folder. In
+# production that is nine round-trips and several thousand listed objects per
+# page load, for a dropdown most visits never open.
+#
+# Datasets are curated collections that change rarely, so a short shared cache
+# collapses that to one walk per window. A single in-flight future also stops
+# concurrent visitors from each starting their own walk.
+_DATASETS_CACHE_TTL_SECONDS = 300
+_datasets_cache: Optional[Tuple[float, List[DatasetInfo]]] = None
+_datasets_inflight: Optional[asyncio.Future] = None
+_datasets_lock = asyncio.Lock()
+
+
+async def _get_datasets_cached() -> List[DatasetInfo]:
+    global _datasets_cache, _datasets_inflight
+
+    now = time.monotonic()
+    cached = _datasets_cache
+    if cached and now - cached[0] < _DATASETS_CACHE_TTL_SECONDS:
+        return cached[1]
+
+    async with _datasets_lock:
+        # Re-check: another caller may have refreshed while we waited.
+        cached = _datasets_cache
+        if cached and time.monotonic() - cached[0] < _DATASETS_CACHE_TTL_SECONDS:
+            return cached[1]
+        if _datasets_inflight is not None:
+            inflight = _datasets_inflight
+        else:
+            inflight = asyncio.ensure_future(get_storage().list_datasets())
+            _datasets_inflight = inflight
+
+    try:
+        datasets = await inflight
+    finally:
+        async with _datasets_lock:
+            if _datasets_inflight is inflight:
+                _datasets_inflight = None
+
+    _datasets_cache = (time.monotonic(), datasets)
+    return datasets
+
+
+def invalidate_datasets_cache() -> None:
+    """Drop the cached dataset listing, e.g. after a dataset is uploaded."""
+    global _datasets_cache
+    _datasets_cache = None
+
+
 @router.get("/datasets", response_model=List[DatasetResponse])
 async def list_datasets():
     """List available datasets (document collections).
@@ -53,8 +107,7 @@ async def list_datasets():
     Returns:
         List of dataset information including name, path, and file count.
     """
-    storage = get_storage()
-    datasets = await storage.list_datasets()
+    datasets = await _get_datasets_cached()
 
     return [
         DatasetResponse(


### PR DESCRIPTION
## Problem

Every workspace page load calls `GET /api/cloud/datasets` to populate the Cloud dataset picker, and the Supabase backend answers by walking the whole bucket: one list call for the root plus one per dataset folder. Production logs show the full sequence repeating on every visit:

```
Fetching datasets from Supabase 'datasets' bucket...
POST .../object/list/datasets        <- root
POST .../object/list/datasets  x8    <- one per dataset, to count files
Dataset 'full_text_constitutions' has 622 files
...
```

Nine round-trips and roughly 1,478 listed objects per page load, for a dropdown most visits never open. The same block appears three times in one minute of logs.

## Solution

A shared 5-minute cache in front of `storage.list_datasets()`, plus a single in-flight future so concurrent visitors do not each start their own walk. Adds `invalidate_datasets_cache()` for callers that add a dataset.

A TTL is appropriate here in a way it was not for `/api/config`: datasets are curated collections that change rarely, and nothing in the response is live server state.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `python -m py_compile`: clean.
- Cache semantics checked in isolation against a stub storage: five concurrent callers produce one walk and identical results; a repeat within the TTL produces no further walk; `invalidate_datasets_cache()` forces the next call to walk again.
- In production: load a workspace twice within five minutes and confirm the `Fetching datasets` block appears once rather than twice.

## Follow-ups not in this PR

- `supabase_backend.py` logs `Raw items: {items}` at INFO on every listing, which is what floods the log with the full bucket contents.
- `icon.png` is served at 3.8 MB on every page load, larger than the entire JS bundle.
- Log lines are tagged `[no-session]` even when a session id is in scope, which made today's session-loss investigation harder than it needed to be.