### PR TITLE
fix(llm): classify provider errors by HTTP status code, retry 500/504

### DIFF
--- a/schematiq-lib/schematiq/core/llm_backends.py
+++ b/schematiq-lib/schematiq/core/llm_backends.py
@@ -24,8 +24,37 @@ logger = logging.getLogger(__name__)
 # Rate limit retry utilities                                                 #
 ##############################################################################
 
-def _is_rate_limit_error(error_str: str) -> bool:
-    """Check if error is a rate limit / quota error (provider-side)."""
+_RATE_LIMIT_STATUS_CODE = 429
+# Transient failures worth retrying with a fixed backoff. 429 is excluded
+# because it is classified separately and uses the provider's own retry hint.
+_TRANSIENT_STATUS_CODES = frozenset({408, 500, 502, 503, 504})
+_AUTH_STATUS_CODES = frozenset({401, 403})
+
+
+def _status_code(error: BaseException) -> Optional[int]:
+    """Return the HTTP status code a provider SDK error carries, if any.
+
+    ``google.genai.errors.APIError`` exposes it as ``code``, the OpenAI SDK as
+    ``status_code``. Unrelated exception types may also define a ``code``
+    attribute, so only plausible HTTP error values are accepted; anything else
+    returns None and the caller falls back to matching the message text.
+    """
+    for attr in ("code", "status_code"):
+        value = getattr(error, attr, None)
+        if isinstance(value, int) and 400 <= value < 600:
+            return value
+    return None
+
+
+def _is_rate_limit_error(error: BaseException) -> bool:
+    """Check if error is a rate limit / quota error (provider-side).
+
+    The status code is authoritative when the SDK exposes one; the text checks
+    remain for exceptions that do not (transport errors, wrapped exceptions).
+    """
+    if _status_code(error) == _RATE_LIMIT_STATUS_CODE:
+        return True
+    error_str = str(error)
     el = error_str.lower()
     if "429" in error_str and (
         "rate" in el or "quota" in el or "limit" in el or "exhausted" in el
@@ -38,8 +67,16 @@ def _is_rate_limit_error(error_str: str) -> bool:
         return True
     return False
 
-def _is_server_overloaded_error(error_str: str) -> bool:
-    """Check if error is a server overloaded/unavailable error (503)."""
+def _is_retryable_server_error(error: BaseException) -> bool:
+    """Check if error is a transient server-side failure worth retrying.
+
+    Any 408/5xx from the provider qualifies, regardless of message wording:
+    500 INTERNAL and 504 DEADLINE_EXCEEDED are as transient as 503 UNAVAILABLE.
+    The 503 text match stays as a fallback for exceptions with no status code.
+    """
+    if _status_code(error) in _TRANSIENT_STATUS_CODES:
+        return True
+    error_str = str(error)
     if "503" not in error_str:
         return False
     error_lower = error_str.lower()
@@ -49,13 +86,16 @@ def _is_server_overloaded_error(error_str: str) -> bool:
     ])
 
 
-def _is_invalid_api_key_error(error_str: str) -> bool:
-    """Check if error indicates a malformed or invalid API key.
+def _is_invalid_api_key_error(error: BaseException) -> bool:
+    """Check if error indicates a malformed, invalid, or rejected API key.
 
     These errors occur when the API key has invalid characters, is corrupted,
     or is otherwise malformed. The key should be permanently marked as invalid.
+    A 401/403 is treated the same way: the request will never succeed on retry.
     """
-    error_lower = error_str.lower()
+    if _status_code(error) in _AUTH_STATUS_CODES:
+        return True
+    error_lower = str(error).lower()
 
     # gRPC plugin credential errors (malformed key with illegal characters)
     if "illegal header value" in error_lower or "invalid metadata" in error_lower:
@@ -215,7 +255,7 @@ class TogetherLLM(LLMInterface):
                 last_exception = e
                 
                 # Check if this is a retryable error
-                if _is_rate_limit_error(error_str):
+                if _is_rate_limit_error(e):
                     if attempt < max_retries:
                         wait_time = _extract_wait_time(error_str)
                         print(f"🚦 Rate limit hit (attempt {attempt + 1}/{max_retries + 1}). Waiting {wait_time}s before retry...")
@@ -223,14 +263,14 @@ class TogetherLLM(LLMInterface):
                         continue
                     else:
                         print(f"❌ Rate limit error after {max_retries} retries: {error_str}")
-                elif _is_server_overloaded_error(error_str):
+                elif _is_retryable_server_error(e):
                     if attempt < max_retries:
                         wait_time = 10 + random.randint(5, 15)
-                        print(f"🔄 Server overloaded (attempt {attempt + 1}/{max_retries + 1}). Waiting {wait_time}s before retry...")
+                        print(f"🔄 Transient provider error (attempt {attempt + 1}/{max_retries + 1}). Waiting {wait_time}s before retry...")
                         time.sleep(wait_time)
                         continue
                     else:
-                        print(f"❌ Server overloaded error after {max_retries} retries: {error_str}")
+                        print(f"❌ Transient provider error after {max_retries} retries: {error_str}")
                 else:
                     # Not a retryable error, don't retry
                     break
@@ -326,7 +366,7 @@ class OpenAILLM(LLMInterface):
                 last_exception = e
                 
                 # Check if this is a retryable error
-                if _is_rate_limit_error(error_str):
+                if _is_rate_limit_error(e):
                     if attempt < max_retries:
                         wait_time = _extract_wait_time(error_str)
                         print(f"🚦 Rate limit hit (attempt {attempt + 1}/{max_retries + 1}). Waiting {wait_time}s before retry...")
@@ -334,14 +374,14 @@ class OpenAILLM(LLMInterface):
                         continue
                     else:
                         print(f"❌ Rate limit error after {max_retries} retries: {error_str}")
-                elif _is_server_overloaded_error(error_str):
+                elif _is_retryable_server_error(e):
                     if attempt < max_retries:
                         wait_time = 10 + random.randint(5, 15)
-                        print(f"🔄 Server overloaded (attempt {attempt + 1}/{max_retries + 1}). Waiting {wait_time}s before retry...")
+                        print(f"🔄 Transient provider error (attempt {attempt + 1}/{max_retries + 1}). Waiting {wait_time}s before retry...")
                         time.sleep(wait_time)
                         continue
                     else:
-                        print(f"❌ Server overloaded error after {max_retries} retries: {error_str}")
+                        print(f"❌ Transient provider error after {max_retries} retries: {error_str}")
                 else:
                     # Not a retryable error, don't retry
                     break
@@ -808,12 +848,12 @@ class GeminiLLM(LLMInterface):
                     return "Response blocked by Gemini safety filters. Please try rephrasing your request."
 
                 # Check for invalid/malformed API key errors - don't retry
-                if _is_invalid_api_key_error(error_str):
+                if _is_invalid_api_key_error(e):
                     print(f"Invalid/malformed API key: {error_str[:200]}")
                     raise
 
                 # Check if this is a retryable error
-                if _is_rate_limit_error(error_str):
+                if _is_rate_limit_error(e):
                     if attempt < max_retries:
                         wait_time = _extract_wait_time(error_str)
                         snippet = error_str.replace("\n", " ")[:280]
@@ -833,14 +873,14 @@ class GeminiLLM(LLMInterface):
                             f"Last error: {snippet}",
                             flush=True,
                         )
-                elif _is_server_overloaded_error(error_str):
+                elif _is_retryable_server_error(e):
                     if attempt < max_retries:
                         wait_time = 10 + random.randint(5, 15)
-                        print(f"Server overloaded (attempt {attempt + 1}/{max_retries + 1}). Waiting {wait_time}s before retry...")
+                        print(f"Transient provider error (attempt {attempt + 1}/{max_retries + 1}). Waiting {wait_time}s before retry...")
                         time.sleep(wait_time)
                         continue
                     else:
-                        print(f"Server overloaded error after {max_retries} retries: {error_str}")
+                        print(f"Transient provider error after {max_retries} retries: {error_str}")
                 else:
                     # Not a retryable error, don't retry
                     break
@@ -981,9 +1021,9 @@ class GeminiLLM(LLMInterface):
 
                 if "Invalid operation" in error_str and "finish_reason" in error_str:
                     return "Response blocked by Gemini safety filters."
-                if _is_invalid_api_key_error(error_str):
+                if _is_invalid_api_key_error(e):
                     raise
-                if _is_rate_limit_error(error_str):
+                if _is_rate_limit_error(e):
                     if attempt < max_retries:
                         wait_time = _extract_wait_time(error_str)
                         snippet = error_str.replace("\n", " ")[:280]
@@ -1001,10 +1041,10 @@ class GeminiLLM(LLMInterface):
                         f"provider quota/RPM (not app LLM_CALL_GLOBAL_LIMIT). Last error: {snippet}",
                         flush=True,
                     )
-                elif _is_server_overloaded_error(error_str):
+                elif _is_retryable_server_error(e):
                     if attempt < max_retries:
                         wait_time = 10 + random.randint(5, 15)
-                        print(f"Server overloaded (attempt {attempt + 1}/{max_retries + 1}). Waiting {wait_time}s...")
+                        print(f"Transient provider error (attempt {attempt + 1}/{max_retries + 1}). Waiting {wait_time}s...")
                         time.sleep(wait_time)
                         continue
                 else:

--- a/schematiq-lib/tests/test_llm_error_classification.py
+++ b/schematiq-lib/tests/test_llm_error_classification.py
@@ -1,0 +1,103 @@
+"""Tests for provider-error classification in the LLM retry loops.
+
+Classification drives whether a failed call is retried, so it is checked here
+against real ``google.genai`` exception objects rather than crafted strings.
+"""
+
+import pytest
+
+from schematiq.core.llm_backends import (
+    _is_invalid_api_key_error,
+    _is_rate_limit_error,
+    _is_retryable_server_error,
+    _status_code,
+)
+
+errors = pytest.importorskip("google.genai.errors")
+
+
+def api_error(code: int, status: str, message: str = "boom"):
+    """Build the APIError subclass the SDK would raise for *code*."""
+    with pytest.raises(errors.APIError) as excinfo:
+        errors.APIError.raise_error(
+            code,
+            {"error": {"code": code, "status": status, "message": message}},
+            None,
+        )
+    return excinfo.value
+
+
+class TestStatusCode:
+    def test_reads_code_from_genai_error(self):
+        assert _status_code(api_error(429, "RESOURCE_EXHAUSTED")) == 429
+
+    def test_reads_status_code_attribute(self):
+        class OpenAIStyleError(Exception):
+            status_code = 500
+
+        assert _status_code(OpenAIStyleError("boom")) == 500
+
+    def test_ignores_unrelated_code_attribute(self):
+        # A non-HTTP ``code`` must not be mistaken for a status.
+        class Weird(Exception):
+            code = 7
+
+        assert _status_code(Weird("boom")) is None
+        assert _status_code(ValueError("boom")) is None
+
+
+class TestRateLimit:
+    def test_genai_429(self):
+        assert _is_rate_limit_error(api_error(429, "RESOURCE_EXHAUSTED"))
+
+    def test_text_fallback_without_status_code(self):
+        assert _is_rate_limit_error(RuntimeError("429 quota exceeded"))
+        assert _is_rate_limit_error(RuntimeError("RESOURCE_EXHAUSTED"))
+
+    def test_other_codes_are_not_rate_limits(self):
+        assert not _is_rate_limit_error(api_error(503, "UNAVAILABLE"))
+        assert not _is_rate_limit_error(ValueError("bad schema"))
+
+
+class TestRetryableServerError:
+    @pytest.mark.parametrize(
+        "code,status",
+        [
+            (408, "REQUEST_TIMEOUT"),
+            (500, "INTERNAL"),
+            (502, "BAD_GATEWAY"),
+            (503, "UNAVAILABLE"),
+            (504, "DEADLINE_EXCEEDED"),
+        ],
+    )
+    def test_transient_codes_are_retryable(self, code, status):
+        assert _is_retryable_server_error(api_error(code, status))
+
+    def test_500_is_retryable_without_matching_wording(self):
+        # Previously required the literal "503" in the message, so a 500 with
+        # an unrecognised message was never retried.
+        assert _is_retryable_server_error(api_error(500, "INTERNAL", "unexpected"))
+
+    def test_text_fallback_without_status_code(self):
+        assert _is_retryable_server_error(RuntimeError("503 model is overloaded"))
+
+    def test_client_errors_are_not_retryable(self):
+        assert not _is_retryable_server_error(api_error(400, "INVALID_ARGUMENT"))
+        assert not _is_retryable_server_error(api_error(429, "RESOURCE_EXHAUSTED"))
+
+
+class TestInvalidApiKey:
+    @pytest.mark.parametrize("code", [401, 403])
+    def test_auth_codes(self, code):
+        assert _is_invalid_api_key_error(api_error(code, "PERMISSION_DENIED"))
+
+    def test_text_fallback_for_400_with_bad_key(self):
+        assert _is_invalid_api_key_error(
+            api_error(400, "INVALID_ARGUMENT", "API key not valid. Pass a valid key.")
+        )
+
+    def test_malformed_key_without_status_code(self):
+        assert _is_invalid_api_key_error(ValueError("Illegal header value b'key\\n'"))
+
+    def test_transient_errors_are_not_key_errors(self):
+        assert not _is_invalid_api_key_error(api_error(503, "UNAVAILABLE"))


### PR DESCRIPTION
## Problem

Retry classification in `llm_backends.py` matched substrings in `str(exception)`. Two consequences:

1. `_is_server_overloaded_error` required the literal `"503"` in the message, so a transient `500 INTERNAL` or `504 DEADLINE_EXCEEDED` from Gemini was never retried. It broke out of the loop and failed the run.
2. Classification depended on provider message wording, so a rephrasing on Google's side could silently stop a 429 or 503 from being retried.

`google.genai.errors.APIError` already exposes `code`, `status`, `message`, and `details`. `backend/app/services/pipeline/error_reporting.py` reads those attributes; the retry path did not.

## Solution

- Add `_status_code(error)`: reads `.code` (google-genai) or `.status_code` (OpenAI), accepting only values in 400-599 so an unrelated `code` attribute is not mistaken for an HTTP status.
- The three classifiers now take the exception instead of its string form and check the status code first, falling back to the existing text heuristics when no code is present. Superset semantics: nothing classified correctly today stops being classified.
- `_is_server_overloaded_error` -> `_is_retryable_server_error`, covering 408/500/502/503/504.
- 401/403 are treated as key errors and are not retried.
- Retry log lines say "Transient provider error" instead of "Server overloaded", which is no longer accurate for a 500.

Behavior change: 500/502/504 now retry up to 3 times with a 10-25s wait. A genuinely broken request takes about a minute longer to fail; transient provider blips now recover.

Scope note: the classifiers are shared with `TogetherLLM` and `OpenAILLM`, so those paths gain the same retry coverage. Release mode is locked to Gemini, so production is unaffected.

Not in this PR: parsing `retryDelay` out of `APIError.details` (the current regexes do not match the new SDK's JSON shape, so a 429 always uses the 45s/90s default), and replacing the manual loop with the SDK's own `types.HttpRetryOptions`. Both are separate changes.

## Verify

- `python -m py_compile schematiq-lib/schematiq/core/llm_backends.py schematiq-lib/tests/test_llm_error_classification.py`
- `( cd schematiq-lib && python -m pytest tests/test_llm_error_classification.py -q )` — 19 tests, built against real `ClientError`/`ServerError` objects from the SDK rather than crafted strings
- Full `schematiq-lib` suite shows no new failures
- No frontend files touched