### PR TITLE
fix(ui): stop displaying a temperature that the model ignores

### DIFF
--- a/frontend/src/components/LLMConfigDisplay/LLMConfigDisplay.tsx
+++ b/frontend/src/components/LLMConfigDisplay/LLMConfigDisplay.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Brain, Zap, HardDrive, Thermometer } from 'lucide-react';
+import { Brain, Zap, HardDrive } from 'lucide-react';
 
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -9,12 +9,16 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
+// Temperature is deliberately not displayed. It is not user-configurable (every
+// call site sends 0), and Gemini 3.x ignores the parameter outright, so showing
+// "Temp: 0" next to "0.0 = deterministic" told users their runs were
+// reproducible when they are not.
+// See https://ai.google.dev/gemini-api/docs/latest-model
 interface LLMConfigDisplayProps {
   config: {
     provider?: string;
     model?: string;
     max_output_tokens?: number;
-    temperature?: number;
   } | null;
   title?: string;
   variant?: 'card' | 'inline' | 'compact';
@@ -90,20 +94,6 @@ const LLMConfigDisplay: React.FC<LLMConfigDisplayProps> = ({
               </TooltipTrigger>
               <TooltipContent>
                 Maximum tokens the model can generate in its response
-              </TooltipContent>
-            </Tooltip>
-          )}
-
-          {config.temperature !== undefined && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Badge variant="outline" className="gap-1 cursor-help">
-                  <Thermometer className="h-3 w-3" />
-                  Temp: {config.temperature}
-                </Badge>
-              </TooltipTrigger>
-              <TooltipContent>
-                Temperature controls randomness (0.0 = deterministic, 1.0 = very random)
               </TooltipContent>
             </Tooltip>
           )}


### PR DESCRIPTION
## Problem
`LLMConfigDisplay` rendered a `Temp: 0` badge whose tooltip read "Temperature controls randomness (0.0 = deterministic, 1.0 = very random)".

Per https://ai.google.dev/gemini-api/docs/latest-model, temperature is deprecated and ignored on gemini-3.6-flash and gemini-3.5-flash-lite, the models used for extraction and chat. Two runs over the same corpus and question produced 9 rows / 7 columns and 5 rows / 8 columns respectively, so the badge asserted reproducibility the system does not provide.

The badge was also not actionable: there is no temperature control in the UI, and all ten call sites hardcode `temperature: 0`.

## Solution
Remove the badge, its tooltip and the now-unused `Thermometer` import and `temperature` prop. A comment records why, with the doc link, so it is not reinstated.

Not chosen: a per-model `honorsSamplingParams` flag in `llmModels.ts`. That would duplicate `model_specs.supports_sampling_params` in the frontend and drift from it, to surface a value the user cannot change.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone of main (9216e8d)
- `npx tsc --noEmit` clean on the patched clean clone
- `LLMConfigDisplay.tsx` is CRLF-only; verified CRLF=140, bare LF=0 after apply, diff is 6 insertions / 16 deletions
- All four call sites pass whole config objects, so dropping the optional prop is source-compatible

## Follow-up (not here)
If you want researchers told that runs are not reproducible, that belongs near the run or the export, not in a config badge. Worth a separate product decision.