### PR TITLE
fix(workspace): report a busy server as retryable instead of as a failure

### DIFF
--- a/backend/app/services/pipeline/data_query.py
+++ b/backend/app/services/pipeline/data_query.py
@@ -393,37 +393,25 @@ async def get_data(
             has_more=end < filtered_count
         )
     else:
-        # Efficient pagination (no filtering/sorting)
+        # Single pass: count every deduplicated row and materialise only the
+        # requested window.
+        #
+        # This was two passes over every file -- one to count, one to build the
+        # page -- so an unfiltered request parsed the whole dataset twice. The
+        # window is still the only thing retained, so the memory profile is
+        # unchanged; only the second read is gone.
+        #
+        # The two passes also kept separate deduplication sets (seen_keys and
+        # seen_keys_page) running the same logic, which meant total_count and the
+        # returned rows were derived independently and could drift apart. One set
+        # now feeds both.
         total_count = 0
-        seen_keys: set = set()
-        for data_file in data_files:
-            file_keys: set = set()
-            with open(data_file, 'r', encoding='utf-8') as f:
-                for line in f:
-                    if not line.strip():
-                        continue
-                    try:
-                        row_data = json.loads(line.strip())
-                        key = row_dedup_key(row_data)
-                        if key[0] and key in seen_keys:
-                            continue
-                        if key[0]:
-                            file_keys.add(key)
-                        total_count += 1
-                    except (json.JSONDecodeError, TypeError):
-                        pass
-            seen_keys.update(file_keys)
-
         rows = []
         start_line = page * page_size
         end_line = start_line + page_size
-        global_line = 0
-        seen_keys_page: set = set()
+        seen_keys: set = set()
 
         for data_file in data_files:
-            if global_line >= end_line:
-                break
-
             file_keys: set = set()
             with open(data_file, 'r', encoding='utf-8') as f:
                 for line in f:
@@ -434,19 +422,18 @@ async def get_data(
                     except (json.JSONDecodeError, TypeError):
                         continue
                     key = row_dedup_key(row_data)
-                    if key[0] and key in seen_keys_page:
+                    if key[0] and key in seen_keys:
                         continue
                     if key[0]:
                         file_keys.add(key)
 
-                    if global_line >= end_line:
-                        break
-                    if global_line >= start_line:
-                        normalized = normalize_row(row_data)
-                        data_row = DataRow(**normalized)
-                        rows.append(data_row)
-                    global_line += 1
-            seen_keys_page.update(file_keys)
+                    # total_count doubles as the position among deduplicated
+                    # rows, which is the unit the page window is expressed in.
+                    # No early break: the full count is part of the response.
+                    if start_line <= total_count < end_line:
+                        rows.append(DataRow(**normalize_row(row_data)))
+                    total_count += 1
+            seen_keys.update(file_keys)
 
         return PaginatedData(
             rows=rows,

--- a/frontend/src/pages/Workspace/helpers.ts
+++ b/frontend/src/pages/Workspace/helpers.ts
@@ -328,3 +328,27 @@ export function formatToolsList(tools: ChatToolInfo[]): string {
     })
     .join('\n');
 }
+
+// The concurrency limiter answers 503 when the server is at capacity. That is a
+// "come back shortly" condition, not a failure of the thing the user asked for,
+// and it was only being distinguished in one of the three Workspace entry points
+// that can provoke it -- so re-extraction and project start reported it as
+// though the operation itself had broken.
+export const SERVER_BUSY_MESSAGE =
+  'The server is at capacity right now. Nothing was lost -- try again in a few minutes.';
+
+export function describeRequestError(
+  err: unknown,
+  fallback: string,
+): { message: string; isBusy: boolean } {
+  const response = (err as { response?: { status?: number; data?: { detail?: unknown } } })?.response;
+  const detail = typeof response?.data?.detail === 'string' ? response.data.detail : '';
+  if (response?.status === 503) {
+    // Prefer the server's wording when it sent any; it names the limit.
+    return { message: detail || SERVER_BUSY_MESSAGE, isBusy: true };
+  }
+  return {
+    message: detail || (err as { message?: string })?.message || fallback,
+    isBusy: false,
+  };
+}

--- a/frontend/src/pages/Workspace/hooks/useAddDocuments.ts
+++ b/frontend/src/pages/Workspace/hooks/useAddDocuments.ts
@@ -11,6 +11,7 @@ import type { DocumentListResponse } from '@/types/unit';
 import { getApiKeyForProvider, getConfiguredProviders } from '@/utils/apiKeyStorage';
 
 import type { SheetId } from '../types';
+import { describeRequestError } from '../helpers';
 
 const normalizeDocName = (s: string) => s.trim().toLowerCase();
 const stripDocExt = (s: string) => s.replace(/\.[^.\\/]+$/, '');
@@ -145,10 +146,7 @@ export function useAddDocuments({
       });
       await refresh({ silent: true });
     } catch (err: any) {
-      const detail = err?.response?.data?.detail;
-      const message = err?.response?.status === 503
-        ? (detail || 'The server is busy. Please try again in a few minutes.')
-        : (typeof detail === 'string' ? detail : err?.message || 'Failed to start processing');
+      const { message } = describeRequestError(err, 'Failed to start processing');
       setAddDocsError(message);
     } finally {
       setAddDocsProcessing(false);

--- a/frontend/src/pages/Workspace/hooks/useReextraction.ts
+++ b/frontend/src/pages/Workspace/hooks/useReextraction.ts
@@ -13,6 +13,7 @@ import type {
 } from '@/types';
 import { getApiKeyForProvider, getConfiguredProviders } from '@/utils/apiKeyStorage';
 
+import { describeRequestError } from '../helpers';
 import type { PendingRerunKind, SheetId, WorkspaceReextractionState, WorkspaceSessionMode } from '../types';
 
 type UseReextractionOptions = {
@@ -187,10 +188,11 @@ export function useReextraction({
         duration: 4000,
       });
     } catch (err: any) {
+      const { message, isBusy } = describeRequestError(err, 'Could not start re-extraction');
       toast({
-        title: 'Re-extraction failed to start',
-        description: err?.response?.data?.detail || err?.message || 'Could not start re-extraction',
-        variant: 'destructive',
+        title: isBusy ? 'Server busy' : 'Re-extraction failed to start',
+        description: message,
+        variant: isBusy ? 'default' : 'destructive',
       });
     } finally {
       setRerunStarting(false);
@@ -266,10 +268,11 @@ export function useReextraction({
       });
       await refresh({ silent: true });
     } catch (err: any) {
+      const { message, isBusy } = describeRequestError(err, 'Could not start schema rediscovery');
       toast({
-        title: 'Schema rediscovery failed',
-        description: err?.response?.data?.detail || err?.message || 'Could not start schema rediscovery',
-        variant: 'destructive',
+        title: isBusy ? 'Server busy' : 'Schema rediscovery failed',
+        description: message,
+        variant: isBusy ? 'default' : 'destructive',
       });
     } finally {
       setRerunStarting(false);


### PR DESCRIPTION
## Problem

The concurrency limiter answers 503 when the server is at capacity. Nothing has broken and nothing is lost — the user needs to retry shortly. Three Workspace entry points can provoke it, and only one said so.

`useAddDocuments.ts` had a one-off branch with a "server is busy, try again" message. `useReextraction.ts` (both re-extraction and schema rediscovery) fell through to `detail || err.message` with a destructive toast titled "Re-extraction failed to start" — telling the user their operation broke when it merely queued out.

A second defect in the old shape: FastAPI returns `detail` as an array for validation errors, and `err?.response?.data?.detail || err?.message` would put that object straight into the description, rendering as `[object Object]`.

## Solution

A shared `describeRequestError(err, fallback)` in `helpers.ts` returning `{ message, isBusy }`, used at all three sites. It prefers the server's own wording on 503, since that names the actual limit, and falls back to a message that says nothing was lost. Non-string `detail` values are ignored rather than interpolated.

Re-extraction toasts now read "Server busy" with `variant: 'default'` instead of a destructive "failed to start" — that is the retry indicator: the condition is transient, not a failure.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean.
- The describer was exercised against seven real error shapes: 503 with server wording, 503 with no body, 503 with a non-string detail, 500 with a detail, 422 with an array detail, a network error with no response, and undefined. Only the 503 cases set `isBusy`, and the array detail falls back rather than stringifying to `[object Object]`.
- Manually: with the concurrency limit reached, start a re-extraction and confirm a non-destructive "Server busy" toast rather than a red failure.