### PR TITLE
fix(units): stamp and forward _row_index so by-unit cell edits carry a stable row identity

### DIFF
--- a/backend/app/api/routes/units.py
+++ b/backend/app/api/routes/units.py
@@ -394,6 +394,10 @@ async def get_unit_data(
                     source_document=row_data.get('_source_document') or row_data.get('source_document'),
                     parent_document=row_data.get('_parent_document'),
                     cell_status=row_data.get('_cell_status'),
+                    # Without this the by-unit view sent row_index=None on every
+                    # row, so cell edits from the default view fell back to
+                    # first-match on row_name + source_document.
+                    row_index=row_data.get('_row_index'),
                 )
             else:
                 # Flat format - extract special fields
@@ -404,6 +408,9 @@ async def get_unit_data(
                 source_document = flat_data.pop('_source_document', None) or flat_data.pop('source_document', None)
                 parent_document = flat_data.pop('_parent_document', None)
                 cell_status = flat_data.pop('_cell_status', None)
+                # pop, not get: leaving it in flat_data would surface the index
+                # as a data column.
+                row_index = flat_data.pop('_row_index', None)
                 flat_data.pop('_original_units', None)  # Remove internal merge tracking
 
                 data_row = DataRow(
@@ -414,6 +421,7 @@ async def get_unit_data(
                     source_document=source_document,
                     parent_document=parent_document,
                     cell_status=cell_status,
+                    row_index=row_index,
                 )
             data_rows.append(data_row)
 

--- a/backend/app/services/unit_view_service.py
+++ b/backend/app/services/unit_view_service.py
@@ -164,9 +164,18 @@ class UnitViewService:
             file_keys: set = set()
             try:
                 with open(data_file, 'r', encoding='utf-8') as f:
+                    # Absolute non-blank line position, stamped the same way
+                    # file_parser._load_all_rows does it. data_editor resolves an
+                    # edit by this number, so the two readers must agree: count
+                    # every non-blank line and stamp before the dedup skip below,
+                    # or a deduplicated row would shift every index after it and
+                    # edits would land on the wrong row -- worse than no index.
+                    row_index = 0
                     for line in f:
                         if line.strip():
                             row = json.loads(line)
+                            row['_row_index'] = row_index
+                            row_index += 1
                             key = row_dedup_key(row)
                             if key[0] and key in seen_keys:
                                 continue

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -992,6 +992,43 @@ export function SpreadsheetSurface({
         const rowName = sourceRow?.row_name || sourceRow?._unit_name || '';
         const rowIndexId = sourceRow?._row_index;
         const sourceDocument = sourceRow?._source_document || sourceRow?._parent_document;
+
+        // TEMPORARY DIAGNOSTIC -- remove once the missing row_index is explained.
+        //
+        // A PUT captured from a real edit carried row_name and source_document
+        // but no row_index, even though the payload contains _row_index and the
+        // alignment memos only reorder rows. That means sourceRow._row_index was
+        // undefined for that edit and we do not know why. Opt in per browser:
+        //   localStorage.setItem('schematiq.debugCellEdit', '1')
+        // then edit a cell and read the console. Off for everyone else.
+        if (localStorage.getItem('schematiq.debugCellEdit') === '1') {
+          const physicalRow = toPhysicalRow(visualRowIndex);
+          // eslint-disable-next-line no-console
+          console.log('[cell-edit-identity]', {
+            dataView,
+            column: key,
+            visualRowIndex,
+            physicalRow,
+            rowsLength: data.rows.length,
+            hasToPhysicalRow: typeof hot?.toPhysicalRow === 'function',
+            sourceRowFound: Boolean(sourceRow),
+            // The three values actually sent to the backend.
+            sent: { rowName, sourceDocument, rowIndexId },
+            // Present but undefined vs absent entirely are different bugs.
+            rowIndexKeyPresent: sourceRow ? '_row_index' in sourceRow : null,
+            sourceRowUnderscoreKeys: sourceRow
+              ? Object.keys(sourceRow).filter((k) => k.startsWith('_'))
+              : null,
+            // A sort or filter makes visual != physical; worth knowing which.
+            sortConfig: hot?.getPlugin('columnSorting')?.getSortConfig?.() ?? null,
+            filtersActive: Boolean(hot?.getPlugin('filters')?.isEnabled?.()),
+            // The neighbouring rows, to see whether the index is missing on this
+            // row alone or across the payload.
+            neighbourRowIndexes: data.rows
+              .slice(Math.max(0, physicalRow - 2), physicalRow + 3)
+              .map((r) => r?._row_index),
+          });
+        }
         if (!rowName && rowIndexId == null) {
           unidentified += 1;
           continue;


### PR DESCRIPTION
## Problem

Cell edits from the by-unit view — the default view — send `row_index=None`, falling back to first-match on `row_name` + `source_document`. Diagnostic output from a real edit:

| view | rowIndexId | neighbourRowIndexes |
|---|---|---|
| by_document | 2, 4 | [0,1,2,3,4] · [2,3,4,5,7] |
| by_unit | null | [null,null,null,null,null] |

`_row_index` is present as a key with a null value, on all 194 rows. `visualRowIndex === physicalRow` in every sample, so visual/physical resolution is not involved.

Two independent failures, each sufficient on its own:

1. `unit_view_service._load_all_rows` appends the raw parsed dict and never stamps `_row_index`, unlike `file_parser._load_all_rows` which does `row['_row_index'] = idx`.
2. `get_unit_data` constructs `DataRow(...)` field by field in both the nested and flat branches and omits `row_index`, so it would default to `None` even if the reader stamped it.

Not currently harmful: `row_name` + `source_document` is unique in the datasets checked, and that pair was verified to hit the correct row out of five sharing a name. But the fallback is silent.

## Solution

Stamp during the read and forward it through the response model.

The stamping detail matters. `data_editor` resolves an edit by absolute position — `_row_index` is the reader's non-blank line position in the file — and `unit_view_service` deduplicates, skipping rows. A counter that advanced only on kept rows would drift from `file_parser`'s numbering, and a wrong index is worse than a missing one: null falls back to a pair that works, while a wrong index confidently targets another row. So the counter advances on every non-blank line and the stamp happens before the dedup skip.

In the flat branch `_row_index` is popped rather than read, since anything left in `flat_data` becomes `data` and would surface as a column.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `py_compile`: clean. Applies alongside the diagnostic patch.
- Stamping checked against a file containing a duplicate row and a trailing blank line: kept rows are A=0, B=1, C=3 — the deduplicated row is still counted, so C keeps its true position rather than shifting to 2, and the blank line is not counted. This matches `file_parser` numbering.
- Manually, with the diagnostic still applied: edit a cell in By Unit and confirm `rowIndexId` is a number and `neighbourRowIndexes` are numbers. Cross-check the value against the same row's index in By Document; they should agree.