### PR TITLE
fix(workspace): show a missing project as not found instead of importing forever

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -69,6 +69,7 @@ export function SpreadsheetSurface({
   onRecordEdit,
   onNewProject,
   onImportProject,
+  sessionMissing,
   compactRows,
   layoutRevision,
   dataView,
@@ -125,6 +126,8 @@ export function SpreadsheetSurface({
   // height so rows do not drift while scrolling horizontally, but it sizes each
   // row to its tallest cell across all columns, which on wide schemas left ~5
   // of 194 rows on screen. Uniform heights avoid the drift the same way.
+  // Session id is present in the URL but the backend cannot resolve it.
+  sessionMissing?: boolean;
   compactRows?: boolean;
   layoutRevision: string;
   // Current Data-sheet grouping. Drives the visual cell-merge of the leftmost
@@ -1456,11 +1459,13 @@ export function SpreadsheetSurface({
     };
   }, [activeSheet, customColumnMenuItems]);
 
-  if (!sessionId) {
+  if (!sessionId || sessionMissing) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-4 p-6 text-center">
         <p className="text-sm text-muted-foreground">
-          Start or open a project to populate the workbook.
+          {sessionMissing
+            ? 'This project could not be found. It may have been removed, or the link may be out of date.'
+            : 'Start or open a project to populate the workbook.'}
         </p>
         {(onNewProject || onImportProject) && (
           <div className="flex flex-wrap items-center justify-center gap-2">

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -385,6 +385,12 @@ function Workspace() {
     try {
       if (sessionMode === 'load') {
         const loadSession = await loadAPI.getSession(sessionId).catch(() => null);
+        if (!loadSession) {
+          setSessionMissing(true);
+          if (!silent) setLoading(false);
+          return;
+        }
+        setSessionMissing(false);
         setStatus(statusFromLoadSession(loadSession));
         setSchema(schemaFromLoadSession(loadSession));
         setSession(loadSession);
@@ -404,6 +410,7 @@ function Workspace() {
           schematiqAPI.getConfig(sessionId).catch(() => null),
           loadAPI.getSession(sessionId).catch(() => null),
         ]);
+        setSessionMissing(false);
         setStatus(nextStatus);
         setSchema(nextSchema);
         setSession(statsSession);
@@ -415,7 +422,13 @@ function Workspace() {
         );
       } catch (err) {
         const loadSession = await loadAPI.getSession(sessionId).catch(() => null);
-        if (!loadSession) throw err;
+        if (!loadSession) {
+          // Neither mode can resolve it: the session is gone, not mid-import.
+          setSessionMissing(true);
+          if (!silent) setLoading(false);
+          return;
+        }
+        setSessionMissing(false);
         setSessionMode('load');
         setStatus(statusFromLoadSession(loadSession));
         setSchema(schemaFromLoadSession(loadSession));
@@ -855,6 +868,11 @@ function Workspace() {
   // revert is written back rather than only shown.
   // Reached through getPlugin rather than hot.undo(): the convenience methods
   // are attached at runtime by the plugin and are not on the Handsontable type.
+  // The backend 404s for a session it cannot resolve. Every fetch here swallows
+  // that with .catch(() => null), so the workspace fell back to its
+  // still-working state and showed "Importing…" forever, with no error anywhere
+  // on screen -- the worst possible reading of "this project is gone".
+  const [sessionMissing, setSessionMissing] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [compactRows, setCompactRows] = useState<boolean>(() => {
     try { return localStorage.getItem('workspace.compactRows') === '1'; } catch { return false; }
@@ -930,6 +948,7 @@ function Workspace() {
     const isDone = rawStatus === 'completed' || rawStatus === 'schema_extracted' || rawStatus === 'stopped';
     const isFailed = rawStatus === 'error' || rawStatus === 'failed';
 
+    if (sessionMissing) return 'Project not found';
     if (isFailed) return 'Extraction failed';
 
     // Still working: surface a live, human label instead of the raw status key.
@@ -1056,6 +1075,7 @@ function Workspace() {
         onRecordEdit={editHistory.push}
         onNewProject={() => setProjectDialogOpen(true)}
         onImportProject={() => importInputRef.current?.click()}
+        sessionMissing={sessionMissing}
         compactRows={compactRows}
         layoutRevision={gridLayoutRevision}
         dataView={dataView}


### PR DESCRIPTION
## Problem
Opening a workspace URL the backend cannot resolve shows "Importing…" indefinitely. Measured on production against a session that 404s:
```

title   : ScheMatiQ 959f3e3f | Importing…

rows    : 0

toast   : (none)

4xx     : 404 x5 — load/sessions, reference, units/documents, chat/tools, load/data

```
The words "not found" never appear anywhere on the page. The user waits for an import that will never happen.
Cause: the load-mode branch of `refresh()` does `loadAPI.getSession(sessionId).catch(() => null)`, which swallows the 404. `statusFromLoadSession(null)` yields a not-done status, so `statusLabel` falls through to `'Importing…'`. The schematiq branch has the same shape — `if (!loadSession) throw err` lands in a `finally` that only clears the loading flag.
## Solution
A `sessionMissing` state, set when neither mode can resolve the session and cleared on every successful load. It changes three things: the status label reads "Project not found"; the sheet area shows an explanation plus the New project / Import project buttons already wired into the empty state; and `loadHeavy` is no longer fired for a session that does not exist.
This is presentation only — it does not address why sessions stop resolving, which is a separate backend question.
## Verify
- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.

- Manually: open /workspace/<a-random-uuid>?mode=load and confirm "Project not found" plus a usable way out, rather than "Importing…". Open a real project and confirm nothing changed.