### PR TITLE
perf(workspace): coalesce the post-edit refresh across a burst of edits

### DIFF
--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -98,6 +98,10 @@ import './Workspace.css';
 // immer's patch APIs are opt-in and must be enabled once before use (undo stack).
 enablePatches();
 
+// Long enough to absorb a burst of single-cell edits, short enough that the
+// server round-trip still feels immediate.
+const EDIT_REFRESH_COALESCE_MS = 400;
+
 type RefreshDataOptions = {
   silent?: boolean;
   force?: boolean;
@@ -307,7 +311,29 @@ function Workspace() {
     refreshDataRef.current = refreshData;
   }, [refreshData]);
 
-  const refreshAfterEdit = useCallback(() => refreshData({ silent: true, force: true }), [refreshData]);
+  // Every edit refetches the whole page to confirm the write landed -- about
+  // 986 kB for a 500-row session. applyCellUpdates already collapses a batch
+  // paste into one refresh, but sequential single-cell edits each fired their
+  // own, so typing through ten cells cost ten full pages.
+  //
+  // Coalesce on the trailing edge: the last edit of a burst is the one that
+  // refreshes, and one always does. The verification is preserved -- it is
+  // deferred by at most EDIT_REFRESH_COALESCE_MS, not skipped. Until it lands
+  // the grid shows the optimistic value, which is already the case today
+  // because the refresh was never synchronous.
+  const editRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const refreshAfterEdit = useCallback(() => {
+    if (editRefreshTimerRef.current) clearTimeout(editRefreshTimerRef.current);
+    editRefreshTimerRef.current = setTimeout(() => {
+      editRefreshTimerRef.current = null;
+      void refreshData({ silent: true, force: true });
+    }, EDIT_REFRESH_COALESCE_MS);
+  }, [refreshData]);
+
+  useEffect(() => () => {
+    if (editRefreshTimerRef.current) clearTimeout(editRefreshTimerRef.current);
+  }, []);
 
   const refreshSilent = useCallback(() => refreshData({ silent: true }), [refreshData]);
 


### PR DESCRIPTION
## Problem

Every cell edit refetches the whole data page to confirm the write landed — about 986 kB for a 500-row session, measured in the network tab.

`applyCellUpdates` already collapses a batch paste into one refresh, so bulk operations are fine. Sequential single-cell edits are not: each Enter fires its own refresh, so typing through ten cells costs ten full pages, roughly 9.9 MB.

## Solution

`refreshAfterEdit` coalesces on the trailing edge with a 400 ms window. The last edit of a burst is the one that refreshes, and one always does.

The verification is preserved, not removed — it is deferred by at most 400 ms. Until it lands the grid shows the optimistic value, which was already the case since the refresh was never synchronous. Two alternatives were rejected: a single-row refresh endpoint does not cover edits that change grouping or the status of other rows, and trusting the PUT response would drop the verification that has been catching exactly the class of bug we have been chasing.

An effect cleanup clears a pending timer, so navigating away mid-burst cannot fire a fetch against a session that is no longer open.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.
- Coalescing checked in isolation: ten edits 80 ms apart produce one fetch (was ten); two edits spaced beyond the window still produce two, so distant edits are each verified; a single edit always produces one; cancelling mid-burst produces none.
- Manually: edit a cell, wait a second, hard-refresh, and confirm the value persisted — this checks the verification still happens rather than being deferred indefinitely. Then edit five cells in quick succession and confirm one `data` request instead of five.