### PR TITLE
perf(data): paginate unfiltered reads in one pass instead of two

### DIFF
--- a/backend/app/services/pipeline/data_query.py
+++ b/backend/app/services/pipeline/data_query.py
@@ -393,37 +393,25 @@ async def get_data(
             has_more=end < filtered_count
         )
     else:
-        # Efficient pagination (no filtering/sorting)
+        # Single pass: count every deduplicated row and materialise only the
+        # requested window.
+        #
+        # This was two passes over every file -- one to count, one to build the
+        # page -- so an unfiltered request parsed the whole dataset twice. The
+        # window is still the only thing retained, so the memory profile is
+        # unchanged; only the second read is gone.
+        #
+        # The two passes also kept separate deduplication sets (seen_keys and
+        # seen_keys_page) running the same logic, which meant total_count and the
+        # returned rows were derived independently and could drift apart. One set
+        # now feeds both.
         total_count = 0
-        seen_keys: set = set()
-        for data_file in data_files:
-            file_keys: set = set()
-            with open(data_file, 'r', encoding='utf-8') as f:
-                for line in f:
-                    if not line.strip():
-                        continue
-                    try:
-                        row_data = json.loads(line.strip())
-                        key = row_dedup_key(row_data)
-                        if key[0] and key in seen_keys:
-                            continue
-                        if key[0]:
-                            file_keys.add(key)
-                        total_count += 1
-                    except (json.JSONDecodeError, TypeError):
-                        pass
-            seen_keys.update(file_keys)
-
         rows = []
         start_line = page * page_size
         end_line = start_line + page_size
-        global_line = 0
-        seen_keys_page: set = set()
+        seen_keys: set = set()
 
         for data_file in data_files:
-            if global_line >= end_line:
-                break
-
             file_keys: set = set()
             with open(data_file, 'r', encoding='utf-8') as f:
                 for line in f:
@@ -434,19 +422,18 @@ async def get_data(
                     except (json.JSONDecodeError, TypeError):
                         continue
                     key = row_dedup_key(row_data)
-                    if key[0] and key in seen_keys_page:
+                    if key[0] and key in seen_keys:
                         continue
                     if key[0]:
                         file_keys.add(key)
 
-                    if global_line >= end_line:
-                        break
-                    if global_line >= start_line:
-                        normalized = normalize_row(row_data)
-                        data_row = DataRow(**normalized)
-                        rows.append(data_row)
-                    global_line += 1
-            seen_keys_page.update(file_keys)
+                    # total_count doubles as the position among deduplicated
+                    # rows, which is the unit the page window is expressed in.
+                    # No early break: the full count is part of the response.
+                    if start_line <= total_count < end_line:
+                        rows.append(DataRow(**normalize_row(row_data)))
+                    total_count += 1
+            seen_keys.update(file_keys)
 
         return PaginatedData(
             rows=rows,

--- a/backend/tests/test_session_data_read_failed.py
+++ b/backend/tests/test_session_data_read_failed.py
@@ -1,0 +1,142 @@
+"""Tests for the guard that tells "could not read" apart from "no rows".
+
+``session_data_read_failed`` decides whether an empty page means the session
+genuinely has nothing or that its data could not be read. Callers use it to
+explain an empty table instead of rendering bare column headers, so a wrong
+answer in either direction is user-visible: a false negative shows an
+unexplained empty grid, a false positive tells someone their data is missing
+when they simply deleted every row.
+
+The four conditions are ordered cheapest-first and only the last touches
+storage. That ordering is asserted here, not just the return value, because it
+is the reason the guard is safe to call on every read.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.models.session import PaginatedData
+from app.services.pipeline.data_query import session_data_read_failed
+
+SESSION_ID = "sess-guard-1"
+
+
+def _page(total_count: int) -> PaginatedData:
+    return PaginatedData(
+        rows=[],
+        total_count=total_count,
+        filtered_count=None,
+        page=0,
+        page_size=50,
+        has_more=False,
+    )
+
+
+def _session(total_rows):
+    if total_rows is None:
+        return SimpleNamespace(statistics=None)
+    return SimpleNamespace(statistics=SimpleNamespace(total_rows=total_rows))
+
+
+@pytest.fixture
+def spies(monkeypatch):
+    """Patch the two helpers and record whether each was consulted."""
+    calls = {"enumerate": 0, "storage": 0}
+    state = {"local_files": [], "in_storage": False}
+
+    def fake_enumerate(session_id, *args, **kwargs):
+        calls["enumerate"] += 1
+        return list(state["local_files"])
+
+    async def fake_stored(session_id, *args, **kwargs):
+        calls["storage"] += 1
+        return state["in_storage"]
+
+    monkeypatch.setattr(
+        "app.services.data_utils.enumerate_session_data_files", fake_enumerate
+    )
+    monkeypatch.setattr(
+        "app.services.data_utils.session_has_stored_data", fake_stored
+    )
+    return calls, state
+
+
+async def test_rows_present_is_not_a_failure(spies):
+    """A page with rows is never a read failure, and costs nothing to check."""
+    calls, _state = spies
+
+    assert await session_data_read_failed(SESSION_ID, _page(3), _session(3)) is False
+    assert calls == {"enumerate": 0, "storage": 0}
+
+
+@pytest.mark.parametrize(
+    "total_rows",
+    [None, 0],
+    ids=["no-statistics", "statistics-report-zero"],
+)
+async def test_session_never_had_rows_is_not_a_failure(spies, total_rows):
+    """Without an independent record of rows there is nothing to contradict."""
+    calls, _state = spies
+
+    result = await session_data_read_failed(SESSION_ID, _page(0), _session(total_rows))
+
+    assert result is False
+    # Short-circuits before touching the filesystem or storage.
+    assert calls == {"enumerate": 0, "storage": 0}
+
+
+async def test_local_file_present_is_not_a_failure(spies, tmp_path):
+    """An emptied table keeps its file; that is deletion, not a failed read."""
+    calls, state = spies
+    data_file = tmp_path / "extracted_data.jsonl"
+    data_file.write_text("")
+    state["local_files"] = [data_file]
+
+    result = await session_data_read_failed(SESSION_ID, _page(0), _session(12))
+
+    assert result is False
+    assert calls["enumerate"] == 1
+    # The expensive check is skipped once a local file is found.
+    assert calls["storage"] == 0
+
+
+async def test_no_local_file_and_nothing_stored_is_not_a_failure(spies):
+    """Stale statistics with no data anywhere is not a hydration failure."""
+    calls, state = spies
+    state["local_files"] = []
+    state["in_storage"] = False
+
+    result = await session_data_read_failed(SESSION_ID, _page(0), _session(12))
+
+    assert result is False
+    assert calls == {"enumerate": 1, "storage": 1}
+
+
+async def test_rows_in_storage_but_not_local_is_a_failure(spies):
+    """The case the guard exists for: the rows exist remotely, hydration failed."""
+    calls, state = spies
+    state["local_files"] = []
+    state["in_storage"] = True
+
+    result = await session_data_read_failed(SESSION_ID, _page(0), _session(12))
+
+    assert result is True
+    assert calls == {"enumerate": 1, "storage": 1}
+
+
+async def test_filtered_page_with_matches_elsewhere_is_not_a_failure(spies):
+    """total_count is the unfiltered count, so a filter matching nothing still
+    reports rows and must not be mistaken for a failed read."""
+    calls, _state = spies
+    page = PaginatedData(
+        rows=[],
+        total_count=40,
+        filtered_count=0,
+        page=0,
+        page_size=50,
+        has_more=False,
+    )
+
+    assert await session_data_read_failed(SESSION_ID, page, _session(40)) is False
+    assert calls == {"enumerate": 0, "storage": 0}


### PR DESCRIPTION
## Problem

The unfiltered branch of `get_data` walked every data file twice: once to accumulate `total_count`, then again to build the page rows. Every request without filters, sorting, or search parsed the whole dataset twice. Negligible on a 194-row session; less so on a dataset like `full_text_constitutions`, which has 622 files.

The two passes also maintained separate deduplication sets — `seen_keys` and `seen_keys_page` — running the same logic independently. `total_count` and the returned rows were therefore derived from two separate sources and could drift apart.

## Solution

One pass. `total_count` doubles as the position among deduplicated rows, and only the requested window is materialised, so the memory profile is unchanged — that mattered, since this branch exists specifically to avoid holding everything in memory the way the filtered branch does.

No early break: the full count is part of the response, so the file still has to be read to the end. The saving is one read instead of two, not a partial read. One deduplication set now feeds both the count and the rows.

Net 21 insertions, 34 deletions.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `py_compile`: clean.
- Old and new logic were run side by side on the same inputs: three files including a duplicated row, a row with no `row_name` (never deduplicated), malformed JSON, and a trailing blank line. All 20 combinations of `page` 0–3 and `page_size` 1/2/3/5/100 return identical `total_count` and identical rows.
- Not executed against a running backend. After merging, open a project and confirm the row count in the status bar and a full first page.