### PR TITLE
fix(llm): honor provider RetryInfo delay and retry transport failures

### DIFF
--- a/schematiq-lib/schematiq/core/llm_backends.py
+++ b/schematiq-lib/schematiq/core/llm_backends.py
@@ -14,6 +14,8 @@ from abc import ABC, abstractmethod
 from typing import List, Dict, Any, Union, Optional
 import re
 
+import httpx
+
 from schematiq.core.model_specs import get_model_spec, get_max_output_tokens, ModelNames
 from schematiq.core.llm_call_tracker import LLMCallTracker
 
@@ -29,6 +31,10 @@ _RATE_LIMIT_STATUS_CODE = 429
 # because it is classified separately and uses the provider's own retry hint.
 _TRANSIENT_STATUS_CODES = frozenset({408, 500, 502, 503, 504})
 _AUTH_STATUS_CODES = frozenset({401, 403})
+# Transport failures carry no HTTP status, so they need their own check. These
+# are the two the google-genai client retries internally, and generation is a
+# read-only call, so replaying it has no side effect beyond the token cost.
+_TRANSPORT_RETRY_ERRORS = (httpx.TimeoutException, httpx.ConnectError)
 
 
 def _status_code(error: BaseException) -> Optional[int]:
@@ -72,9 +78,13 @@ def _is_retryable_server_error(error: BaseException) -> bool:
 
     Any 408/5xx from the provider qualifies, regardless of message wording:
     500 INTERNAL and 504 DEADLINE_EXCEEDED are as transient as 503 UNAVAILABLE.
-    The 503 text match stays as a fallback for exceptions with no status code.
+    Timeouts and connection failures qualify as well, since they carry no status
+    code and would otherwise be treated as permanent. The 503 text match stays
+    as a fallback for exceptions with neither a status code nor an httpx type.
     """
     if _status_code(error) in _TRANSIENT_STATUS_CODES:
+        return True
+    if isinstance(error, _TRANSPORT_RETRY_ERRORS):
         return True
     error_str = str(error)
     if "503" not in error_str:
@@ -110,33 +120,85 @@ def _is_invalid_api_key_error(error: BaseException) -> bool:
 
     return any(indicator in error_lower for indicator in invalid_key_indicators)
 
-def _extract_wait_time(error_str: str) -> int:
-    """Extract wait time from rate limit error or return default."""
-    # Try to extract actual retry delay from Gemini error
-    retry_match = re.search(r"retry in ([\d.]+)s", error_str.lower())
+_MIN_RETRY_WAIT_SECONDS = 10
+_MAX_RETRY_WAIT_SECONDS = 120
+# google.rpc.RetryInfo in JSON form; snake_case appears in gRPC-style payloads.
+_RETRY_DELAY_KEYS = ("retryDelay", "retry_delay")
+# A protobuf Duration serialized as JSON, e.g. "54s" or "1.5s".
+_DURATION_RE = re.compile(r"\s*(\d+(?:\.\d+)?)s?\s*")
+
+
+def _clamp_wait(seconds: float) -> int:
+    """Keep a retry wait within sane bounds.
+
+    A malformed or extreme hint should not produce a near-instant retry that
+    burns an attempt, nor stall a request for hours. The bounds are wide enough
+    that they never bind on the fallback paths below.
+    """
+    return int(min(max(seconds, _MIN_RETRY_WAIT_SECONDS), _MAX_RETRY_WAIT_SECONDS))
+
+
+def _parse_duration(value: Any) -> Optional[float]:
+    """Parse a protobuf Duration in its JSON form. Returns None if unparseable."""
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    if isinstance(value, str):
+        match = _DURATION_RE.fullmatch(value)
+        if match:
+            return float(match.group(1))
+    return None
+
+
+def _retry_delay_from_details(error: BaseException) -> Optional[float]:
+    """Read the provider's own retry delay from a structured error payload.
+
+    A 429 carries ``google.rpc.RetryInfo`` inside ``APIError.details``, which is
+    the API telling us exactly when the quota window reopens. The nesting depth
+    varies by transport, so the payload is walked rather than indexed by a fixed
+    path. Returns None when no delay is present.
+    """
+    stack = [getattr(error, "details", None)]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, dict):
+            for key in _RETRY_DELAY_KEYS:
+                seconds = _parse_duration(node.get(key))
+                if seconds is not None:
+                    return seconds
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+    return None
+
+
+def _extract_wait_time(error: BaseException) -> int:
+    """Seconds to wait before retrying a rate-limited request.
+
+    The provider's RetryInfo wins when present. The text patterns below remain
+    for SDKs that only put the delay in the message, and the fixed defaults are
+    the last resort.
+    """
+    provider_delay = _retry_delay_from_details(error)
+    if provider_delay is not None:
+        # Small buffer so the retry lands after the window reopens, not on it.
+        return _clamp_wait(provider_delay + random.randint(5, 10))
+
+    error_str = str(error)
+
+    retry_match = re.search(r"retry in (\d+(?:\.\d+)?)s", error_str.lower())
     if retry_match:
-        try:
-            retry_seconds = float(retry_match.group(1))
-            # Add small buffer to avoid immediate retry
-            return int(retry_seconds) + random.randint(5, 10)
-        except (ValueError, IndexError):
-            pass
-    
-    # Try to extract from retry_delay field 
+        return _clamp_wait(float(retry_match.group(1)) + random.randint(5, 10))
+
     delay_match = re.search(r"retry_delay.*?seconds:\s*(\d+)", error_str)
     if delay_match:
-        try:
-            delay_seconds = int(delay_match.group(1))
-            return delay_seconds + random.randint(5, 10)
-        except (ValueError, IndexError):
-            pass
-    
+        return _clamp_wait(int(delay_match.group(1)) + random.randint(5, 10))
+
     # For per-minute limits, default to longer wait
     if "per minute" in error_str.lower():
-        return 90 + random.randint(5, 15)
-    
+        return _clamp_wait(90 + random.randint(5, 15))
+
     # Default fallback
-    return 45 + random.randint(5, 15)
+    return _clamp_wait(45 + random.randint(5, 15))
 
 ##############################################################################
 # Base class (copied from scaffold for convenience – delete if already there)
@@ -257,7 +319,7 @@ class TogetherLLM(LLMInterface):
                 # Check if this is a retryable error
                 if _is_rate_limit_error(e):
                     if attempt < max_retries:
-                        wait_time = _extract_wait_time(error_str)
+                        wait_time = _extract_wait_time(e)
                         print(f"🚦 Rate limit hit (attempt {attempt + 1}/{max_retries + 1}). Waiting {wait_time}s before retry...")
                         time.sleep(wait_time)
                         continue
@@ -368,7 +430,7 @@ class OpenAILLM(LLMInterface):
                 # Check if this is a retryable error
                 if _is_rate_limit_error(e):
                     if attempt < max_retries:
-                        wait_time = _extract_wait_time(error_str)
+                        wait_time = _extract_wait_time(e)
                         print(f"🚦 Rate limit hit (attempt {attempt + 1}/{max_retries + 1}). Waiting {wait_time}s before retry...")
                         time.sleep(wait_time)
                         continue
@@ -855,7 +917,7 @@ class GeminiLLM(LLMInterface):
                 # Check if this is a retryable error
                 if _is_rate_limit_error(e):
                     if attempt < max_retries:
-                        wait_time = _extract_wait_time(error_str)
+                        wait_time = _extract_wait_time(e)
                         snippet = error_str.replace("\n", " ")[:280]
                         print(
                             f"[Gemini rate limit] attempt {attempt + 1}/{max_retries + 1}, "
@@ -1025,7 +1087,7 @@ class GeminiLLM(LLMInterface):
                     raise
                 if _is_rate_limit_error(e):
                     if attempt < max_retries:
-                        wait_time = _extract_wait_time(error_str)
+                        wait_time = _extract_wait_time(e)
                         snippet = error_str.replace("\n", " ")[:280]
                         print(
                             f"[Gemini rate limit/cached] attempt {attempt + 1}/{max_retries + 1}, "

--- a/schematiq-lib/tests/test_llm_error_classification.py
+++ b/schematiq-lib/tests/test_llm_error_classification.py
@@ -7,6 +7,9 @@ against real ``google.genai`` exception objects rather than crafted strings.
 import pytest
 
 from schematiq.core.llm_backends import (
+    _MAX_RETRY_WAIT_SECONDS,
+    _MIN_RETRY_WAIT_SECONDS,
+    _extract_wait_time,
     _is_invalid_api_key_error,
     _is_rate_limit_error,
     _is_retryable_server_error,
@@ -16,15 +19,28 @@ from schematiq.core.llm_backends import (
 errors = pytest.importorskip("google.genai.errors")
 
 
-def api_error(code: int, status: str, message: str = "boom"):
+def api_error(code: int, status: str, message: str = "boom", details=None):
     """Build the APIError subclass the SDK would raise for *code*."""
+    error_body = {"code": code, "status": status, "message": message}
+    if details is not None:
+        error_body["details"] = details
     with pytest.raises(errors.APIError) as excinfo:
-        errors.APIError.raise_error(
-            code,
-            {"error": {"code": code, "status": status, "message": message}},
-            None,
-        )
+        errors.APIError.raise_error(code, {"error": error_body}, None)
     return excinfo.value
+
+
+def rate_limited(retry_delay=None):
+    """A 429 carrying google.rpc.RetryInfo, as the API returns it."""
+    details = None
+    if retry_delay is not None:
+        details = [
+            {"@type": "type.googleapis.com/google.rpc.QuotaFailure", "violations": []},
+            {
+                "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                "retryDelay": retry_delay,
+            },
+        ]
+    return api_error(429, "RESOURCE_EXHAUSTED", "quota exceeded", details)
 
 
 class TestStatusCode:
@@ -81,6 +97,11 @@ class TestRetryableServerError:
     def test_text_fallback_without_status_code(self):
         assert _is_retryable_server_error(RuntimeError("503 model is overloaded"))
 
+    def test_transport_failures_are_retryable(self):
+        httpx = pytest.importorskip("httpx")
+        assert _is_retryable_server_error(httpx.ReadTimeout("timed out"))
+        assert _is_retryable_server_error(httpx.ConnectError("refused"))
+
     def test_client_errors_are_not_retryable(self):
         assert not _is_retryable_server_error(api_error(400, "INVALID_ARGUMENT"))
         assert not _is_retryable_server_error(api_error(429, "RESOURCE_EXHAUSTED"))
@@ -101,3 +122,38 @@ class TestInvalidApiKey:
 
     def test_transient_errors_are_not_key_errors(self):
         assert not _is_invalid_api_key_error(api_error(503, "UNAVAILABLE"))
+
+
+class TestExtractWaitTime:
+    def test_uses_provider_retry_delay(self):
+        # 54s + a 5-10s buffer.
+        wait = _extract_wait_time(rate_limited("54s"))
+        assert 59 <= wait <= 64
+
+    def test_fractional_duration(self):
+        wait = _extract_wait_time(rate_limited("0.5s"))
+        # Below the floor, so clamped up rather than retried almost immediately.
+        assert wait == _MIN_RETRY_WAIT_SECONDS
+
+    def test_extreme_delay_is_capped(self):
+        assert _extract_wait_time(rate_limited("86400s")) == _MAX_RETRY_WAIT_SECONDS
+
+    def test_unparseable_delay_falls_back_to_default(self):
+        wait = _extract_wait_time(rate_limited("later"))
+        assert 50 <= wait <= 60
+
+    def test_default_when_no_details(self):
+        wait = _extract_wait_time(rate_limited())
+        assert 50 <= wait <= 60
+
+    def test_per_minute_message_waits_longer(self):
+        wait = _extract_wait_time(RuntimeError("429 quota exceeded per minute"))
+        assert 95 <= wait <= 105
+
+    def test_text_retry_hint(self):
+        wait = _extract_wait_time(RuntimeError("Please retry in 30s"))
+        assert 35 <= wait <= 40
+
+    def test_malformed_text_hint_does_not_raise(self):
+        wait = _extract_wait_time(RuntimeError("retry in 1.2.3s"))
+        assert 50 <= wait <= 60


### PR DESCRIPTION
## Problem

Follow-up to #413. Two gaps remained in the Gemini retry path.

**1. The provider's retry delay is never used.** `_extract_wait_time` matched `"retry in 54s"` and `"retry_delay { seconds: 54 }"` in the message text. The google-genai SDK emits neither: a 429 carries `google.rpc.RetryInfo` as `{"retryDelay": "54s"}` inside `APIError.details`. The `"per minute"` branch does not fire either, because Google's quota id is `GenerateRequestsPerMinutePerProjectPerModel` with no spaces. Every 429 therefore fell through to the fixed 45s+jitter default, ignoring what the API told us.

**2. Transport failures are treated as permanent.** A read timeout or refused connection has no HTTP status and no `"503"` in its message, so it fell through to `break` and failed the run on the first occurrence. The SDK's own retry predicate covers `httpx.TimeoutException` and `httpx.ConnectError`; our loop did not.

## Solution

- `_extract_wait_time` now takes the exception. `_retry_delay_from_details` walks `APIError.details` for a `retryDelay`/`retry_delay` key at any depth, since the nesting differs by transport, and `_parse_duration` reads the JSON Duration form (`"54s"`, `"1.5s"`, or a bare number).
- `_clamp_wait` bounds every path to 10-120s, so a small or malformed hint cannot cause a near-instant retry that burns an attempt, and an extreme one cannot stall a request. The existing paths produce 50-60s and 95-105s, so the bounds never bind on them: no behavior change where the delay was already a guess.
- The two message regexes are tightened from `([\\d.]+)` to `(\\d+(?:\\.\\d+)?)`, which removes the two `try/except ValueError` blocks around the conversions.
- `_is_retryable_server_error` also returns True for `httpx.TimeoutException` and `httpx.ConnectError` — the same two the SDK retries, not all of `TransportError`. Generation is a read-only call, so replaying it has no side effect beyond token cost.
- `import httpx` is unguarded: `google-genai>=1.0.0` is a hard dependency in `schematiq-lib/pyproject.toml` and requires httpx.

Considered and rejected: replacing the manual loop with the SDK's `types.HttpRetryOptions`. Its implementation is `tenacity.wait_exponential_jitter` capped at 60s with no reference to Retry-After or RetryInfo, so it would discard the delay this PR starts honoring.

## Verify

- `python -m py_compile schematiq-lib/schematiq/core/llm_backends.py schematiq-lib/tests/test_llm_error_classification.py`
- `( cd schematiq-lib && python -m pytest tests/test_llm_error_classification.py -q )` — 28 tests, 9 new, built against real SDK error objects with a RetryInfo payload
- Test suite run 40 times consecutively to rule out flakiness from the jitter in the wait calculation
- Full `schematiq-lib` suite shows no new failures
- No frontend files touched