### PR TITLE
fix(classic): give cell undo the same row identifiers as the edit

### DIFF
--- a/frontend/src/components/DataTable/DataTable.tsx
+++ b/frontend/src/components/DataTable/DataTable.tsx
@@ -417,7 +417,9 @@ const DataTable: React.FC<DataTableProps> = ({
   );
 
   // Cell edit handler
-  const handleCellUpdate = useCallback(async (rowName: string, column: string, value: string, sourceDocument?: string) => {
+  // rowIndex is threaded through so the undo below identifies the row the same
+  // way the edit did; identifying it more weakly can revert a different row.
+  const handleCellUpdate = useCallback(async (rowName: string, column: string, value: string, sourceDocument?: string, rowIndex?: number) => {
     try {
       const result = await schematiqAPI.updateCell(sessionId, rowName, column, value, sourceDocument);
       const previousValue = result.previous_value;
@@ -430,7 +432,7 @@ const DataTable: React.FC<DataTableProps> = ({
         action: (
           <ToastAction altText="Undo" onClick={async () => {
             try {
-              await schematiqAPI.restoreCell(sessionId, rowName, column, previousValue, sourceDocument);
+              await schematiqAPI.restoreCell(sessionId, rowName, column, previousValue, sourceDocument, rowIndex);
               refetchData();
             } catch {
               toast({ title: 'Undo failed', description: 'Could not revert the cell edit.', variant: 'destructive' });
@@ -896,6 +898,7 @@ const DataTable: React.FC<DataTableProps> = ({
       rowName: row?.row_name || row?._unit_name,
       column: columnName,
       sourceDocument: row?._source_document,
+      rowIndex: row?._row_index,
     });
     setModalOpen(true);
   };
@@ -1483,7 +1486,7 @@ const DataTable: React.FC<DataTableProps> = ({
                                 value={getFrozenCellValue()}
                                 rowName={row.row_name}
                                 column={frozenColumn}
-                                onSave={(rn, col, val) => handleCellUpdate(rn, col, val, row._source_document)}
+                                onSave={(rn, col, val) => handleCellUpdate(rn, col, val, row._source_document, row._row_index)}
                               >
                                 {formatCellValue(getFrozenCellValue(), frozenColumn, row)}
                               </EditableCell>
@@ -1575,7 +1578,7 @@ const DataTable: React.FC<DataTableProps> = ({
                                 value={cellValue}
                                 rowName={row.row_name || ''}
                                 column={column}
-                                onSave={(rn, col, val) => handleCellUpdate(rn, col, val, row._source_document)}
+                                onSave={(rn, col, val) => handleCellUpdate(rn, col, val, row._source_document, row._row_index)}
                               >
                                 {formatCellValue(cellValue, column, row)}
                               </EditableCell>
@@ -1661,7 +1664,7 @@ const DataTable: React.FC<DataTableProps> = ({
         })()}
         onSave={!readonly && modalContent.rowName && modalContent.column
           ? async (value: string) => {
-              await handleCellUpdate(modalContent.rowName!, modalContent.column!, value, modalContent.sourceDocument);
+              await handleCellUpdate(modalContent.rowName!, modalContent.column!, value, modalContent.sourceDocument, modalContent.rowIndex);
             }
           : undefined
         }

--- a/frontend/src/components/DataTable/UnitGroupedTable.tsx
+++ b/frontend/src/components/DataTable/UnitGroupedTable.tsx
@@ -396,11 +396,14 @@ export const UnitGroupedTable: React.FC<UnitGroupedTableProps> = ({
       rowName: row?.row_name || row?._unit_name,
       column: columnName,
       sourceDocument: row?._source_document,
+      rowIndex: row?._row_index,
     });
     setModalOpen(true);
   }, []);
 
-  const handleCellUpdate = useCallback(async (rowName: string, column: string, value: string, sourceDocument?: string) => {
+  // rowIndex is threaded through so the undo below identifies the row the same
+  // way the edit did; identifying it more weakly can revert a different row.
+  const handleCellUpdate = useCallback(async (rowName: string, column: string, value: string, sourceDocument?: string, rowIndex?: number) => {
     try {
       const result = await schematiqAPI.updateCell(sessionId, rowName, column, value, sourceDocument);
       const previousValue = result.previous_value;
@@ -413,7 +416,7 @@ export const UnitGroupedTable: React.FC<UnitGroupedTableProps> = ({
         action: (
           <ToastAction altText="Undo" onClick={async () => {
             try {
-              await schematiqAPI.restoreCell(sessionId, rowName, column, previousValue, sourceDocument);
+              await schematiqAPI.restoreCell(sessionId, rowName, column, previousValue, sourceDocument, rowIndex);
               refetchData();
             } catch {
               toast({ title: 'Undo failed', description: 'Could not revert the cell edit.', variant: 'destructive' });
@@ -1144,7 +1147,7 @@ export const UnitGroupedTable: React.FC<UnitGroupedTableProps> = ({
         })()}
         onSave={modalContent.rowName && modalContent.column
           ? async (value: string) => {
-              await handleCellUpdate(modalContent.rowName!, modalContent.column!, value, modalContent.sourceDocument);
+              await handleCellUpdate(modalContent.rowName!, modalContent.column!, value, modalContent.sourceDocument, modalContent.rowIndex);
             }
           : undefined
         }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -424,16 +424,26 @@ export const schematiqAPI = {
     return response.data;
   },
 
-  /** Restore a cell to its previous full value (undo). */
+  /**
+   * Restore a cell to its previous full value (undo).
+   *
+   * Takes the same identifiers as updateCell, rowIndex included. The two must
+   * stay in step: the backend resolves the target row from whatever it is given,
+   * so an undo that omits an identifier the original edit supplied can resolve
+   * to a different row. That is worse than a failed write, because it silently
+   * reverts a cell the user never touched.
+   */
   restoreCell: async (
     sessionId: string,
     rowName: string,
     column: string,
     previousValue: any,
-    sourceDocument?: string
+    sourceDocument?: string,
+    rowIndex?: number
   ): Promise<{ status: string }> => {
-    const params: Record<string, string> = { row_name: rowName, column, value: '' };
+    const params: Record<string, string | number> = { row_name: rowName, column, value: '' };
     if (sourceDocument) params.source_document = sourceDocument;
+    if (rowIndex != null) params.row_index = rowIndex;
     const response = await api.put(`/schematiq/cell/${sessionId}`, { restore: previousValue }, { params });
     return response.data;
   },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -443,6 +443,9 @@ export interface ModalContent {
   rowName?: string;
   column?: string;
   sourceDocument?: string;
+  // Absolute row position from the paginated data. Carried so an edit made
+  // from the modal can be undone against the same row it was applied to.
+  rowIndex?: number;
 }
 
 export interface ApiError {


### PR DESCRIPTION
## Problem

Two functions in `services/api.ts` are meant to target the same row, and they identify it differently:

```ts
updateCell:  if (rowIndex != null) params.row_index = rowIndex;   // three identifiers
restoreCell: // nothing                                           // two identifiers
```

The backend accepts `row_index` on both paths (`schematiq.py:517`); the frontend simply never supplied it for undo.

An undo that identifies the row more weakly than the edit did can resolve to a different row, silently reverting a cell the user never touched. That is worse than a failed write, and it is invisible.

Scope is the classic flow only — `restoreCell` is called from `DataTable.tsx` and `UnitGroupedTable.tsx`. The Workspace builds `inverseUpdates` that go through `updateCell`, which does send the index, so its undo was already correct. But the classic flow is the one with toast-based undo, where a mis-targeted revert is least likely to be noticed.

## Solution

`rowIndex` is threaded from the row through to the undo call:

- `ModalContent.rowIndex?: number`
- `restoreCell` accepts and forwards it, matching `updateCell`
- `handleCellUpdate` in both tables takes it and passes it on; `setModalContent` populates it from `row?._row_index`; all three `onSave` sites pass `row._row_index`

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.
- `DataTable.tsx` is CRLF and was edited at byte level; after `git apply` on a clean clone it is 1811 CRLF lines with zero bare LF lines. The other three files are LF and stayed LF.
- Manually: in /classic, edit a cell on a row whose name is shared with other rows, hit Undo in the toast, and confirm the value reverts on that row. Check the network tab shows `row_index` on the undo PUT.