### PR TITLE
feat(chat): consume streamed chat messages over the WebSocket

### DIFF
--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -10,7 +10,14 @@ import { ModelSelector } from '@/components/ModelSelector';
 import { getDefaultModelForProvider } from '@/constants';
 import { chatAPI, referenceAPI, type ReferenceDocumentInfo } from '@/services/api';
 import webSocketService from '@/services/websocket';
-import type { ChatToolInfo, PaginatedData, SchemaData, ScheMatiQStatus, WebSocketMessage } from '@/types';
+import type {
+  ChatToolInfo,
+  ChatTurnMessage,
+  PaginatedData,
+  SchemaData,
+  ScheMatiQStatus,
+  WebSocketMessage,
+} from '@/types';
 
 import {
   CHAT_MUTATION_TOOLS,
@@ -217,8 +224,21 @@ export function ChatPanel({
     [sessionId, references],
   );
 
+  // Ids are the deduplication key. Assistant and tool messages now arrive over
+  // two channels -- live over the WebSocket as the agent produces them, and
+  // again in the HTTP response at the end of the turn -- so whichever lands
+  // first wins and the other copy is dropped. The HTTP response stays the source
+  // of truth: if the socket is down, nothing is lost.
   const appendMessages = useCallback((next: WorkspaceMessage[]) => {
-    setMessages((current) => [...current, ...next]);
+    setMessages((current) => {
+      const seen = new Set(current.map((message) => message.id));
+      const fresh = next.filter((message) => {
+        if (seen.has(message.id)) return false;
+        seen.add(message.id);
+        return true;
+      });
+      return fresh.length ? [...current, ...fresh] : current;
+    });
   }, []);
 
   // A column fill runs in the background after the chat turn ends, streaming cells
@@ -227,7 +247,12 @@ export function ChatPanel({
   useEffect(() => {
     if (!sessionId) return undefined;
     const handler = (message: WebSocketMessage) => {
-      if (message.type === 'reference_fill_started') {
+      if (message.type === 'chat_message' && message.data) {
+        // Emitted by agent_service as each assistant/tool message is produced,
+        // so the panel fills in while the turn is still running instead of
+        // staying empty until the HTTP response returns.
+        appendMessages([mapChatTurnMessage(message.data as unknown as ChatTurnMessage)]);
+      } else if (message.type === 'reference_fill_started') {
         const data = (message.data ?? {}) as unknown as { column?: string };
         setFillRunning({ column: data.column ?? '' });
       } else if (message.type === 'reference_fill_completed') {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -358,7 +358,7 @@ export interface ObservationUnitReadyData {
 }
 
 export interface WebSocketMessage {
-  type: 'progress' | 'log' | 'error' | 'completed' | 'connected' | 'disconnected' | 'reconnecting' | 'pong' | 'heartbeat' | 'schema_completed' | 'schema_progress' | 'row_completed' | 'schema_updated' | 'reprocessing_progress' | 'reprocessing_completed' | 'reextraction_started' | 'reextraction_progress' | 'reextraction_completed' | 'reextraction_failed' | 'reextraction_stopped' | 'document_started' | 'cell_extracted' | 'stopped' | 'continue_discovery_progress' | 'continue_discovery_completed' | 'continue_discovery_stopped' | 'incremental_extraction_progress' | 'quota_exceeded' | 'observation_unit_ready' | 'observation_unit_definition_updated' | 'reference_fill_started' | 'reference_fill_completed';
+  type: 'progress' | 'log' | 'error' | 'completed' | 'connected' | 'disconnected' | 'reconnecting' | 'pong' | 'heartbeat' | 'schema_completed' | 'schema_progress' | 'row_completed' | 'schema_updated' | 'reprocessing_progress' | 'reprocessing_completed' | 'reextraction_started' | 'reextraction_progress' | 'reextraction_completed' | 'reextraction_failed' | 'reextraction_stopped' | 'document_started' | 'cell_extracted' | 'stopped' | 'continue_discovery_progress' | 'continue_discovery_completed' | 'continue_discovery_stopped' | 'incremental_extraction_progress' | 'quota_exceeded' | 'observation_unit_ready' | 'observation_unit_definition_updated' | 'reference_fill_started' | 'reference_fill_completed' | 'chat_message';
   timestamp?: string;
   session_id?: string;
   message?: string;


### PR DESCRIPTION
## Problem

#330 made `agent_service` broadcast each assistant and tool message over the session WebSocket as it is produced:

```python
# agent_service.py:456
await websocket_manager.broadcast_to_session(
    state.workspace_session_id,
    {"type": "chat_message", "data": message},
)
```

Nothing consumed it. `useWorkspaceSocket` handles twenty message types and `chat_message` is not among them, so the panel still stayed empty until the HTTP response returned at the end of the turn. The feature was half-built: the server streamed, no one listened.

The backend docstring also already claimed "The frontend dedupes by message id, so a message delivered over both channels appears once" — which was not true, and was a trap for whoever built this side.

## Solution

- `ChatPanel` handles `chat_message` in the socket effect that already exists for `reference_fill_*`, so there is no new subscription or lifecycle change.
- `appendMessages` now drops messages whose id is already present. Both channels carry the same messages, so whichever arrives first wins and the duplicate is discarded. The HTTP response remains the source of truth: with the socket down, nothing is lost.
- `'chat_message'` added to the `WebSocketMessage.type` union. tsc caught the omission (`TS2367: no overlap`), which is what that union is for.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.
- Dedup semantics checked in isolation: WS-first then HTTP yields `greet,a1,t1,a2` with no repeats; HTTP-only (socket down) yields every message; an append with nothing new returns the same array reference, so no needless re-render; duplicate ids within one batch collapse.
- Manually: send a message that triggers a tool and confirm the tool messages appear while the agent is still working rather than all at once at the end, then confirm no duplicates once the response lands.

## Follow-up

Token-level streaming (`send_message_stream` in the agent loop) is now unblocked — it was waiting on a consumer existing at all.