### PR TITLE
fix(runner): purge the stored data file when resetting for observation unit rediscovery

### DIFF
--- a/backend/app/services/data_utils.py
+++ b/backend/app/services/data_utils.py
@@ -420,6 +420,42 @@ async def ensure_session_data_file_local(
     return True
 
 
+async def purge_session_data_file(
+    session_id: str,
+    local_path: Path,
+    storage=None,
+) -> None:
+    """Remove a data JSONL object from storage so a reset stays reset.
+
+    Deleting only the local file is not enough. ``resolve_session_data_files``
+    hydrates from storage whenever the local copy is absent, and it cannot
+    tell a file wiped by a redeploy (hydrate) from one deleted on purpose for
+    a re-run (do not hydrate). Callers that clear local artifacts must clear
+    the storage object too, or the stale rows come straight back."""
+    storage_path = storage_path_for_data_file(local_path, session_id)
+    if not storage_path:
+        return
+
+    if storage is None:
+        from app.storage import get_storage
+
+        storage = get_storage()
+
+    try:
+        await storage.delete_file("data", storage_path)
+    except Exception as exc:
+        logger.warning(
+            "Failed to purge storage data/%s for session %s: %s",
+            storage_path,
+            session_id,
+            exc,
+        )
+    else:
+        logger.info(
+            "Purged storage data/%s for session %s", storage_path, session_id
+        )
+
+
 async def persist_session_data_file(
     session_id: str,
     local_path: Path,

--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -30,6 +30,8 @@ from app.services.pipeline.data_query import (
     compute_statistics, get_status as _get_status, get_schema as _get_schema, get_data as _get_data,
 )
 
+from app.services.data_utils import purge_session_data_file
+
 logger = logging.getLogger(__name__)
 
 from schematiq.core.schema import ObservationUnit
@@ -463,6 +465,11 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
             if artifact.exists():
                 artifact.unlink()
                 logger.info("Removed %s for observation unit rediscovery", fname)
+
+        # Unlinking locally is not enough: get_data hydrates the data file back
+        # from storage whenever the local copy is missing, which would resurrect
+        # the previous run's rows into a session that is being rediscovered.
+        await purge_session_data_file(session_id, session_dir / "extracted_data.jsonl")
 
         session = self.session_manager.get_session(session_id)
         if not session:


### PR DESCRIPTION
## Problem
`_reset_for_observation_unit_rediscovery` unlinks local artifacts but leaves the `data` bucket object in place. `resolve_session_data_files` hydrates from storage whenever the local copy is absent, and it cannot tell a file wiped by a redeploy (hydrate, correct) from one deleted on purpose for a re-run (hydrate, wrong). The previous run's rows come straight back into a session being rediscovered.

Rare today because the storage copy only exists if the user edited a cell. Persisting after every run would make it the normal case.

## Solution
Add `purge_session_data_file` in `data_utils` and call it from the reset so clearing local artifacts also clears storage. Failures are logged and non-fatal.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone of main
- `python -m py_compile` on both files
- `data_utils.py` is CRLF-only; line endings confirmed unchanged after apply (CRLF=575, bare LF=0)
- Trigger observation unit rediscovery and confirm `Purged storage data/...` in the log and no stale rows in the table
- No frontend files touched