### PR TITLE
chore(storage): warn when the Supabase key is publishable or a bucket is public

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ npm start
 | `GEMINI_API_KEY` | Google Gemini API key |
 | `TOGETHER_API_KEY` | Together AI API key |
 | `ALLOWED_ORIGINS` | CORS origins (default: `http://localhost:3000`) |
-| `SUPABASE_URL` / `SUPABASE_KEY` | Cloud storage (production) |
+| `SUPABASE_URL` / `SUPABASE_KEY` | Cloud storage (production). `SUPABASE_KEY` must be the service_role or secret key, never the anon key |
 | `MAX_CONCURRENT_SESSIONS` | Concurrent session limit (default: 5) |
 | `DEVELOPER_MODE` | Set `true` to unlock all features (see below) |
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -41,9 +41,16 @@ OPENAI_API_KEY=your_openai_key_here
 STORAGE_BACKEND=local
 
 # Supabase Configuration (required if STORAGE_BACKEND=supabase)
-# Create these buckets in your Supabase dashboard: sessions, documents, data, exports
+# Create these buckets in your Supabase dashboard: sessions, documents, data,
+# exports, datasets, templates, initial_schemas
+# Keep all of them private. The application never builds a public storage URL.
+#
+# SUPABASE_KEY must be a server-only key: the service_role key, or the newer
+# secret key if your project offers one. Do NOT use the anon/publishable key.
+# Supabase treats that one as safe to ship in a browser bundle, so any storage
+# permission granted to it is granted to anyone who obtains it.
 # SUPABASE_URL=https://your-project.supabase.co
-# SUPABASE_KEY=your-anon-key
+# SUPABASE_KEY=your-service-role-key
 
 # ===================
 # ScheMatiQ Configuration

--- a/backend/app/storage/supabase_backend.py
+++ b/backend/app/storage/supabase_backend.py
@@ -1,15 +1,51 @@
 """Supabase cloud storage backend implementation."""
 
+import base64
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from supabase import create_client, Client
 
 from app.storage.interface import StorageInterface, DatasetInfo, FileInfo, TemplateInfo, InitialSchemaInfo
 
 logger = logging.getLogger(__name__)
+
+
+def classify_supabase_key(key: str) -> Tuple[str, str]:
+    """Classify SUPABASE_KEY as 'server', 'publishable' or 'unknown'.
+
+    Supabase treats publishable keys (legacy `anon`, newer `sb_publishable_`) as
+    non-secret: they are meant to sit in a browser bundle. The backend needs the
+    opposite property, so knowing which one is live is worth a log line. The
+    newer key formats are opaque strings rather than JWTs, so only legacy keys
+    carry a decodable role claim.
+
+    Returns:
+        (kind, human readable detail). Never raises, and never logs the key.
+    """
+    if key.startswith("sb_secret_"):
+        return "server", "secret key"
+    if key.startswith("sb_publishable_"):
+        return "publishable", "publishable key"
+
+    parts = key.split(".")
+    if len(parts) == 3:
+        try:
+            payload = parts[1]
+            payload += "=" * (-len(payload) % 4)
+            claims = json.loads(base64.urlsafe_b64decode(payload))
+        except Exception:
+            return "unknown", "JWT-shaped but the payload did not decode"
+        role = claims.get("role")
+        if role == "service_role":
+            return "server", "legacy service_role JWT"
+        if role == "anon":
+            return "publishable", "legacy anon JWT"
+        return "unknown", f"JWT with role={role!r}"
+
+    return "unknown", "unrecognised key format"
 
 # Overwrite in a single request instead of remove-then-upload.
 #
@@ -39,23 +75,61 @@ class SupabaseStorageBackend(StorageInterface):
     # Required buckets for the application
     REQUIRED_BUCKETS = ["sessions", "documents", "data", "exports", "datasets", "templates", "initial_schemas"]
 
+    # Buckets whose contents are user research data. A Public flag on any of
+    # these means the objects are served over an open URL with no key at all,
+    # which is a different act from making them reachable through the API.
+    USER_DATA_BUCKETS = {"sessions", "documents", "data", "exports"}
+
     def __init__(self, url: str, key: str):
         """Initialize Supabase storage backend.
 
         Args:
             url: Supabase project URL
-            key: Supabase anon/service key
+            key: Supabase service_role or secret key. A publishable (anon) key
+                works only while storage.objects carries permissive policies for
+                the anon role, and those policies apply to anyone holding the
+                key, so the backend warns when it sees one.
         """
         logger.info(f"Initializing Supabase storage backend with URL: {url[:30]}...")
+        self._warn_if_publishable_key(key)
         self.client: Client = create_client(url, key)
         self._verify_buckets()
         logger.info("Supabase storage backend initialized successfully")
 
+    @staticmethod
+    def _warn_if_publishable_key(key: str) -> None:
+        """Log the key category so a publishable key is not silently in use."""
+        kind, detail = classify_supabase_key(key)
+        if kind == "server":
+            logger.info(f"SUPABASE_KEY is a server-only credential ({detail})")
+            return
+        if kind == "publishable":
+            logger.warning(
+                f"SUPABASE_KEY is a publishable credential ({detail}). Supabase "
+                "treats it as non-secret, so every storage permission granted to "
+                "it is granted to anyone who obtains it. Use the service_role or "
+                "secret key for the backend."
+            )
+            return
+        logger.warning(f"Could not classify SUPABASE_KEY ({detail}); verify it by hand")
+
     def _verify_buckets(self) -> None:
-        """Verify required buckets exist in Supabase."""
+        """Verify required buckets exist and that user data buckets are private."""
         try:
             existing_buckets = self.client.storage.list_buckets()
-            existing_names = {b.name for b in existing_buckets}
+            existing_names = set()
+            public_names = set()
+            for bucket in existing_buckets:
+                if isinstance(bucket, dict):
+                    name, is_public = bucket.get("name"), bucket.get("public")
+                else:
+                    name = getattr(bucket, "name", None)
+                    is_public = getattr(bucket, "public", None)
+                if not name:
+                    continue
+                existing_names.add(name)
+                if is_public:
+                    public_names.add(name)
             logger.info(f"Found Supabase buckets: {existing_names}")
 
             missing = set(self.REQUIRED_BUCKETS) - existing_names
@@ -64,6 +138,22 @@ class SupabaseStorageBackend(StorageInterface):
                 logger.warning("Please create these buckets in your Supabase dashboard.")
             else:
                 logger.info("All required buckets exist")
+
+            exposed_user_data = public_names & self.USER_DATA_BUCKETS
+            if exposed_user_data:
+                logger.error(
+                    f"Supabase buckets holding user data are marked Public: "
+                    f"{sorted(exposed_user_data)}. Their objects are served over an "
+                    f"open URL with no key. Uncheck Public in the dashboard."
+                )
+            other_public = public_names & (set(self.REQUIRED_BUCKETS) - self.USER_DATA_BUCKETS)
+            if other_public:
+                logger.warning(
+                    f"Supabase buckets marked Public: {sorted(other_public)}. The "
+                    f"application never builds a public URL, so this only exposes "
+                    f"their contents to the open internet. Run "
+                    f"scripts/audit_storage_access.py to confirm what is served."
+                )
         except Exception as e:
             logger.error(f"Could not verify Supabase buckets: {e}", exc_info=True)
 


### PR DESCRIPTION
Problem

The backend accepts any Supabase key and says nothing about which kind it got. A
publishable key (legacy anon, or the newer sb_publishable_) is treated by
Supabase as non-secret and normally ships in a browser bundle, so every storage
permission granted to it is granted to anyone who obtains it. Nothing surfaces
that. .env.example actively recommends it. _verify_buckets already fetches the
bucket list but ignores the public flag, so a bucket serving objects over an
open URL is invisible too.

Solution

Add classify_supabase_key, covering both key formats, and log the category at
init: info for a server-only key, warning for a publishable one, warning when it
cannot be classified. The key itself is never logged. Extend _verify_buckets to
read the public flag from the same response it already fetches: error for
sessions, documents, data and exports, warning for the rest, pointing at
scripts/audit_storage_access.py.

Warning rather than hard failure on purpose: factory.py falls back to local
storage on any exception during init, so raising here would silently lose data
instead of preventing a problem.

Fix .env.example and README to ask for the service_role or secret key and to
list all seven buckets.

Verify

python -m py_compile backend/app/storage/supabase_backend.py
Restart with STORAGE_BACKEND=supabase and read the startup log:
  the key category line appears, and datasets and initial_schemas are reported
  as Public until they are unchecked in the dashboard.
Both bucket-list response shapes are handled (objects and dicts), and a
list_buckets failure is still caught as before.