### PR TITLE
fix(logging): carry the session context into thread pool workers

### DIFF
--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -913,9 +913,9 @@ async def add_documents(session_id: str, files: List[UploadFile] = File(...), by
                     content = await file.read()
                     f.write(content)
 
-                loop = asyncio.get_event_loop()
-                display_name, error = await loop.run_in_executor(
-                    None,
+                # to_thread rather than run_in_executor: it copies the context,
+                # so preprocessing logs keep the session id.
+                display_name, error = await asyncio.to_thread(
                     _preprocess_and_record,
                     file_path, file.filename, docs_dir, session, document_extraction,
                 )
@@ -1158,9 +1158,9 @@ async def add_cloud_documents(session_id: str, request: CloudDocumentRequest):
                 with open(file_path, 'wb') as f:
                     f.write(content)
 
-                loop = asyncio.get_event_loop()
-                display_name, error = await loop.run_in_executor(
-                    None,
+                # to_thread rather than run_in_executor: it copies the context,
+                # so preprocessing logs keep the session id.
+                display_name, error = await asyncio.to_thread(
                     _preprocess_and_record,
                     file_path, filename, docs_dir, session, document_extraction,
                 )

--- a/backend/app/core/logging_utils.py
+++ b/backend/app/core/logging_utils.py
@@ -2,13 +2,20 @@
 
 Uses Python's contextvars to automatically inject session IDs into all
 logger.* calls via a custom logging.Filter. Set the session context once
-at the entry point (route handler or service method), and it propagates
-automatically through BackgroundTasks, run_in_executor threads, and
-asyncio.create_task calls.
+at the entry point (route handler or service method).
+
+Propagation is not uniform, which is worth knowing before adding a call:
+``asyncio.create_task`` and ``asyncio.to_thread`` copy the current context,
+so the session id survives. Plain ``loop.run_in_executor`` does NOT: the
+function runs in a bare thread with a fresh context and every record from it
+logs as ``no-session``. Use ``ContextPropagatingThreadPoolExecutor`` below
+for executors, or ``asyncio.to_thread`` instead of the default executor.
 """
 
 import contextvars
+import functools
 import logging
+from concurrent.futures import ThreadPoolExecutor
 
 # Context variable holding the current session ID.
 # Empty string means no session context (e.g., startup, system-level logs).
@@ -24,6 +31,21 @@ class SessionFilter(logging.Filter):
         sid = current_session_id.get('')
         record.session_id = sid[:8] if sid else 'no-session'
         return True
+
+
+class ContextPropagatingThreadPoolExecutor(ThreadPoolExecutor):
+    """ThreadPoolExecutor that carries the caller's context into the worker.
+
+    ``loop.run_in_executor(pool, fn)`` calls ``pool.submit(fn)``, and a plain
+    pool runs ``fn`` in a thread with a fresh context, so ``current_session_id``
+    is lost and the whole offloaded operation logs as ``no-session``. Copying
+    the context at submit time fixes every call site through this pool without
+    touching any of them.
+    """
+
+    def submit(self, fn, /, *args, **kwargs):
+        ctx = contextvars.copy_context()
+        return super().submit(ctx.run, functools.partial(fn, *args, **kwargs))
 
 
 def set_session_context(session_id: str) -> contextvars.Token:

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import os
 import time
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
@@ -13,13 +12,16 @@ from .session_manager import SessionManager
 
 from app.core.config import MAX_CONCURRENT_SESSIONS, SCHEMATIQ_THREAD_POOL_SIZE
 from app.core.exceptions import CapacityExceededError
+from app.core.logging_utils import ContextPropagatingThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
 
 # ── Shared thread pool for blocking ScheMatiQ operations ─────────────
 # Bounded pool prevents unbounded thread growth under concurrent load.
 # 6 workers on 8 vCPU leaves headroom for the event loop and OS.
-schematiq_thread_pool = ThreadPoolExecutor(
+# Context-propagating so that logs from offloaded work still carry the
+# session id; a plain pool loses it and everything reads as no-session.
+schematiq_thread_pool = ContextPropagatingThreadPoolExecutor(
     max_workers=SCHEMATIQ_THREAD_POOL_SIZE,
     thread_name_prefix="schematiq-worker",
 )


### PR DESCRIPTION
## Problem
Value extraction and schema discovery logged as `[no-session]`: in one production run, 248 of the tagged lines had no session id against 67 that did, so a customer's run could not be filtered out of the log.

Cause: `loop.run_in_executor` does not propagate contextvars. The worker runs with a fresh context, `current_session_id` reads empty, and `SessionFilter` stamps `no-session`. The module docstring in `logging_utils.py` claimed the opposite ("propagates automatically through ... run_in_executor threads"), which is what made this hard to spot.

Measured: `run_in_executor` loses the id; `asyncio.to_thread` and `copy_context().run` keep it.

## Solution
29 of the 31 `run_in_executor` calls go through the single shared `schematiq_thread_pool`, so fixing the pool fixes them all without touching a call site. `ContextPropagatingThreadPoolExecutor` copies the context at submit time.

The remaining 2 (document preprocessing in `load.py`) used the default executor and became `asyncio.to_thread`, which propagates natively.

Docstring corrected to state which mechanisms propagate and which do not.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone of main (3ae292e)
- `python -m pytest` in backend: 177 passed, same 3 pre-existing environment failures as unpatched main. Zero regressions
- Direct test: propagating pool stamps `[0413c980]` where a plain pool stamps `[no-session]`; positional and keyword args arrive intact; exceptions still surface through `ctx.run`; `submit` from inside a worker keeps the id
- Confirmed 0 remaining `run_in_executor(None, ...)` calls in backend/app
- `logging_utils.py` is CRLF-only; verified CRLF=57, bare LF=0 after apply
- No frontend files touched