### PR TITLE
chore(lib): disable the sentence-transformers progress bar in _embed

### DIFF
--- a/schematiq-lib/schematiq/core/schema.py
+++ b/schematiq-lib/schematiq/core/schema.py
@@ -17,7 +17,7 @@ MAX_KEYS_DEFAULT = None         # unlimited unless specified
 
 def _embed(text: str):
     """Small helper – add caching in production."""
-    return EMB_MODEL.encode(text, normalize_embeddings=True)
+    return EMB_MODEL.encode(text, normalize_embeddings=True, show_progress_bar=False)
 
 
 # -------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem
`_embed` in `core/schema.py` was the only `model.encode` call site not passing `show_progress_bar=False`. Every unit-dedup embedding printed a tqdm bar to stderr, which Railway tags as `[err]`. In one 350-line production log 52 lines were this noise, burying real errors.

## Solution
Pass `show_progress_bar=False`, matching every other encode call in `core/retrievers.py`.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone of main
- `python -m py_compile schematiq-lib/schematiq/core/schema.py`
- Run an extraction and confirm no `Batches:` lines in the log
- No frontend files touched