### PR TITLE
fix(workspace): surface the data-read 503 with a retry banner and backoff

### DIFF
--- a/frontend/src/pages/Workspace/DataLoadErrorBanner.tsx
+++ b/frontend/src/pages/Workspace/DataLoadErrorBanner.tsx
@@ -1,0 +1,38 @@
+// Banner shown when the table-data endpoint answers 503 ("data read failed"):
+// the session's rows exist in storage but could not be hydrated to the server's
+// local disk, so the grid would otherwise render schema headers over an empty
+// table with no explanation. Retries run automatically with backoff (see
+// noteDataFetchError in index.tsx); the button retries immediately.
+// Parent: Workspace (index.tsx).
+
+import { Loader2, RotateCw } from 'lucide-react';
+
+export function DataLoadErrorBanner({
+  message,
+  retrying,
+  onRetry,
+}: {
+  message: string;
+  retrying: boolean;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="workspace-followup-banner workspace-data-error-banner" role="alert">
+      <div className="workspace-followup-banner-copy">
+        <strong>Table data could not be loaded</strong>
+        <span>{message} Retrying automatically — the rows are safe in storage.</span>
+      </div>
+      <div className="workspace-followup-banner-actions">
+        <button
+          className="workspace-followup-action workspace-followup-action-primary"
+          type="button"
+          onClick={onRetry}
+          disabled={retrying}
+        >
+          {retrying ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RotateCw className="h-3.5 w-3.5" />}
+          Retry now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Workspace/Workspace.css
+++ b/frontend/src/pages/Workspace/Workspace.css
@@ -525,6 +525,29 @@
   font-weight: 500;
 }
 
+/* Red variant of the follow-up banner: table data failed to load (503 from the
+   data endpoint — rows exist in storage but could not be read) and is being
+   retried automatically. */
+.workspace-data-error-banner {
+  background: #fdecea;
+  border-bottom-color: #f5c2bd;
+  color: #7a2f26;
+}
+
+.workspace-data-error-banner .workspace-followup-banner-copy strong {
+  color: #5f1d15;
+}
+
+.workspace-data-error-banner .workspace-followup-action-primary {
+  border-color: #c5221f;
+  background: #fce8e6;
+  color: #a50e0e;
+}
+
+.workspace-data-error-banner .workspace-followup-action-primary:hover:not(:disabled) {
+  background: #f8d7d4;
+}
+
 .workspace-body {
   flex: 1 1 auto;
   min-height: 0;
@@ -1367,6 +1390,26 @@
 .dark .workspace-followup-banner {
   background: hsl(38 32% 14%);
   border-bottom-color: hsl(38 28% 26%);
+}
+
+.dark .workspace-data-error-banner {
+  background: hsl(4 40% 14%);
+  border-bottom-color: hsl(4 34% 26%);
+  color: hsl(6 70% 82%);
+}
+
+.dark .workspace-data-error-banner .workspace-followup-banner-copy strong {
+  color: hsl(6 80% 86%);
+}
+
+.dark .workspace-data-error-banner .workspace-followup-action-primary {
+  border-color: hsl(4 60% 45%);
+  background: hsl(4 45% 20%);
+  color: hsl(6 80% 84%);
+}
+
+.dark .workspace-data-error-banner .workspace-followup-action-primary:hover:not(:disabled) {
+  background: hsl(4 45% 24%);
 }
 
 .dark .workspace-sheet-tab[data-active="true"] {

--- a/frontend/src/pages/Workspace/constants.ts
+++ b/frontend/src/pages/Workspace/constants.ts
@@ -129,6 +129,14 @@ export const emptyData: PaginatedData = {
 // finish, short enough that a genuinely emptied table clears without a visible
 // wait. See applyData in index.tsx.
 export const EMPTY_DATA_RECHECK_MS = 900;
+// Automatic retry schedule for a table-data fetch that failed with 503: the
+// backend answers 503 specifically when the session's rows exist in storage
+// but could not be hydrated locally, so a retry is expected to succeed once
+// hydration recovers. The delay doubles per consecutive failure and is capped,
+// so a backend that recovers quickly is retried quickly without hammering one
+// that does not. See noteDataFetchError in index.tsx.
+export const DATA_LOAD_RETRY_BASE_MS = 4000;
+export const DATA_LOAD_RETRY_MAX_MS = 30000;
 export const WORKSPACE_DEFAULT_ADVANCED: AdvancedSettingsValue = {
   ...DEFAULT_ADVANCED_SETTINGS,
   schemaProvider: DEFAULT_PROVIDER,

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -62,7 +62,15 @@ import type { DocumentListResponse } from '@/types/unit';
 import { applyPatches, enablePatches, produceWithPatches } from 'immer';
 
 import { ChatPanel } from './chat/ChatPanel';
-import { emptyData, EMPTY_DATA_RECHECK_MS, SHEETS, cellFormatKey } from './constants';
+import {
+  DATA_LOAD_RETRY_BASE_MS,
+  DATA_LOAD_RETRY_MAX_MS,
+  emptyData,
+  EMPTY_DATA_RECHECK_MS,
+  SHEETS,
+  cellFormatKey,
+} from './constants';
+import { DataLoadErrorBanner } from './DataLoadErrorBanner';
 import { useEditHistory } from './hooks/useEditHistory';
 import {
   buildExportFilename,
@@ -218,12 +226,65 @@ function Workspace() {
   const unitDataRowCountRef = useRef(0);
   const emptyRecheckTimerRef = useRef<number | null>(null);
   const refreshDataRef = useRef<((options?: RefreshDataOptions) => Promise<void>) | null>(null);
+  // Surfaced 503 from the table-data endpoint: rows exist in storage but could
+  // not be read. Everything else (network blips during background polls) stays
+  // silent, exactly as before.
+  const [dataLoadError, setDataLoadError] = useState<string | null>(null);
+  const [dataRetrying, setDataRetrying] = useState(false);
+  const dataRetryTimerRef = useRef<number | null>(null);
+  const dataRetryAttemptRef = useRef(0);
 
   const clearEmptyRecheck = useCallback(() => {
     if (emptyRecheckTimerRef.current == null) return;
     window.clearTimeout(emptyRecheckTimerRef.current);
     emptyRecheckTimerRef.current = null;
   }, []);
+
+  const clearDataRetryTimer = useCallback(() => {
+    if (dataRetryTimerRef.current == null) return;
+    window.clearTimeout(dataRetryTimerRef.current);
+    dataRetryTimerRef.current = null;
+  }, []);
+
+  // A successful data fetch clears the surfaced error and resets the backoff,
+  // whether it came from a scheduled retry, the manual button, or any ordinary
+  // refresh that happened to land first.
+  const noteDataFetchSuccess = useCallback(() => {
+    dataRetryAttemptRef.current = 0;
+    clearDataRetryTimer();
+    setDataLoadError(null);
+  }, [clearDataRetryTimer]);
+
+  // The backend answers 503 on the data endpoints only when the session's own
+  // statistics record rows, no data file resolved locally, and the rows are
+  // present in remote storage — i.e. hydration failed, not "the table is
+  // empty". That is the one failure worth telling the user about, and it is
+  // retryable by construction. Other errors keep today's behaviour: the rows
+  // already on screen stay put and nothing is shown.
+  const noteDataFetchError = useCallback((err: unknown) => {
+    const response = (err as { response?: { status?: number; data?: { detail?: unknown } } })?.response;
+    if (response?.status !== 503) return;
+    const detail = typeof response.data?.detail === 'string' ? response.data.detail : '';
+    setDataLoadError(detail || 'Table data could not be loaded right now.');
+    if (dataRetryTimerRef.current != null) return; // a retry is already scheduled
+    const attempt = dataRetryAttemptRef.current;
+    const delay = Math.min(DATA_LOAD_RETRY_BASE_MS * 2 ** attempt, DATA_LOAD_RETRY_MAX_MS);
+    dataRetryAttemptRef.current = attempt + 1;
+    dataRetryTimerRef.current = window.setTimeout(() => {
+      dataRetryTimerRef.current = null;
+      void refreshDataRef.current?.({ silent: true });
+    }, delay);
+  }, []);
+
+  const retryDataLoad = useCallback(async () => {
+    clearDataRetryTimer();
+    setDataRetrying(true);
+    try {
+      await refreshDataRef.current?.({ silent: true });
+    } finally {
+      setDataRetrying(false);
+    }
+  }, [clearDataRetryTimer]);
 
   const cancelChatPendingIfAny = useCallback(async (): Promise<boolean> => {
     if (!cancelChatPendingRef.current) return true;
@@ -300,10 +361,15 @@ function Workspace() {
     // Keep the rows already on screen when the fetch fails instead of blanking
     // the grid. The columns come from the schema, so falling back to emptyData
     // here is exactly what leaves the user looking at headers with no data.
-    const nextData = await fetchData().catch(() => null);
+    // A 503 additionally raises the retry banner (see noteDataFetchError).
+    const nextData = await fetchData().catch((err) => {
+      noteDataFetchError(err);
+      return null;
+    });
     if (!nextData) return;
+    noteDataFetchSuccess();
     applyData(nextData, options);
-  }, [applyData, sessionId, sessionMode]);
+  }, [applyData, noteDataFetchError, noteDataFetchSuccess, sessionId, sessionMode]);
 
   // The re-check scheduled by applyData needs the current refreshData without
   // making applyData depend on it (they are mutually recursive by design).
@@ -397,11 +463,18 @@ function Workspace() {
         const [nextData, nextDocuments] = await Promise.all([
           // Keep the current rows if the fetch fails (null) rather than blanking
           // the grid with emptyData — e.g. a transient error during a
-          // structural refresh right after a column delete.
-          fetchData().catch(() => null),
+          // structural refresh right after a column delete. A 503 additionally
+          // raises the retry banner (see noteDataFetchError).
+          fetchData().catch((err) => {
+            noteDataFetchError(err);
+            return null;
+          }),
           fetchDocuments().catch(() => null),
         ]);
-        if (nextData) applyData(nextData, options);
+        if (nextData) {
+          noteDataFetchSuccess();
+          applyData(nextData, options);
+        }
         setDocuments(nextDocuments);
       } finally {
         if (!silent) setDataLoading(false);
@@ -471,7 +544,7 @@ function Workspace() {
         setLoading(false);
       }
     }
-  }, [applyData, sessionId, sessionMode]);
+  }, [applyData, noteDataFetchError, noteDataFetchSuccess, sessionId, sessionMode]);
 
   const {
     addDocsFiles,
@@ -582,9 +655,15 @@ function Workspace() {
     unitDataRowCountRef.current = 0;
     deferredDataRef.current = null;
     clearEmptyRecheck();
-  }, [clearEmptyRecheck, editHistory, sessionId]);
+    // The retry loop belongs to the session we are leaving.
+    dataRetryAttemptRef.current = 0;
+    clearDataRetryTimer();
+    setDataLoadError(null);
+  }, [clearDataRetryTimer, clearEmptyRecheck, editHistory, sessionId]);
 
   useEffect(() => clearEmptyRecheck, [clearEmptyRecheck]);
+
+  useEffect(() => clearDataRetryTimer, [clearDataRetryTimer]);
 
   // Belt-and-braces re-sync: every commit writes dataRowCountRef eagerly, this
   // keeps it correct for the paths that set `data` directly (optimistic edits).
@@ -1181,6 +1260,14 @@ function Workspace() {
           onReextract={() => requestReextraction(pendingRerunKind === 'schema' ? pendingSchemaColumns : undefined)}
           onRediscover={startSchemaRediscovery}
           onDismiss={clearPendingRerun}
+        />
+      )}
+
+      {dataLoadError && sessionId && (
+        <DataLoadErrorBanner
+          message={dataLoadError}
+          retrying={dataRetrying}
+          onRetry={() => void retryDataLoad()}
         />
       )}
 


### PR DESCRIPTION
## Problem
The backend deliberately answers 503 on /load/data and /schematiq/data when a session's rows exist in remote storage but could not be hydrated to local disk (session_data_read_failed). The Workspace swallowed this in both data-fetch paths (refreshData and loadHeavy inside refresh) with .catch(() => null), so the user saw schema column headers over an empty grid with no explanation and no way to retry.

## Solution
- New DataLoadErrorBanner component (styled like the follow-up banner, red variant incl. dark mode) with a Retry now button.
- refreshData and loadHeavy route failures through noteDataFetchError: only a 503 raises the banner (using the server's detail message) and schedules an automatic silent retry with exponential backoff (4s base, doubling, capped at 30s). All other errors keep today's behaviour: rows on screen stay put, nothing is shown.
- Any successful data fetch (scheduled retry, manual button, or an ordinary background poll) clears the banner and resets the backoff.
- Retry timer and error state are cleared on session change and unmount.

## Verify
- git apply --ignore-whitespace --check on a fresh clone of main (9ad4660): clean.
- ( cd frontend && npx tsc --noEmit ): passes with the patch applied.
- Manual: with a session whose local data file is missing but rows exist in storage, opening the workspace shows the red banner instead of a silently empty grid; once hydration succeeds (auto-retry or Retry now), rows appear and the banner clears.