### PR TITLE
feat(extraction): diagnose fully-empty extraction rows

### DIFF
--- a/schematiq-lib/schematiq/core/llm_backends.py
+++ b/schematiq-lib/schematiq/core/llm_backends.py
@@ -588,6 +588,17 @@ class GeminiLLM(LLMInterface):
     """
     _provider = "gemini"
 
+    # Sentinel strings returned when the API produced no usable content. These
+    # flow downstream as ordinary text and cause a fully-empty extraction row,
+    # so callers can compare against this set to tell an empty-signal apart from
+    # a genuine (but unparseable) model answer. See ``last_call_diag``.
+    EMPTY_SIGNAL_RESPONSES = frozenset({
+        "No response generated due to safety filters or other restrictions.",
+        "Empty response from Gemini.",
+        "Response blocked by Gemini safety filters. Please try rephrasing your request.",
+        "Response blocked by Gemini safety filters.",
+    })
+
     def __init__(
         self,
         model: str = ModelNames.DEFAULT_VALUE_EXTRACTION,
@@ -602,6 +613,12 @@ class GeminiLLM(LLMInterface):
         self.model = model
         self.temperature = temperature
         self.system_prefix = system_prefix
+
+        # Diagnostics from the most recent generate/generate_with_cache call.
+        # Lets callers explain a fully-empty extraction row without re-reading
+        # the raw response. Keys: finish_reason, empty_reason, response_chars,
+        # truncated (bool). Reset at the start of every call.
+        self.last_call_diag: Dict[str, Any] = {}
 
         # Auto-detect token limits and capabilities from model specs
         spec = get_model_spec("gemini", model)
@@ -811,6 +828,7 @@ class GeminiLLM(LLMInterface):
         # Log prompt size for performance correlation
         print(f"🚀 Starting Gemini API call (model: {self.model}, prompt: ~{len(prompt_text):,} chars)")
         start_time = time.time()
+        self.last_call_diag = {}
 
         # Build generation config using new SDK types
         config_kwargs = {
@@ -854,6 +872,12 @@ class GeminiLLM(LLMInterface):
                 if not response.candidates:
                     feedback = getattr(response, 'prompt_feedback', None)
                     print(f"Gemini returned no candidates. Feedback: {feedback}")
+                    self.last_call_diag = {
+                        "finish_reason": "NO_CANDIDATES",
+                        "empty_reason": f"no candidates (prompt_feedback={feedback})",
+                        "response_chars": 0,
+                        "truncated": False,
+                    }
                     return "No response generated due to safety filters or other restrictions."
 
                 candidate = response.candidates[0]
@@ -879,10 +903,23 @@ class GeminiLLM(LLMInterface):
                 # Check for empty content
                 if not candidate.content or not candidate.content.parts:
                     print("Gemini returned empty content")
+                    self.last_call_diag = {
+                        "finish_reason": finish_reason_name,
+                        "empty_reason": "candidate had no content parts",
+                        "response_chars": 0,
+                        "truncated": finish_reason_name == "MAX_TOKENS",
+                    }
                     return "Empty response from Gemini."
 
                 content = response.text.strip()
-                
+
+                self.last_call_diag = {
+                    "finish_reason": finish_reason_name,
+                    "empty_reason": None,
+                    "response_chars": len(content),
+                    "truncated": finish_reason_name == "MAX_TOKENS",
+                }
+
                 # Track LLM call after success
                 LLMCallTracker.get_instance().increment(
                     model=self.model, 
@@ -907,6 +944,12 @@ class GeminiLLM(LLMInterface):
                 # Handle safety filter errors specifically - don't retry
                 if "Invalid operation" in error_str and "finish_reason" in error_str:
                     print(f"Gemini safety filter triggered: {error_str}")
+                    self.last_call_diag = {
+                        "finish_reason": "SAFETY_EXCEPTION",
+                        "empty_reason": f"safety filter exception: {error_str[:280]}",
+                        "response_chars": 0,
+                        "truncated": False,
+                    }
                     return "Response blocked by Gemini safety filters. Please try rephrasing your request."
 
                 # Check for invalid/malformed API key errors - don't retry
@@ -1008,6 +1051,7 @@ class GeminiLLM(LLMInterface):
         )
         print(f"🚀 Starting Gemini cached API call (model: {self.model}, prompt: ~{len(prompt_text):,} chars)")
         start_time = time.time()
+        self.last_call_diag = {}
 
         config_kwargs = {
             "max_output_tokens": kwargs.get("max_output_tokens", self.max_output_tokens),
@@ -1037,6 +1081,13 @@ class GeminiLLM(LLMInterface):
                 print(f"⏱️  Gemini cached API call completed in {elapsed:.1f}s")
 
                 if not response.candidates:
+                    feedback = getattr(response, 'prompt_feedback', None)
+                    self.last_call_diag = {
+                        "finish_reason": "NO_CANDIDATES",
+                        "empty_reason": f"no candidates (prompt_feedback={feedback})",
+                        "response_chars": 0,
+                        "truncated": False,
+                    }
                     return "No response generated due to safety filters or other restrictions."
 
                 candidate = response.candidates[0]
@@ -1058,9 +1109,22 @@ class GeminiLLM(LLMInterface):
                         )
 
                 if not candidate.content or not candidate.content.parts:
+                    self.last_call_diag = {
+                        "finish_reason": finish_reason_name,
+                        "empty_reason": "candidate had no content parts",
+                        "response_chars": 0,
+                        "truncated": finish_reason_name == "MAX_TOKENS",
+                    }
                     return "Empty response from Gemini."
 
                 content = response.text.strip()
+
+                self.last_call_diag = {
+                    "finish_reason": finish_reason_name,
+                    "empty_reason": None,
+                    "response_chars": len(content),
+                    "truncated": finish_reason_name == "MAX_TOKENS",
+                }
 
                 LLMCallTracker.get_instance().increment(
                     model=self.model,
@@ -1082,6 +1146,12 @@ class GeminiLLM(LLMInterface):
                 print(repr(e))
 
                 if "Invalid operation" in error_str and "finish_reason" in error_str:
+                    self.last_call_diag = {
+                        "finish_reason": "SAFETY_EXCEPTION",
+                        "empty_reason": f"safety filter exception: {error_str[:280]}",
+                        "response_chars": 0,
+                        "truncated": False,
+                    }
                     return "Response blocked by Gemini safety filters."
                 if _is_invalid_api_key_error(e):
                     raise

--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -1640,6 +1640,10 @@ class PaperProcessor:
         )
 
         all_cleaned: Dict[str, Any] = {}
+        # Diagnostics collected per batch so a fully-empty unit can be explained
+        # from the logs without re-running. Each entry records the batch's
+        # finish reason, why it was empty (if it was), and the full raw response.
+        batch_diags: List[Dict[str, Any]] = []
 
         batches = list(
             _chunk_list(columns, _MAX_COLUMNS_FOR_CONTROLLED_GENERATION)
@@ -1685,6 +1689,24 @@ class PaperProcessor:
                 **self._gemini_kwargs(thinking_budget=0),
             )
 
+            # Snapshot backend diagnostics for this call before the next one
+            # overwrites them. Also flag the sentinel strings the Gemini backend
+            # returns for no-candidate / empty-content / safety cases, which
+            # otherwise reach the JSON parser as ordinary (unparseable) text.
+            call_diag = dict(getattr(self.llm, "last_call_diag", {}) or {})
+            empty_signals = getattr(type(self.llm), "EMPTY_SIGNAL_RESPONSES", frozenset())
+            is_empty_signal = isinstance(raw, str) and raw.strip() in empty_signals
+            batch_diags.append({
+                "batch_idx": batch_idx,
+                "columns_requested": [c.name for c in col_batch],
+                "finish_reason": call_diag.get("finish_reason"),
+                "empty_reason": call_diag.get("empty_reason"),
+                "truncated": call_diag.get("truncated"),
+                "response_chars": call_diag.get("response_chars"),
+                "is_empty_signal": is_empty_signal,
+                "raw_response": raw,
+            })
+
             if self._check_stop_requested():
                 return all_cleaned
 
@@ -1718,6 +1740,8 @@ class PaperProcessor:
                 all_cleaned.update(cleaned)
 
             except Exception as e:
+                if batch_diags and batch_diags[-1]["batch_idx"] == batch_idx:
+                    batch_diags[-1]["parse_error"] = repr(e)
                 logger.warning(
                     "[%s] Error extracting values for unit '%s' (batch %d/%d): %s\n"
                     "Raw response was:\n%s",
@@ -1739,6 +1763,31 @@ class PaperProcessor:
             effective_text=eff,
             max_new_tokens=effective_max,
         )
+
+        # When the unit came back completely empty after all passes, dump the
+        # full picture to the logs (Railway-visible) so we can see WHY every
+        # column blanked. This is the anomaly path only, so it stays quiet in
+        # normal operation and needs no env var to enable.
+        final_filled, _ = _count_filled_columns(all_cleaned)
+        if final_filled == 0:
+            for d in batch_diags:
+                logger.warning(
+                    "[%s] EMPTY-UNIT batch %d/%d '%s': finish_reason=%s empty_signal=%s "
+                    "truncated=%s resp_chars=%s parse_error=%s empty_reason=%s\n"
+                    "columns_requested=%s\nFULL raw response:\n%s",
+                    paper_title,
+                    d["batch_idx"] + 1,
+                    len(batch_diags),
+                    unit_name,
+                    d.get("finish_reason"),
+                    d.get("is_empty_signal"),
+                    d.get("truncated"),
+                    d.get("response_chars"),
+                    d.get("parse_error"),
+                    d.get("empty_reason"),
+                    d.get("columns_requested"),
+                    d.get("raw_response"),
+                )
 
         from schematiq.value_extraction.utils.schema_builder import (
             align_extraction_keys_to_schema,


### PR DESCRIPTION
## Problem
Units sometimes extract to a fully empty row (0 filled of N columns) even when the data is clearly in the document. The Gemini backend detects the underlying causes (no candidates / safety filter, empty content, finish_reason=MAX_TOKENS, safety exception) but returns them as sentinel strings that flow downstream as ordinary text. They fail JSON parsing, get caught, and leave the result dict empty. There is no way to tell from the logs which cause fired for a given unit. The existing _debug_dump only runs on the success path, truncates raw_response to 5000 chars, and writes to a local dir that no-ops on Railway.

## Solution
- GeminiLLM records last_call_diag (finish_reason, empty_reason, response_chars, truncated) after every generate / generate_with_cache call, and exposes EMPTY_SIGNAL_RESPONSES so callers can recognize an empty-signal string.
- extract_values_for_unit collects per-batch diagnostics. When a unit ends up with zero filled columns after all retry passes, it logs finish_reason, empty-signal flag, truncation, response length, parse error, and the FULL untruncated raw response to logger.warning.
- Always on (anomaly path only), no env var needed, no extra LLM calls.

## Verify
- python -m py_compile on both changed files passes.
- git apply --ignore-whitespace --check passes on a fresh clone of main.
- Re-run extraction on session 4f8bb771; the EMPTY-UNIT log line will show which cause produced the empty row.