### PR TITLE
fix(privacy): withhold the query from the summary row when the user opted out

### DIFF
--- a/backend/app/services/data_collection_service.py
+++ b/backend/app/services/data_collection_service.py
@@ -189,9 +189,15 @@ class DataCollectionService:
         except Exception as e:
             logger.debug("[data-collection] Could not read LLM call stats: %s", e)
 
+        # The query is the user's own text. Withhold it when they opted out of
+        # research collection: the counts below still give us usage metrics, and
+        # the policy can then promise a numeric-only row rather than document
+        # that we keep the query anyway.
+        query = "" if session.opt_out_data_collection else (session.schema_query or "")
+
         self._sheets_logger.log_session(
             session_id=session_id,
-            query=session.schema_query or "",
+            query=query,
             doc_count=stats.total_documents if stats else 0,
             column_count=stats.total_columns if stats else len(session.columns),
             row_count=stats.total_rows if stats else 0,

--- a/privacy_policy.md
+++ b/privacy_policy.md
@@ -1,7 +1,7 @@
 
 # Privacy Policy — ScheMatiQ Research Data Collection
 
-**Last Updated:** February 2026
+**Last Updated:** August 2026
 
 ## Who We Are
 
@@ -20,8 +20,10 @@ When you use ScheMatiQ in its public deployment, we may collect the following da
 ## What We Do NOT Collect
 
 - API keys or authentication credentials.
-- Your IP address, browser fingerprint, or device identifiers.
 - Any account or login information (ScheMatiQ does not require accounts).
+- Browser fingerprints or device identifiers.
+
+Note that our hosting provider records standard web server logs for the service, which include the IP address of incoming requests, the pages requested, and the browser user-agent string. These logs are a byproduct of operating the service, are not used for research, and are not linked to your session contents.
 
 ## Purpose
 
@@ -33,7 +35,19 @@ The collected data is used solely for **open academic research** on query-based 
 
 ## How Data Is Stored
 
-Session data is bundled into a ZIP archive and uploaded to a private Google Drive folder accessible only to the research team. An optional summary row may be logged to a Google Sheet for tracking purposes.
+Your data is stored in two separate places for two different reasons. The distinction matters, because your research opt-out applies to one of them and not the other.
+
+**1. Operational storage — so the tool works for you.**
+
+Your project (your query, the discovered schema, the extracted table, and your uploaded documents) is stored in our cloud storage provider, Supabase, on servers operated on our behalf. This is what allows you to close the tab and come back to your project later, and to keep your table when we deploy an update. Without it your work would be lost whenever our server restarts.
+
+This storage is part of delivering the tool and happens whether or not you opt out of research data collection. It is not used for research.
+
+**2. Research archive — so we can study the system.**
+
+Separately, a copy of your session is bundled into a ZIP archive and uploaded to a private Google Drive folder accessible only to the research team. A summary row is also recorded in a private Google Sheet.
+
+**This is the copy your opt-out controls.** If you opt out, no ZIP archive is created and nothing is uploaded to Google Drive.
 
 ## Identifying Information
 
@@ -41,12 +55,21 @@ We do not intentionally collect personal identifiers. However, the content of yo
 
 ## Your Choices
 
-- **Opt out of data collection:** When you click "Start ScheMatiQ," a consent dialog will appear. You can check the **"Do not share my data for research purposes"** box to prevent your session data from being archived. Your session will work identically — the only difference is that no data is sent to Google Drive.
+- **Opt out of research data collection:** When you click "Start ScheMatiQ," a consent dialog will appear. You can check the **"Do not share my data for research purposes"** box. Your session will work identically, and no ZIP archive of your documents, schema, or extracted table will be created or uploaded to Google Drive.
+
+  For transparency: even when you opt out, we record a numeric summary row in our private tracking sheet so we can measure how the tool is used. That row contains your session ID and counts only — the number of documents, columns and rows, a completeness percentage, the observation unit name, and the number of LLM calls. It does **not** contain your query, your documents, or your extracted table. If you would prefer this row removed as well, contact us with your session ID.
+
 - **"Don't show again":** You can dismiss the consent dialog for future sessions. Your opt-out preference is saved locally in your browser and will be applied automatically.
+
+- **Request deletion:** You can ask us to delete everything associated with your session at any time. See Contact below.
 
 ## Data Retention
 
-Collected session archives are retained indefinitely for research purposes. If you would like your data removed, please contact us (see below) with your session ID (shown in the browser URL during your session).
+**Operational storage:** Project data is retained for **180 days** after your session was last modified, then deleted. If you need a project kept longer, contact us.
+
+**Research archive:** Collected session archives are retained indefinitely for research purposes, because published research datasets cannot be revised retroactively. If you would like your archive removed, please contact us (see below) with your session ID (shown in the browser URL during your session), and we will delete it and exclude it from future dataset releases.
+
+**Server logs:** Retained according to our hosting provider's standard log retention period.
 
 ## Eligibility
 


### PR DESCRIPTION
## Problem
`_log_opt_out_to_sheet` still wrote the user's `schema_query` text to the tracking sheet. "Your research query" is listed under What We Collect, so a user who checked "Do not share my data for research purposes" had their query retained anyway. The old policy text was literally true (nothing went to Drive) but would not match what a user understood themselves to be choosing.

The policy also described only the Drive ZIP under How Data Is Stored, while session metadata, extracted tables and reference documents live in Supabase (measured: 63.2 MB / 16.8 MB / 46.9 MB across 1,134 sessions), and that storage is not opt-out gated because it is what makes a project survive a redeploy. It also listed IP addresses as not collected, while the host records standard access logs containing them.

## Solution
Pass an empty query when `opt_out_data_collection` is set. Every other field in the row is unchanged, so usage metrics are unaffected. Condition on `opt_out_data_collection` rather than `data_saved`, which means "was the ZIP saved" and would wrongly suppress a consenting user's query if a Drive upload ever failed.

Policy updated to match: storage split into operational (Supabase, service delivery, 180-day retention) and research archive (Drive + Sheet, opt-out gated, indefinite with removal on request); the opt-out row is now described as numeric-only; the IP claim corrected; an explicit deletion request option added.

## Verify
- `git apply --ignore-whitespace --check` for both patches on a clean clone of main
- `python -m py_compile backend/app/services/data_collection_service.py`
- `_log_session_to_sheet` exercised for both consent states: query present when consented, empty when opted out, and all of doc_count / column_count / row_count / completeness / observation_unit identical between the two rows
- `data_collection_service.py` is CRLF-only; verified CRLF=628, bare LF=0 after apply. `privacy_policy.md` remains LF-only
- No frontend files touched

Note: the two patches belong together. The policy promises a numeric-only row, which is only accurate with the code change.