### PR TITLE
fix(lib): drive sampling params and thinking level from the per-model spec

### DIFF
--- a/schematiq-lib/schematiq/core/llm_backends.py
+++ b/schematiq-lib/schematiq/core/llm_backends.py
@@ -509,9 +509,13 @@ class GeminiLLM(LLMInterface):
         # combined with response_schema, causing 400 INVALID_ARGUMENT.
         self.supports_thinking = spec.supports_thinking
         # Gemini 3.x+ models use the thinking_level enum instead of the legacy
-        # integer thinking_budget and reject temperature/top_p/top_k. See
-        # _apply_thinking_config for the translation.
+        # integer thinking_budget. See _apply_thinking_config for the translation.
         self.uses_thinking_level = spec.uses_thinking_level
+        # Per-model sampling and thinking-level facts. The Gemini 3.x family is
+        # not uniform, so these come from the spec rather than one shared rule.
+        self.supports_sampling_params = spec.supports_sampling_params
+        self.allowed_thinking_levels = spec.allowed_thinking_levels
+        self.fallback_thinking_level = spec.fallback_thinking_level
 
         # Load single API key
         self.api_key = api_key or os.getenv("GEMINI_API_KEY")
@@ -601,34 +605,58 @@ class GeminiLLM(LLMInterface):
         return True
 
     # Map a legacy integer thinking_budget onto a Gemini 3.x thinking_level.
-    # (max_budget_inclusive, level). Anything larger maps to "high".
-    # "low" is the floor rather than "minimal": Gemini 3.x cannot disable
-    # thinking, and "minimal" additionally requires thought-signature handling
-    # (returns 400 without it), which this pipeline does not implement.
+    # (max_budget_inclusive, level). Anything larger maps to "high". Used only
+    # to translate a caller's budget hint; the result is then clamped to the
+    # levels the specific model accepts.
     _THINKING_LEVEL_THRESHOLDS = (
         (2048, "low"),
         (8192, "medium"),
     )
 
     def _thinking_budget_to_level(self, budget: int) -> str:
-        """Translate a legacy thinking_budget hint to a Gemini 3.x thinking_level."""
-        for max_budget, level in self._THINKING_LEVEL_THRESHOLDS:
+        """Translate a legacy thinking_budget hint to a Gemini 3.x thinking_level.
+
+        The requested level is constrained to ``allowed_thinking_levels`` for this
+        model, because the set differs per model and sending an unsupported value
+        returns 400 (gemini-3-pro rejects "medium", for example). When the model
+        declares no allowed set, the translated level is used unchanged.
+        """
+        level = "high"
+        for max_budget, candidate in self._THINKING_LEVEL_THRESHOLDS:
             if budget <= max_budget:
-                return level
-        return "high"
+                level = candidate
+                break
+
+        allowed = self.allowed_thinking_levels
+        if not allowed or level in allowed:
+            return level
+
+        # Substitute this model's fallback, then the nearest level it does
+        # accept, so a budget hint can never produce a 400.
+        if self.fallback_thinking_level and self.fallback_thinking_level in allowed:
+            return self.fallback_thinking_level
+        return allowed[-1]
 
     def _apply_thinking_config(self, config_kwargs: dict, thinking_budget) -> None:
-        """Attach thinking config and prune sampling params for the model family.
+        """Attach thinking config and prune sampling params for this model.
 
-        Gemini 3.x+ (``uses_thinking_level``): translate the integer budget to a
-        ``thinking_level`` enum and drop temperature/top_p/top_k, which those
-        models reject with 400 INVALID_ARGUMENT. Earlier Gemini models keep the
-        legacy integer ``thinking_budget``. Mutates ``config_kwargs`` in place.
+        Both behaviours come from the model's ``ModelSpec`` rather than from a
+        single Gemini-3-wide assumption, because the family is not uniform: the
+        accepted ``thinking_level`` values and the default level differ per model.
+
+        ``supports_sampling_params=False`` drops temperature/top_p/top_k. Gemini
+        3.x deprecated them, the API ignores them today, and future generations
+        return 400. Dropping them here means a caller asking for temperature=0
+        is not silently told it took effect. Models that still honour the
+        sampling params keep them. Mutates ``config_kwargs`` in place.
         """
-        if self.uses_thinking_level:
-            # These are rejected / no longer supported by Gemini 3.x.
+        if not self.supports_sampling_params:
             for stale in ("temperature", "top_p", "top_k"):
                 config_kwargs.pop(stale, None)
+
+        if self.uses_thinking_level:
+            # No budget means no thinking_config, same as before: let the model
+            # apply its own default rather than pinning a level here.
             if thinking_budget is not None:
                 config_kwargs["thinking_config"] = self.types.ThinkingConfig(
                     thinking_level=self._thinking_budget_to_level(thinking_budget)

--- a/schematiq-lib/schematiq/core/model_specs.py
+++ b/schematiq-lib/schematiq/core/model_specs.py
@@ -24,10 +24,26 @@ class ModelSpec:
     max_output_tokens: int
     supports_thinking: bool = False
     # Gemini 3.x+ models replace the integer ``thinking_budget`` with the
-    # semantic ``thinking_level`` enum and reject the legacy sampling params
-    # (temperature/top_p/top_k). Sending the old parameters returns
-    # 400 INVALID_ARGUMENT. True selects the thinking_level code path.
+    # semantic ``thinking_level`` enum. They also deprecated the sampling
+    # params (temperature/top_p/top_k): the API silently ignores them today
+    # and returns 400 in future model generations, so they must not be sent.
+    # See https://ai.google.dev/gemini-api/docs/latest-model
     uses_thinking_level: bool = False
+    # Whether the provider still honours temperature/top_p/top_k. When False the
+    # values are dropped before the request rather than sent and ignored, so a
+    # caller asking for temperature=0 is never quietly told it worked.
+    supports_sampling_params: bool = True
+    # Thinking levels this pipeline may send to this model. Sending a level the
+    # model does not accept returns 400 (gemini-3.1-pro-preview rejects the
+    # medium level). This is the *sendable* set, not everything the model
+    # supports: the minimal level is deliberately excluded everywhere because it
+    # requires thought-signature handling that this pipeline does not implement.
+    # Empty means no constraint is known and the translated level is used as is.
+    allowed_thinking_levels: tuple = ()
+    # Level substituted when the translated level is not in the sendable set.
+    # Only a clamp target. It is never sent on its own when the caller passes no
+    # thinking_budget, so omitting a budget still means "let the server decide".
+    fallback_thinking_level: Optional[str] = None
 
 
 # ── Canonical model names ───────────────────────────────────────────
@@ -73,13 +89,42 @@ class ModelNames:
 # ── Model specifications ────────────────────────────────────────────
 MODEL_SPECS: Dict[str, Dict[str, ModelSpec]] = {
     "gemini": {
+        # Gemini 2.5: legacy integer thinking_budget, sampling params still honoured.
         ModelNames.GEMINI_25_FLASH: ModelSpec(1_048_576, 65_535, supports_thinking=True),
         ModelNames.GEMINI_25_FLASH_LITE: ModelSpec(1_048_576, 65_535, supports_thinking=True),
-        ModelNames.GEMINI_31_FLASH_LITE: ModelSpec(1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True),
-        ModelNames.GEMINI_35_FLASH: ModelSpec(1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True),
-        ModelNames.GEMINI_36_FLASH: ModelSpec(1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True),
-        ModelNames.GEMINI_35_FLASH_LITE: ModelSpec(1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True),
-        ModelNames.GEMINI_31_PRO_PREVIEW: ModelSpec(1_000_000, 64_000, supports_thinking=True, uses_thinking_level=True),
+        # Gemini 3.x: thinking_level enum, sampling params deprecated and ignored.
+        # Defaults per https://ai.google.dev/gemini-api/docs/latest-model
+        ModelNames.GEMINI_31_FLASH_LITE: ModelSpec(
+            1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True,
+            supports_sampling_params=False,
+            allowed_thinking_levels=("low", "medium", "high"),
+            fallback_thinking_level="low",
+        ),
+        ModelNames.GEMINI_35_FLASH: ModelSpec(
+            1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True,
+            supports_sampling_params=False,
+            allowed_thinking_levels=("low", "medium", "high"),
+            fallback_thinking_level="medium",
+        ),
+        ModelNames.GEMINI_36_FLASH: ModelSpec(
+            1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True,
+            supports_sampling_params=False,
+            allowed_thinking_levels=("low", "medium", "high"),
+            fallback_thinking_level="medium",
+        ),
+        ModelNames.GEMINI_35_FLASH_LITE: ModelSpec(
+            1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True,
+            supports_sampling_params=False,
+            allowed_thinking_levels=("low", "medium", "high"),
+            fallback_thinking_level="low",
+        ),
+        # Pro rejects "medium" (400 INVALID_ARGUMENT); low/high only.
+        ModelNames.GEMINI_31_PRO_PREVIEW: ModelSpec(
+            1_000_000, 64_000, supports_thinking=True, uses_thinking_level=True,
+            supports_sampling_params=False,
+            allowed_thinking_levels=("low", "high"),
+            fallback_thinking_level="high",
+        ),
         "_default": ModelSpec(1_000_000, 32_000, supports_thinking=False),
     },
     "openai": {


### PR DESCRIPTION
## Problem
Two behaviours were decided by one Gemini-3-wide assumption instead of per model.

`_THINKING_LEVEL_THRESHOLDS` mapped a thinking_budget to a level with a single global table, ignoring which levels each model accepts. `gemini-3.1-pro-preview` accepts only low and high, so a budget of 2049-8192 produced `medium` and a 400 INVALID_ARGUMENT.

Sampling-param pruning was tied to `uses_thinking_level`, so the two facts could not diverge. Per https://ai.google.dev/gemini-api/docs/latest-model temperature/top_p/top_k are deprecated for Gemini 3.x: ignored today, 400 in future generations. Pre-3.x Gemini and other providers still honour them.

## Solution
Add `supports_sampling_params`, `allowed_thinking_levels` and `fallback_thinking_level` to `ModelSpec` and read both behaviours from there. A translated level outside the sendable set is clamped rather than sent.

The minimal level stays out of every sendable set, preserving the existing note that it needs thought-signature handling this pipeline does not implement and returns 400 without it.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone of main
- `python -m py_compile` on both files
- Behaviour matrix of 8 models x 5 thinking_budget values (0, 1024, 4096, 32768, None) diffed against main: 1 of 40 cells changed, `gemini-3.1-pro-preview` at budget 4096 now sends high instead of the rejected medium. Gemini 2.5 still receives temperature and the integer budget; no budget still sends no thinking_config
- No frontend files touched