### PR TITLE
docs(privacy): describe operational storage separately from the research archive

### DIFF
--- a/privacy_policy.md
+++ b/privacy_policy.md
@@ -1,7 +1,7 @@
 
 # Privacy Policy — ScheMatiQ Research Data Collection
 
-**Last Updated:** February 2026
+**Last Updated:** August 2026
 
 ## Who We Are
 
@@ -20,8 +20,10 @@ When you use ScheMatiQ in its public deployment, we may collect the following da
 ## What We Do NOT Collect
 
 - API keys or authentication credentials.
-- Your IP address, browser fingerprint, or device identifiers.
 - Any account or login information (ScheMatiQ does not require accounts).
+- Browser fingerprints or device identifiers.
+
+Note that our hosting provider records standard web server logs for the service, which include the IP address of incoming requests, the pages requested, and the browser user-agent string. These logs are a byproduct of operating the service, are not used for research, and are not linked to your session contents.
 
 ## Purpose
 
@@ -33,7 +35,19 @@ The collected data is used solely for **open academic research** on query-based 
 
 ## How Data Is Stored
 
-Session data is bundled into a ZIP archive and uploaded to a private Google Drive folder accessible only to the research team. An optional summary row may be logged to a Google Sheet for tracking purposes.
+Your data is stored in two separate places for two different reasons. The distinction matters, because your research opt-out applies to one of them and not the other.
+
+**1. Operational storage — so the tool works for you.**
+
+Your project (your query, the discovered schema, the extracted table, and your uploaded documents) is stored in our cloud storage provider, Supabase, on servers operated on our behalf. This is what allows you to close the tab and come back to your project later, and to keep your table when we deploy an update. Without it your work would be lost whenever our server restarts.
+
+This storage is part of delivering the tool and happens whether or not you opt out of research data collection. It is not used for research.
+
+**2. Research archive — so we can study the system.**
+
+Separately, a copy of your session is bundled into a ZIP archive and uploaded to a private Google Drive folder accessible only to the research team. A summary row is also recorded in a private Google Sheet.
+
+**This is the copy your opt-out controls.** If you opt out, no ZIP archive is created and nothing is uploaded to Google Drive.
 
 ## Identifying Information
 
@@ -41,12 +55,21 @@ We do not intentionally collect personal identifiers. However, the content of yo
 
 ## Your Choices
 
-- **Opt out of data collection:** When you click "Start ScheMatiQ," a consent dialog will appear. You can check the **"Do not share my data for research purposes"** box to prevent your session data from being archived. Your session will work identically — the only difference is that no data is sent to Google Drive.
+- **Opt out of research data collection:** When you click "Start ScheMatiQ," a consent dialog will appear. You can check the **"Do not share my data for research purposes"** box. Your session will work identically, and no ZIP archive of your documents, schema, or extracted table will be created or uploaded to Google Drive.
+
+  For transparency: even when you opt out, we record a short summary row in our private tracking sheet so we can measure how the tool is used. That row contains your session ID, your research query text, counts (documents, columns, rows), a completeness percentage, the observation unit name, and the number of LLM calls. It does **not** contain your documents or your extracted table. If you would prefer this row removed as well, contact us with your session ID.
+
 - **"Don't show again":** You can dismiss the consent dialog for future sessions. Your opt-out preference is saved locally in your browser and will be applied automatically.
+
+- **Request deletion:** You can ask us to delete everything associated with your session at any time. See Contact below.
 
 ## Data Retention
 
-Collected session archives are retained indefinitely for research purposes. If you would like your data removed, please contact us (see below) with your session ID (shown in the browser URL during your session).
+**Operational storage:** Project data is retained for **180 days** after your session was last modified, then deleted. If you need a project kept longer, contact us.
+
+**Research archive:** Collected session archives are retained indefinitely for research purposes, because published research datasets cannot be revised retroactively. If you would like your archive removed, please contact us (see below) with your session ID (shown in the browser URL during your session), and we will delete it and exclude it from future dataset releases.
+
+**Server logs:** Retained according to our hosting provider's standard log retention period.
 
 ## Eligibility
 


### PR DESCRIPTION
## Problem
The policy's "How Data Is Stored" section described only the Google Drive ZIP. In production, session metadata, extracted tables and reference documents are also stored in Supabase (measured: 63.2 MB sessions, 16.8 MB data, 46.9 MB documents across 1,134 sessions), and that storage is not gated by the research opt-out because it is what makes a project survive a redeploy.

Two further inaccuracies:
- "What We Do NOT Collect" listed IP addresses, but the hosting provider records standard access logs containing client IPs, paths and user-agents.
- "Your Choices" implied opting out stops collection, but `_log_opt_out_to_sheet` still records a summary row containing the user's query text.

## Solution
Split storage into operational (Supabase, service delivery, not opt-out gated, 180-day retention) and research archive (Drive + Sheet, opt-out gated, indefinite with removal on request). Correct the IP claim. State exactly what the opt-out summary row contains. Add an explicit deletion request option.

No code changes.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone of main
- Every claim checked against code: `data_collection_service._log_session_to_sheet` field list, `opt_out_data_collection` usage, `supabase_backend.REQUIRED_BUCKETS`, and measured bucket sizes
- Line endings unchanged (LF-only, matching the original)

## Follow-up (not in this PR)
Consider passing `query=""` to the summary row when the user has opted out, so the policy can promise a numeric-only row instead of documenting that the query is retained.