### PR TITLE
fix(data): distinguish a missing data file from an empty result

### DIFF
--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -239,6 +239,11 @@ class PaginatedData(BaseModel):
     page: int
     page_size: int
     has_more: bool
+    # True when no data file could be resolved for the session at all, as
+    # opposed to a file that exists and yielded no rows. Those two were
+    # indistinguishable to callers, so a session whose data was lost rendered
+    # as an ordinary empty table.
+    data_missing: bool = False
 
 
 # Filter/Sort request models for server-side filtering

--- a/backend/app/services/pipeline/data_query.py
+++ b/backend/app/services/pipeline/data_query.py
@@ -304,7 +304,19 @@ async def get_data(
     )
 
     if not data_files:
-        return PaginatedData(rows=[], total_count=0, filtered_count=None, page=page, page_size=page_size, has_more=False)
+        # Nothing resolved from the work dir, the data dir, or storage. For a
+        # session still extracting this is normal; for a completed one the data
+        # is gone, and returning a plain empty page made the two identical to
+        # every caller. Flag it, and say so in the log.
+        logger.warning(
+            "No data file resolved for session %s; returning an empty page with data_missing set",
+            session_id,
+        )
+        return PaginatedData(
+            rows=[], total_count=0, filtered_count=None,
+            page=page, page_size=page_size, has_more=False,
+            data_missing=True,
+        )
 
     from app.services.data_utils import row_dedup_key
 

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -70,6 +70,7 @@ export function SpreadsheetSurface({
   onNewProject,
   onImportProject,
   sessionMissing,
+  dataMissing,
   compactRows,
   layoutRevision,
   dataView,
@@ -128,6 +129,8 @@ export function SpreadsheetSurface({
   // of 194 rows on screen. Uniform heights avoid the drift the same way.
   // Session id is present in the URL but the backend cannot resolve it.
   sessionMissing?: boolean;
+  // Session resolves, but its extracted data file does not exist in storage.
+  dataMissing?: boolean;
   compactRows?: boolean;
   layoutRevision: string;
   // Current Data-sheet grouping. Drives the visual cell-merge of the leftmost
@@ -1459,13 +1462,15 @@ export function SpreadsheetSurface({
     };
   }, [activeSheet, customColumnMenuItems]);
 
-  if (!sessionId || sessionMissing) {
+  if (!sessionId || sessionMissing || dataMissing) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-4 p-6 text-center">
         <p className="text-sm text-muted-foreground">
           {sessionMissing
             ? 'This project could not be found. It may have been removed, or the link may be out of date.'
-            : 'Start or open a project to populate the workbook.'}
+            : dataMissing
+              ? 'This project exists but its extracted data is no longer in storage. The schema is intact, so re-running extraction will rebuild the table.'
+              : 'Start or open a project to populate the workbook.'}
         </p>
         {(onNewProject || onImportProject) && (
           <div className="flex flex-wrap items-center justify-center gap-2">

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -940,6 +940,13 @@ function Workspace() {
   const progressPercent = Math.round((status?.progress || 0) * 100);
   const topbarQuestion = schema?.query || config?.query || '';
   const projectTitle = topbarQuestion || (sessionId ? `ScheMatiQ ${sessionId.slice(0, 8)}` : 'Untitled workspace');
+  // Extraction has stopped moving, either successfully or not. Used to decide
+  // whether an empty data payload means "nothing yet" or "nothing left".
+  const extractionSettled = useMemo(() => {
+    const rawStatus = status?.status || '';
+    return ['completed', 'schema_extracted', 'stopped', 'error', 'failed'].includes(rawStatus);
+  }, [status?.status]);
+
   const chromeStatus = useMemo(() => {
     if (!sessionId) return 'No project open';
     if (loading) return 'Loading…';
@@ -1076,6 +1083,7 @@ function Workspace() {
         onNewProject={() => setProjectDialogOpen(true)}
         onImportProject={() => importInputRef.current?.click()}
         sessionMissing={sessionMissing}
+        dataMissing={Boolean(data?.data_missing) && extractionSettled}
         compactRows={compactRows}
         layoutRevision={gridLayoutRevision}
         dataView={dataView}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -183,6 +183,9 @@ export interface PaginatedData {
   page: number;
   page_size: number;
   has_more: boolean;
+  // Set by the backend when no data file could be resolved for the session,
+  // as opposed to a file that exists and yielded no rows.
+  data_missing?: boolean;
 }
 
 export interface FileValidationResult {


### PR DESCRIPTION
## Problem

A session whose extracted data has been lost renders as an ordinary empty table: schema and headers present, no rows, no explanation. Confirmed on a production session — the folder for it does not exist in the `data` bucket at all, and the backend logs two failed lookups before giving up:

```
GET .../object/data/<session>/extracted_data.jsonl -> 400
GET .../object/data/<session>/data.jsonl          -> 400
```

`data_query.get_data` then returns:

```python
if not data_files:
    return PaginatedData(rows=[], total_count=0, ...)
```

"No data file exists" and "the file exists and has no rows" produce byte-identical responses, with nothing logged. Callers cannot tell them apart, which is why this took a long investigation to identify rather than being obvious from the response.

## Solution

- `PaginatedData.data_missing: bool = False` — defaults false, so existing consumers are unaffected.
- A `logger.warning` naming the session when no data file resolves.
- The workspace shows a real message instead of an empty grid: the project exists, its data is gone from storage, and the schema is intact so re-running extraction will rebuild the table.

Gated on `extractionSettled` (completed / schema_extracted / stopped / error / failed). A session still extracting legitimately has no data file yet and must not be told its data is lost. This required hoisting the settled check out of the `chromeStatus` useMemo, where `isDone`/`isFailed` were local — tsc caught that.

This makes the failure legible; it does not address why the data went missing, which is still open.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `py_compile` and `tsc --noEmit`: clean.
- Manually: open a session whose data folder is absent and confirm the explanation instead of an empty table, and that the log carries a warning naming the session. Open a healthy project and a mid-extraction one and confirm neither changes.