### PR TITLE
fix(workspace): keep observation unit visible and sync schema + monitor during rediscovery

### DIFF
--- a/backend/app/services/pipeline/data_query.py
+++ b/backend/app/services/pipeline/data_query.py
@@ -218,6 +218,18 @@ async def get_status(
 async def get_schema(session_id: str, session_manager, work_dir: Path) -> Dict[str, Any]:
     """Get discovered schema."""
     session = session_manager.get_session(session_id)
+
+    # An observation-unit rediscovery reset (see
+    # ScheMatiQRunner._reset_for_observation_unit_rediscovery) clears
+    # session.columns and deletes discovered_schema.json but deliberately keeps
+    # session.observation_unit. Attach that unit to every return path so the
+    # Observation Unit tab does not blank out mid-rediscovery: without this, the
+    # empty-columns branch below dropped the unit until columns were repopulated.
+    def _with_observation_unit(result: Dict[str, Any]) -> Dict[str, Any]:
+        if session and session.observation_unit and not result.get("observation_unit"):
+            result["observation_unit"] = session.observation_unit.model_dump()
+        return result
+
     if session and session.columns:
         result = {
             "query": session.schema_query or "",
@@ -230,10 +242,10 @@ async def get_schema(session_id: str, session_manager, work_dir: Path) -> Dict[s
     schema_file = work_dir / session_id / "discovered_schema.json"
     if schema_file.exists():
         with open(schema_file) as f:
-            return json.load(f)
+            return _with_observation_unit(json.load(f))
 
     if session:
-        return {"query": session.schema_query or "", "schema": []}
+        return _with_observation_unit({"query": session.schema_query or "", "schema": []})
     return {"query": "", "schema": []}
 
 

--- a/frontend/src/components/ScheMatiQMonitor/ScheMatiQMonitor.tsx
+++ b/frontend/src/components/ScheMatiQMonitor/ScheMatiQMonitor.tsx
@@ -201,6 +201,40 @@ const ScheMatiQMonitor: React.FC<ScheMatiQMonitorProps> = ({
     if (status?.schema_only !== undefined) {
       setSchemaOnly(status.schema_only);
     }
+
+    // An externally-triggered rediscovery (Observation Unit tab edit ->
+    // "Rediscover schema & re-extract" in the Workspace banner) resets the
+    // backend to the schema phase without going through this monitor's own
+    // handleResume. The backend then reports status='processing' with
+    // schema_completed=false and columns_discovered=0, while this component
+    // still shows the *previous* run's completed phase cards -- the header
+    // reads "Discovering Schema..." while both phase cards still read
+    // "Complete". Detect that transition and reset the phase state so the
+    // monitor tracks the new run. Guarded by "the monitor thinks the last run
+    // finished" so it never fires on the initial run (phases not yet complete)
+    // or during normal extraction (schema_completed=true there).
+    const monitorThinksRunFinished =
+      processingState === 'completed' ||
+      processingState === 'stopped' ||
+      schemaProgress.isComplete ||
+      extractionProgress.isComplete;
+    if (
+      status?.status === 'processing' &&
+      status?.schema_completed === false &&
+      (status?.columns_discovered ?? 0) === 0 &&
+      !stopRequestedRef.current &&
+      monitorThinksRunFinished
+    ) {
+      setProcessingState('schema');
+      setCurrentStepMessage('Rediscovering schema...');
+      setSchemaProgress({ iteration: 0, maxIterations: 5, columnsDiscovered: 0, isComplete: false });
+      setExtractionProgress({ processedDocs: 0, totalDocs: 0, isComplete: false });
+      setStoppedInfo(null);
+      setErrorMessage('');
+      lastLoggedPhaseRef.current = null;
+      return;
+    }
+
     if (status?.status === 'processing' && processingState === 'idle') {
       setProcessingState('starting');
     } else if (status?.status === 'completed' && processingState !== 'completed') {

--- a/frontend/src/pages/Workspace/hooks/useReextraction.ts
+++ b/frontend/src/pages/Workspace/hooks/useReextraction.ts
@@ -23,6 +23,11 @@ type UseReextractionOptions = {
   refresh: (options?: { silent?: boolean }) => Promise<void>;
   setActiveSheet: (sheet: SheetId) => void;
   cancelChatPendingIfAny: () => Promise<boolean>;
+  // Called the moment a schema rediscovery is confirmed, before the (possibly
+  // slow) resume request returns. Lets the parent clear the stale schema columns
+  // so the Schema tab reflects the reset immediately instead of showing the
+  // previous run's columns for the duration of the request.
+  onRediscoveryStart?: () => void;
   toast: (props: {
     title: string;
     description?: string;
@@ -40,6 +45,7 @@ export function useReextraction({
   refresh,
   setActiveSheet,
   cancelChatPendingIfAny,
+  onRediscoveryStart,
   toast,
 }: UseReextractionOptions) {
   const [pendingRerunKind, setPendingRerunKind] = useState<PendingRerunKind | null>(null);
@@ -259,6 +265,12 @@ export function useReextraction({
         });
         return;
       }
+      // Drop the previous run's columns now, before the resume round-trip. The
+      // backend resets synchronously inside resume, but that request can be slow
+      // (it stops any in-flight pipeline first), and until it returns the Schema
+      // tab would otherwise keep showing stale columns. The observation unit is
+      // preserved by the parent so the Observation Unit tab stays populated.
+      onRediscoveryStart?.();
       await schematiqAPI.resume(sessionId);
       clearPendingRerun();
       toast({
@@ -268,6 +280,9 @@ export function useReextraction({
       });
       await refresh({ silent: true });
     } catch (err: any) {
+      // The optimistic clear above may have already run; re-sync from the server
+      // so a failed resume does not leave the Schema tab wrongly emptied.
+      await refresh({ silent: true }).catch(() => { /* keep the error toast as the primary signal */ });
       const { message, isBusy } = describeRequestError(err, 'Could not start schema rediscovery');
       toast({
         title: isBusy ? 'Server busy' : 'Schema rediscovery failed',
@@ -277,7 +292,7 @@ export function useReextraction({
     } finally {
       setRerunStarting(false);
     }
-  }, [cancelChatPendingIfAny, clearPendingRerun, refresh, rerunStarting, sessionId, sessionMode, toast]);
+  }, [cancelChatPendingIfAny, clearPendingRerun, onRediscoveryStart, refresh, rerunStarting, sessionId, sessionMode, toast]);
 
   const notifyEditFollowUp = useCallback((kind: PendingRerunKind, columns: string[] = []) => {
     markRerunNeeded(kind, columns);

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -593,6 +593,10 @@ function Workspace() {
     refresh,
     setActiveSheet,
     cancelChatPendingIfAny,
+    // Clear the columns as rediscovery starts so the Schema tab reflects the
+    // reset right away. Keep observation_unit so the Observation Unit tab stays
+    // populated (the backend preserves it across the rediscovery reset too).
+    onRediscoveryStart: () => setSchema((prev) => (prev ? { ...prev, schema: [] } : prev)),
     toast,
   });
 


### PR DESCRIPTION
## Problem
Editing the observation unit and triggering rediscovery from the Workspace banner caused three issues:
1. The edited observation unit disappeared from the Observation Unit tab until a tab switch forced a re-read.
2. The Schema tab kept showing the previous run's columns for the whole resume request.
3. The Monitor's phase cards stayed 'Complete' with stale counts while the header already read 'Discovering Schema...'.

Root causes (verified from code):
- Backend get_schema only attached observation_unit inside the 'if session.columns' branch. The rediscovery reset clears session.columns and deletes discovered_schema.json (but keeps session.observation_unit), so get_schema returned a schema with no observation_unit.
- The frontend never cleared stale schema columns while the (synchronous, potentially slow) resume request was in flight.
- The Monitor owns its own state and only resets phases via its internal handleResume; an externally-triggered rediscovery bypassed it, and the status-sync effect only moved to processing from 'idle'.

## Solution
- Backend: get_schema attaches session.observation_unit on every return path.
- Frontend: useReextraction clears schema columns optimistically at rediscovery start (keeping observation_unit), restoring via refresh if resume fails.
- Frontend: ScheMatiQMonitor detects a fresh rediscovery (processing + schema_completed=false + columns_discovered=0 while the monitor thinks the last run finished) and resets phase state. Guarded so it never fires on the initial run or during normal extraction.

## Verify
- git apply --ignore-whitespace --check on a fresh clone: OK
- ( cd frontend && npx tsc --noEmit ): OK
- python -m py_compile backend/app/services/pipeline/data_query.py: OK
- Manual: edit the observation unit, click 'Rediscover schema & re-extract'. Observation Unit tab stays populated; Schema tab clears immediately; Monitor phase cards reset to reflect the new run.