### PR TITLE
chore(workspace): remove the temporary cell-edit identity diagnostic

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -993,42 +993,6 @@ export function SpreadsheetSurface({
         const rowIndexId = sourceRow?._row_index;
         const sourceDocument = sourceRow?._source_document || sourceRow?._parent_document;
 
-        // TEMPORARY DIAGNOSTIC -- remove once the missing row_index is explained.
-        //
-        // A PUT captured from a real edit carried row_name and source_document
-        // but no row_index, even though the payload contains _row_index and the
-        // alignment memos only reorder rows. That means sourceRow._row_index was
-        // undefined for that edit and we do not know why. Opt in per browser:
-        //   localStorage.setItem('schematiq.debugCellEdit', '1')
-        // then edit a cell and read the console. Off for everyone else.
-        if (localStorage.getItem('schematiq.debugCellEdit') === '1') {
-          const physicalRow = toPhysicalRow(visualRowIndex);
-          // eslint-disable-next-line no-console
-          console.log('[cell-edit-identity]', {
-            dataView,
-            column: key,
-            visualRowIndex,
-            physicalRow,
-            rowsLength: data.rows.length,
-            hasToPhysicalRow: typeof hot?.toPhysicalRow === 'function',
-            sourceRowFound: Boolean(sourceRow),
-            // The three values actually sent to the backend.
-            sent: { rowName, sourceDocument, rowIndexId },
-            // Present but undefined vs absent entirely are different bugs.
-            rowIndexKeyPresent: sourceRow ? '_row_index' in sourceRow : null,
-            sourceRowUnderscoreKeys: sourceRow
-              ? Object.keys(sourceRow).filter((k) => k.startsWith('_'))
-              : null,
-            // A sort or filter makes visual != physical; worth knowing which.
-            sortConfig: hot?.getPlugin('columnSorting')?.getSortConfig?.() ?? null,
-            filtersActive: Boolean(hot?.getPlugin('filters')?.isEnabled?.()),
-            // The neighbouring rows, to see whether the index is missing on this
-            // row alone or across the payload.
-            neighbourRowIndexes: data.rows
-              .slice(Math.max(0, physicalRow - 2), physicalRow + 3)
-              .map((r) => r?._row_index),
-          });
-        }
         if (!rowName && rowIndexId == null) {
           unidentified += 1;
           continue;


### PR DESCRIPTION
## Problem

Two reasons to remove this block, and the second is a live bug.

**It has served its purpose.** The diagnostic was added to explain why cell edits sent no `row_index`. It did: the by-unit view reported `_row_index: null` on all 194 rows, while by-document reported real numbers. Root cause was two independent failures in the by-unit path, fixed in #399, and verified by cross-checking indices between the two endpoints with zero mismatches. The block is marked `TEMPORARY DIAGNOSTIC` and the investigation is closed.

**The version on main is the one that crashes.** `SpreadsheetSurface.tsx:1023` reads:

```ts
sortConfig: hot?.getPlugin('columnSorting')?.getSortConfig?.() ?? null,
```

The optional chaining guards the plugin and the method, but the plugin exists while disabled and its internal state manager is null, so `getSortConfig()` throws from inside:

```
TypeError: Cannot read properties of null (reading 'getSortStates')
    at ColumnSorting.getSortConfig
    at Core.afterChange
```

It throws inside `afterChange`, on the path that persists the edit, so the save is aborted. A hardened version with try/catch was written but never merged; #398 carried the original. Anyone with `localStorage.schematiq.debugCellEdit` set — including whoever set it during the investigation — currently loses every cell edit they make.

## Solution

Remove all 36 lines. This clears the debug code and the crash together.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.
- After applying, grep for `cell-edit-identity` and `debugCellEdit` returns zero.
- Manually: with the flag still set in localStorage, edit a cell and confirm no runtime error and that the value persists through a refresh.