### PR TITLE
fix(workspace): declare the HTML sanitizer explicitly instead of relying on Handsontable's deprecated default

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
         "axios": "^1.6.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dompurify": "^3.4.13",
         "handsontable": "^17.0.1",
         "immer": "^11.1.16",
         "lucide-react": "^0.561.0",
@@ -8604,9 +8605,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "axios": "^1.6.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dompurify": "^3.4.13",
     "handsontable": "^17.0.1",
     "immer": "^11.1.16",
     "lucide-react": "^0.561.0",

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -7,6 +7,7 @@ import { HotTable, type HotTableClass } from '@handsontable/react';
 import { registerAllModules } from 'handsontable/registry';
 import 'handsontable/styles/handsontable.min.css';
 import 'handsontable/styles/ht-theme-main.min.css';
+import DOMPurify from 'dompurify';
 
 import { extractDisplayValue } from '@/components/DataTable/utils/valueUtils';
 import {
@@ -45,6 +46,22 @@ import type {
 } from './types';
 
 registerAllModules();
+
+// Cell values come from user-uploaded documents and are written through
+// innerHTML, so they have to be stripped of anything executable first.
+// Handsontable did this for us by calling DOMPurify internally, but v17
+// deprecated that: it now warns on every render and will drop the built-in
+// sanitisation entirely in v18, silently leaving the content unfiltered.
+//
+// Declaring the sanitizer keeps the exact same protection under our own
+// dependency (dompurify is now a direct entry in package.json rather than
+// something we inherit from Handsontable's tree) and survives the upgrade.
+// Handsontable also routes pasted content through this, hence the `source`
+// argument in its type -- both paths get the same treatment.
+//
+// Defined at module scope so its identity is stable; a new function on every
+// render would make Handsontable re-apply settings continuously.
+const sanitizeCellHtml = (content: string): string => DOMPurify.sanitize(content);
 
 export function SpreadsheetSurface({
   activeSheet,
@@ -1544,6 +1561,7 @@ export function SpreadsheetSurface({
         dropdownMenu={dropdownMenuConfig}
         columnSorting={!hasMultiRowGroup}
         copyPaste
+        sanitizer={sanitizeCellHtml}
         // Required for the highlight, not for the query. getPlugin('search')
         // .query() sets `isSearchResult` on cell meta regardless, but the hook
         // that turns that into the htSearchResult class is guarded by the


### PR DESCRIPTION
## Problem

Cell values come from user-uploaded documents and are written through `innerHTML`, so they must be stripped of anything executable first. Handsontable did that for us by calling DOMPurify internally. v17 deprecated it — `helpers/dom/element.mjs:433` warns on every render, and v18 removes the built-in sanitisation entirely, which would leave document-derived content unfiltered without any code change on our side.

## Solution

Declare the sanitizer. Same library, same defaults, now under our own dependency: `dompurify` is an explicit entry in `package.json` rather than something inherited from Handsontable's tree, so it survives the upgrade that removes the built-in path.

`package-lock.json` is updated in the same commit — a mismatch would break `npm ci`.

The callback lives at module scope so its identity is stable; a new function each render would make Handsontable re-apply settings continuously.

Worth noting the type is `(content: string, source: 'innerHTML' | 'CopyPaste.paste') => string` — pasted content is routed through the same callback, so this covers both entry paths, not just display.

## Verify

- `git apply --ignore-whitespace --check` on a clean clone of main: passes. `tsc --noEmit`: clean, which confirms the callback signature against Handsontable's own `settings.d.ts`.
- The sanitisation itself was exercised, not just the types: `Judge <script>alert(1)</script> Moss` becomes `Judge  Moss`; `<img src=x onerror=alert(1)>` becomes `<img src=\"x\">`; `<b>bold</b> and <i>italic</i>` passes through unchanged. Injection is blocked and legitimate markup is preserved — an over-strict sanitizer would have broken rendering silently.
- Not exercised in a running app. Confirm the console warning is gone, the table renders normally, and pasting into a cell still works.