### PR TITLE
fix(logging): tag request logs with their session and drop the bucket dump from INFO

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,7 +18,7 @@ if _SCHEMATIQ_LIB_PATH.exists() and str(_SCHEMATIQ_LIB_PATH) not in sys.path:
 # Set LOG_LEVEL=DEBUG to see detailed schema column tracking
 # Format includes [session_id] for Railway log filtering per session
 from app.core.config import LOG_LEVEL
-from app.core.logging_utils import SessionFilter
+from app.core.logging_utils import SessionFilter, set_session_context
 
 log_level = LOG_LEVEL.upper()
 logging.basicConfig(
@@ -34,7 +34,9 @@ for _handler in logging.root.handlers:
 # Suppress noisy uvicorn access logs (frontend polling every ~3s floods Railway logs)
 logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
 
-from fastapi import FastAPI
+import re
+
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.routes.load import router as load_router
@@ -102,6 +104,24 @@ app = FastAPI(
         }
     ]
 )
+
+# Tag every log line emitted while handling a request with the session it
+# concerns. set_session_context was previously called by hand at about a dozen
+# sites, none of them on the load/data read paths -- so an investigation into a
+# session that would not open had to read a log where every relevant line said
+# [no-session], including the Supabase calls that failed.
+_SESSION_ID_IN_PATH = re.compile(
+    r"/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+)
+
+
+@app.middleware("http")
+async def tag_logs_with_session(request: Request, call_next):
+    match = _SESSION_ID_IN_PATH.search(request.url.path)
+    if match:
+        set_session_context(match.group(1))
+    return await call_next(request)
+
 
 # CORS middleware for frontend communication
 app.add_middleware(

--- a/backend/app/storage/supabase_backend.py
+++ b/backend/app/storage/supabase_backend.py
@@ -467,8 +467,9 @@ class SupabaseStorageBackend(StorageInterface):
             logger.info("Fetching datasets from Supabase 'datasets' bucket...")
             # List top-level folders in datasets bucket with pagination
             items = self._list_all_storage_items("datasets")
-            logger.info(f"Supabase returned {len(items)} items from datasets bucket")
-            logger.info(f"Raw items: {items}")
+            logger.debug(f"Supabase returned {len(items)} items from datasets bucket")
+            # Whole-bucket dump; useful when debugging a listing, far too noisy at INFO.
+            logger.debug(f"Raw items: {items}")
 
             datasets = []
             for item in items:
@@ -476,12 +477,12 @@ class SupabaseStorageBackend(StorageInterface):
                 # Check if it's a folder (no id means folder)
                 if not item.get("id"):
                     dataset_name = item["name"]
-                    logger.info(f"Found folder (dataset): {dataset_name}")
+                    logger.debug(f"Found folder (dataset): {dataset_name}")
                     # Count files in the dataset folder with pagination
                     try:
                         files = self._list_all_storage_items("datasets", dataset_name)
                         file_count = sum(1 for f in files if f.get("id"))
-                        logger.info(f"Dataset '{dataset_name}' has {file_count} files")
+                        logger.debug(f"Dataset '{dataset_name}' has {file_count} files")
                     except Exception as e:
                         logger.warning(f"Error counting files in dataset '{dataset_name}': {e}")
                         file_count = 0


### PR DESCRIPTION
## Problem

**Session context is missing where it matters.** `set_session_context` is called by hand at about a dozen sites, none of them on the load/data read paths. Investigating a session that would not open meant reading a log where every relevant line said `[no-session]`, including the Supabase calls that failed:

```
INFO:httpx:[no-session] GET .../07b6d8cd-.../data.jsonl "HTTP/2 400 Bad Request"
```

The session id was right there in the request path and never reached the log.

**The bucket listing is dumped at INFO.** `list_datasets` logs `Raw items: {items}` — the full raw listing — plus a line per dataset, on every call. Three copies of that block appeared in one minute of production logs.

## Solution

An HTTP middleware that extracts a UUID from the request path and sets the logging context for the whole request, so every line emitted while serving it is tagged. One place instead of scattered calls.

Four lines in `supabase_backend.py` move from INFO to DEBUG, including the raw dump. This complements the dataset caching merged in #391: that reduces how often the listing runs, this reduces what it prints when it does.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `python -m py_compile`: clean.
- Path matcher checked against real paths: `/api/load/data/<uuid>` and `/ws/progress/<uuid>` resolve to the session; `/api/cloud/datasets` and `/api/config` correctly stay `no-session`.
- Not run against a live server. Middleware ordering is the main risk — this registers ahead of CORS, which is the correct order in FastAPI. Worth checking the first log after deploy shows session tags on data requests.