### PR TITLE
chore(workspace): temporary opt-in log for cell-edit row identity

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -992,6 +992,43 @@ export function SpreadsheetSurface({
         const rowName = sourceRow?.row_name || sourceRow?._unit_name || '';
         const rowIndexId = sourceRow?._row_index;
         const sourceDocument = sourceRow?._source_document || sourceRow?._parent_document;
+
+        // TEMPORARY DIAGNOSTIC -- remove once the missing row_index is explained.
+        //
+        // A PUT captured from a real edit carried row_name and source_document
+        // but no row_index, even though the payload contains _row_index and the
+        // alignment memos only reorder rows. That means sourceRow._row_index was
+        // undefined for that edit and we do not know why. Opt in per browser:
+        //   localStorage.setItem('schematiq.debugCellEdit', '1')
+        // then edit a cell and read the console. Off for everyone else.
+        if (localStorage.getItem('schematiq.debugCellEdit') === '1') {
+          const physicalRow = toPhysicalRow(visualRowIndex);
+          // eslint-disable-next-line no-console
+          console.log('[cell-edit-identity]', {
+            dataView,
+            column: key,
+            visualRowIndex,
+            physicalRow,
+            rowsLength: data.rows.length,
+            hasToPhysicalRow: typeof hot?.toPhysicalRow === 'function',
+            sourceRowFound: Boolean(sourceRow),
+            // The three values actually sent to the backend.
+            sent: { rowName, sourceDocument, rowIndexId },
+            // Present but undefined vs absent entirely are different bugs.
+            rowIndexKeyPresent: sourceRow ? '_row_index' in sourceRow : null,
+            sourceRowUnderscoreKeys: sourceRow
+              ? Object.keys(sourceRow).filter((k) => k.startsWith('_'))
+              : null,
+            // A sort or filter makes visual != physical; worth knowing which.
+            sortConfig: hot?.getPlugin('columnSorting')?.getSortConfig?.() ?? null,
+            filtersActive: Boolean(hot?.getPlugin('filters')?.isEnabled?.()),
+            // The neighbouring rows, to see whether the index is missing on this
+            // row alone or across the payload.
+            neighbourRowIndexes: data.rows
+              .slice(Math.max(0, physicalRow - 2), physicalRow + 3)
+              .map((r) => r?._row_index),
+          });
+        }
         if (!rowName && rowIndexId == null) {
           unidentified += 1;
           continue;


### PR DESCRIPTION
## Problem

A PUT captured from a real cell edit carried `row_name` and `source_document` but no `row_index`, even though the data payload contains `_row_index`, `updateCell` sends it whenever it is defined, and the alignment memos in index.tsx only reorder rows without dropping fields. So `sourceRow._row_index` was undefined for that edit, and we do not know why.

Not currently harmful — `row_name` + `source_document` is unique in the datasets we checked, and that pair was proven to target the right row out of five sharing a name. But it is an identifier silently going missing, and the backend falls back to first-match when it does.

## Solution

A diagnostic log at the identity site in `handleChanges`, gated on a per-browser flag so it is silent for everyone else:

```js
localStorage.setItem('schematiq.debugCellEdit', '1')
```

It reports the view, the visual and physical row indices, whether `_row_index` is present as a key versus present-but-undefined, the underscore keys actually on the row, the neighbouring rows' indices, and whether a sort or filter is active. Those distinguish "the backend sent null", "something rebuilt the row object and dropped the key", and "visual/physical resolution picked the wrong row".

## Reverting

Temporary. The block is marked `TEMPORARY DIAGNOSTIC` on its first line and should be reverted once the cause is identified.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.
- With the flag unset, behaviour is unchanged and nothing is logged.
- With the flag set, edit a cell in By Document and again in By Unit, and compare the two outputs against the PUT in the network tab.