### PR TITLE
feat(workspace): support schema rediscovery for imported sessions

### DIFF
--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -981,6 +981,122 @@ async def add_documents(session_id: str, files: List[UploadFile] = File(...), by
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.post("/rediscover/{session_id}", response_model=dict)
+async def rediscover_imported_session(session_id: str, background_tasks: BackgroundTasks):
+    """Run schema rediscovery for an imported (UPLOAD-type) session.
+
+    Mirrors POST /schematiq/resume/{session_id}, which is restricted to
+    SessionType.SCHEMATIQ sessions and expects a config.json already written
+    by /schematiq/configure. An imported project (dual-file/zip) never goes
+    through that flow, so this endpoint synthesizes an equivalent config.json
+    from the session's existing query/observation_unit and runs it through the
+    same schematiq_runner used by every other run. Only reachable when the
+    session's rows already reference real source documents (see
+    precheck_document_availability below) — editing the observation unit alone
+    does not make rediscovery possible for a session with no documents behind
+    its data.
+    """
+    from app.core.config import RELEASE_CONFIG, LLM_CALL_GLOBAL_LIMIT, DEVELOPER_MODE
+    from app.models.schematiq import ScheMatiQConfig, LLMConfig
+    from schematiq.core.llm_call_tracker import QuotaExceededError
+    # Both are module-level singletons constructed in routes/schematiq.py, shared
+    # across the app the same way app.main imports schematiq_runner from there.
+    from app.api.routes.schematiq import schematiq_runner, QUOTA_EXCEEDED_USER_MESSAGE
+    from app.api.routes.schema import reextraction_service
+
+    try:
+        set_session_context(session_id)
+        session = session_manager.get_session(session_id)
+        if not session:
+            raise HTTPException(status_code=404, detail="Session not found")
+        if session.type != SessionType.UPLOAD:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Rediscovery via this endpoint is only for imported sessions (type='{session.type}').",
+            )
+        if not session.observation_unit:
+            raise HTTPException(
+                status_code=400,
+                detail="Session has no observation unit configured. Set one before rediscovering.",
+            )
+
+        # Same gate re-extraction uses: rediscovery is only meaningful if the
+        # session's rows actually resolve to real source documents somewhere
+        # (local pending_documents/documents, or the session's cloud dataset).
+        paper_discovery = await reextraction_service.discover_papers(session_id)
+        availability = await reextraction_service.precheck_document_availability(
+            session_id, operation_type="reextraction", paper_discovery=paper_discovery,
+        )
+        if not availability.get("can_proceed", False):
+            raise HTTPException(
+                status_code=400,
+                detail="No source documents are available for this project. "
+                       "Add the original source documents from the Documents tab, then try again.",
+            )
+
+        if not DEVELOPER_MODE:
+            try:
+                schematiq_runner.check_global_quota(LLM_CALL_GLOBAL_LIMIT)
+            except QuotaExceededError as exc:
+                from app.core.email_alerts import send_quota_exceeded_alert
+                send_quota_exceeded_alert(total_used=exc.used)
+                raise HTTPException(status_code=429, detail=QUOTA_EXCEEDED_USER_MESSAGE)
+
+        # Build a minimal, valid ScheMatiQConfig for this existing session.
+        # docs_path is left unset: resolve_docs_paths() already auto-detects
+        # session-local pending_documents/documents before falling back to it,
+        # which is exactly where an imported project's bundled files live.
+        config = ScheMatiQConfig(
+            query=session.schema_query or "",
+            docs_path=None,
+            schema_creation_backend=LLMConfig(
+                provider=RELEASE_CONFIG["llm_provider"],
+                model=RELEASE_CONFIG["schema_creation_model"],
+                temperature=RELEASE_CONFIG["llm_temperature"],
+            ),
+            value_extraction_backend=LLMConfig(
+                provider=RELEASE_CONFIG["llm_provider"],
+                model=RELEASE_CONFIG["value_extraction_model"],
+                temperature=RELEASE_CONFIG["llm_temperature"],
+            ),
+            output_path="outputs/rediscovered_output.json",
+        )
+        await schematiq_runner.save_config(session_id, config)
+
+        # Mark this run as an observation-unit rediscovery so prepare_resume
+        # clears prior schema/data artifacts and seeds initial_observation_unit
+        # from session.observation_unit, exactly like the SCHEMATIQ-session flow.
+        session = session_manager.get_session(session_id)
+        session.metadata.pending_observation_unit_rediscovery = True
+        session_manager.update_session(session)
+
+        try:
+            await schematiq_runner.prepare_resume(session_id)
+        except RuntimeError as e:
+            msg = str(e)
+            if "already has an active operation" in msg or "Timed out waiting" in msg:
+                raise HTTPException(
+                    status_code=409,
+                    detail="Pipeline is still stopping. Wait a few seconds and try again.",
+                ) from e
+            raise HTTPException(status_code=500, detail=msg) from e
+
+        background_tasks.add_task(schematiq_runner.run_schematiq, session_id)
+
+        return {"message": "Schema rediscovery started", "session_id": session_id}
+
+    except CapacityExceededError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        await concurrency_limiter.release(session_id)
+        logger.error(f"Exception in rediscover_imported_session: {e}")
+        import traceback
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 class CloudDocumentRequest(BaseModel):
     """Request model for adding cloud documents to a session."""
     dataset: str

--- a/backend/app/services/schematiq_runner.py
+++ b/backend/app/services/schematiq_runner.py
@@ -41,7 +41,7 @@ from schematiq.core.cost_estimator import estimate_from_config
 
 from app.models.schematiq import ScheMatiQConfig, ScheMatiQStatus
 from app.models.session import (
-    ColumnInfo, PaginatedData, SessionStatus,
+    ColumnInfo, PaginatedData, SessionStatus, SessionType,
     ObservationUnitInfo,
     SkippedDocumentInfo
 )
@@ -955,6 +955,18 @@ class ScheMatiQRunner(WebSocketBroadcasterMixin):
                 session.metadata.pending_observation_unit_rediscovery = False
                 session.metadata.observation_unit_rediscovery_run = False
                 logger.info("Cleared pending_observation_unit_rediscovery after successful rediscovery")
+                # An imported (UPLOAD-type) session that just completed a
+                # rediscovery run (see /load/rediscover) now has a real,
+                # self-sufficient schematiq_work/{session_id} pipeline output —
+                # promote it so it's treated like any other completed
+                # ScheMatiQ session from here on (status polling, re-extraction,
+                # further rediscovery all assume SessionType.SCHEMATIQ).
+                if session.type == SessionType.UPLOAD:
+                    session.type = SessionType.SCHEMATIQ
+                    logger.info(
+                        "Promoted session %s from UPLOAD to SCHEMATIQ after imported-project rediscovery",
+                        session_id,
+                    )
             self.session_manager.update_session(session)
             self.session_manager.capture_schema_baseline(session_id)
 

--- a/frontend/src/pages/Workspace/PendingRerunBanner.tsx
+++ b/frontend/src/pages/Workspace/PendingRerunBanner.tsx
@@ -3,12 +3,12 @@
 
 import { Loader2, RotateCw, Sparkles } from 'lucide-react';
 
-import type { PendingRerunKind, WorkspaceSessionMode } from './types';
+import type { PendingRerunKind } from './types';
 
 export function PendingRerunBanner({
   kind,
   columns,
-  sessionMode,
+  canRediscoverSchema,
   busy,
   onReextract,
   onRediscover,
@@ -16,7 +16,9 @@ export function PendingRerunBanner({
 }: {
   kind: PendingRerunKind;
   columns: string[];
-  sessionMode: WorkspaceSessionMode;
+  // Whether schema rediscovery is possible for this session (a fresh
+  // ScheMatiQ run, or an imported project with source documents attached).
+  canRediscoverSchema: boolean;
   busy: boolean;
   onReextract: () => void;
   onRediscover: () => void;
@@ -44,8 +46,8 @@ export function PendingRerunBanner({
             className="workspace-followup-action workspace-followup-action-primary"
             type="button"
             onClick={onRediscover}
-            disabled={busy || sessionMode !== 'schematiq'}
-            title={sessionMode !== 'schematiq' ? 'Schema rediscovery requires a ScheMatiQ project with source documents' : undefined}
+            disabled={busy || !canRediscoverSchema}
+            title={!canRediscoverSchema ? 'Schema rediscovery requires source documents attached to this project' : undefined}
           >
             {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
             Rediscover schema &amp; re-extract

--- a/frontend/src/pages/Workspace/hooks/useReextraction.ts
+++ b/frontend/src/pages/Workspace/hooks/useReextraction.ts
@@ -5,7 +5,7 @@ import {
   getDefaultModelForProvider,
   type LLMProviderKey,
 } from '@/constants';
-import { configAPI, schemaAPI, schematiqAPI } from '@/services/api';
+import { configAPI, loadAPI, schemaAPI, schematiqAPI } from '@/services/api';
 import type {
   DocumentAvailabilityResponse,
   ReextractionRequest,
@@ -19,6 +19,11 @@ import type { PendingRerunKind, SheetId, WorkspaceReextractionState, WorkspaceSe
 type UseReextractionOptions = {
   sessionId?: string;
   sessionMode: WorkspaceSessionMode;
+  // Whether the session has any source documents attached (uploaded at import
+  // time, or added afterward via add-documents). sessionMode alone only
+  // reflects the '?mode=load' URL param at page-load time, so an imported
+  // project that later gets documents attached would otherwise stay blocked.
+  hasSourceDocuments: boolean;
   schema: SchemaData | null;
   refresh: (options?: { silent?: boolean }) => Promise<void>;
   setActiveSheet: (sheet: SheetId) => void;
@@ -41,6 +46,7 @@ type UseReextractionOptions = {
 export function useReextraction({
   sessionId,
   sessionMode,
+  hasSourceDocuments,
   schema,
   refresh,
   setActiveSheet,
@@ -48,6 +54,10 @@ export function useReextraction({
   onRediscoveryStart,
   toast,
 }: UseReextractionOptions) {
+  // Rediscovery needs source documents to re-run against. A freshly created
+  // ScheMatiQ session always has them; an imported/dual-file session only has
+  // them if documents were attached afterward via add-documents.
+  const canRediscoverSchema = sessionMode === 'schematiq' || hasSourceDocuments;
   const [pendingRerunKind, setPendingRerunKind] = useState<PendingRerunKind | null>(null);
   const [pendingSchemaColumns, setPendingSchemaColumns] = useState<string[]>([]);
   const [rerunStarting, setRerunStarting] = useState(false);
@@ -245,10 +255,10 @@ export function useReextraction({
   const startSchemaRediscovery = useCallback(async () => {
     if (!sessionId || rerunStarting) return;
 
-    if (sessionMode !== 'schematiq') {
+    if (!canRediscoverSchema) {
       toast({
-        title: 'Rediscovery needs a ScheMatiQ run',
-        description: 'Imported static projects can edit the observation unit, but rediscovering schema requires a ScheMatiQ project with source documents.',
+        title: 'Rediscovery needs source documents',
+        description: 'Imported static projects can edit the observation unit, but rediscovering schema requires source documents attached to this project.',
         variant: 'destructive',
       });
       return;
@@ -271,7 +281,15 @@ export function useReextraction({
       // tab would otherwise keep showing stale columns. The observation unit is
       // preserved by the parent so the Observation Unit tab stays populated.
       onRediscoveryStart?.();
-      await schematiqAPI.resume(sessionId);
+      // Imported (load-mode) sessions never went through /schematiq/configure,
+      // so they have no config.json and schematiqAPI.resume would 404 (it's
+      // scoped to SessionType.SCHEMATIQ). Route them through the dedicated
+      // endpoint that synthesizes a config for the existing session instead.
+      if (sessionMode === 'load') {
+        await loadAPI.rediscoverImported(sessionId);
+      } else {
+        await schematiqAPI.resume(sessionId);
+      }
       clearPendingRerun();
       toast({
         title: 'Schema rediscovery started',
@@ -292,7 +310,7 @@ export function useReextraction({
     } finally {
       setRerunStarting(false);
     }
-  }, [cancelChatPendingIfAny, clearPendingRerun, onRediscoveryStart, refresh, rerunStarting, sessionId, sessionMode, toast]);
+  }, [cancelChatPendingIfAny, canRediscoverSchema, clearPendingRerun, onRediscoveryStart, refresh, rerunStarting, sessionId, sessionMode, toast]);
 
   const notifyEditFollowUp = useCallback((kind: PendingRerunKind, columns: string[] = []) => {
     markRerunNeeded(kind, columns);
@@ -300,13 +318,13 @@ export function useReextraction({
     if (kind === 'unit') {
       // The persistent top banner (driven by markRerunNeeded above) already
       // surfaces the "Rediscover schema & re-extract" action, so we do not fire a
-      // competing toast. Exception: in an imported (non-ScheMatiQ) project
-      // rediscovery is impossible and the banner's action only errors, so we
-      // surface a proactive, action-less explanation instead.
-      if (sessionMode !== 'schematiq') {
+      // competing toast. Exception: when rediscovery is impossible (no source
+      // documents attached) the banner's action only errors, so we surface a
+      // proactive, action-less explanation instead.
+      if (!canRediscoverSchema) {
         toast({
           title: 'Observation unit updated',
-          description: 'Imported static projects can edit the unit, but rediscovery needs a ScheMatiQ project with source documents.',
+          description: 'Imported static projects can edit the unit, but rediscovery needs source documents attached to this project.',
         });
       }
       return;
@@ -317,7 +335,7 @@ export function useReextraction({
     // here. The old toast was also broken — its action captured a stale
     // `requestReextraction` closure (schema not yet refreshed when the toast was
     // created), producing a false "No columns to re-extract" error on click.
-  }, [markRerunNeeded, sessionMode, toast]);
+  }, [canRediscoverSchema, markRerunNeeded, toast]);
 
   const runPendingEdits = useCallback(async () => {
     if (!sessionId || !pendingRerunKind || rerunStarting) return;
@@ -329,6 +347,7 @@ export function useReextraction({
   }, [pendingRerunKind, pendingSchemaColumns, rerunStarting, requestReextraction, sessionId, startSchemaRediscovery]);
 
   return {
+    canRediscoverSchema,
     pendingRerunKind,
     pendingSchemaColumns,
     rerunStarting,

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -481,27 +481,13 @@ function Workspace() {
       }
     };
 
-    try {
-      if (sessionMode === 'load') {
-        const loadSession = await loadAPI.getSession(sessionId).catch(() => null);
-        if (!loadSession) {
-          setSessionMissing(true);
-          if (!silent) setLoading(false);
-          return;
-        }
-        setSessionMissing(false);
-        setStatus(statusFromLoadSession(loadSession));
-        setSchema(schemaFromLoadSession(loadSession));
-        setSession(loadSession);
-        setConfig(null);
-        if (!silent) setLoading(false);
-        await loadHeavy(
-          () => loadAPI.getData(sessionId, 0, 500),
-          () => unitsAPI.getDocuments(sessionId),
-        );
-        return;
-      }
-
+    // Fetches for a session now known to be SCHEMATIQ-typed (either because
+    // sessionMode already said so, or because a load-mode session was just
+    // promoted after finishing an imported-project rediscovery — see
+    // /load/rediscover and the promotion in schematiq_runner.py). Shared so
+    // the promotion case below doesn't have to wait for a re-render before
+    // reading from the right place.
+    const fetchAsSchematiq = async () => {
       try {
         const [nextStatus, nextSchema, nextConfig, statsSession] = await Promise.all([
           schematiqAPI.getStatus(sessionId),
@@ -539,6 +525,41 @@ function Workspace() {
           () => unitsAPI.getDocuments(sessionId),
         );
       }
+    };
+
+    try {
+      if (sessionMode === 'load') {
+        const loadSession = await loadAPI.getSession(sessionId).catch(() => null);
+        if (!loadSession) {
+          setSessionMissing(true);
+          if (!silent) setLoading(false);
+          return;
+        }
+        // An imported session that just finished a schema-rediscovery run
+        // (see useReextraction's loadAPI.rediscoverImported path) is promoted
+        // server-side from UPLOAD to SCHEMATIQ on completion. Once that
+        // happens, its rows live in schematiq_work/, not the load-mode data
+        // dir — read it as a SCHEMATIQ session from here on instead of
+        // rendering a stale/empty load-mode view.
+        if (loadSession.type === 'schematiq') {
+          setSessionMode('schematiq');
+          await fetchAsSchematiq();
+          return;
+        }
+        setSessionMissing(false);
+        setStatus(statusFromLoadSession(loadSession));
+        setSchema(schemaFromLoadSession(loadSession));
+        setSession(loadSession);
+        setConfig(null);
+        if (!silent) setLoading(false);
+        await loadHeavy(
+          () => loadAPI.getData(sessionId, 0, 500),
+          () => unitsAPI.getDocuments(sessionId),
+        );
+        return;
+      }
+
+      await fetchAsSchematiq();
     } finally {
       if (!silent) {
         setLoading(false);
@@ -566,7 +587,17 @@ function Workspace() {
     toast,
   });
 
+  // sessionMode reflects only the '?mode=load' URL param captured at page load,
+  // not whether the session's data actually has source documents to rediscover
+  // from. `documents` (unitsAPI.getDocuments) reflects the real, row-level
+  // _source_document data — the same signal the re-extraction pipeline itself
+  // reads — so an imported project whose rows already carry _source_document
+  // (e.g. a dual-file/zip import) is correctly treated as having source docs,
+  // independent of whether the raw files were also re-attached for preview.
+  const hasSourceDocuments = (documents?.totalDocuments ?? 0) > 0;
+
   const {
+    canRediscoverSchema,
     pendingRerunKind,
     pendingSchemaColumns,
     rerunStarting,
@@ -589,6 +620,7 @@ function Workspace() {
   } = useReextraction({
     sessionId,
     sessionMode,
+    hasSourceDocuments,
     schema,
     refresh,
     setActiveSheet,
@@ -1069,7 +1101,14 @@ function Workspace() {
 
     // Still working: surface a live, human label instead of the raw status key.
     if (!isDone) {
-      return sessionMode === 'load' ? 'Importing…' : 'Extracting…';
+      // An UPLOAD-type session only ever reaches status='processing' via
+      // /load/rediscover (see useReextraction) — a plain import never sets
+      // this status. Label it distinctly so "Rediscover schema" doesn't
+      // misleadingly read as "Importing…" for the run's whole duration.
+      if (sessionMode === 'load') {
+        return rawStatus === 'processing' ? 'Rediscovering schema…' : 'Importing…';
+      }
+      return 'Extracting…';
     }
 
     // Done: replace the status word (which just repeats what the visible table
@@ -1259,7 +1298,7 @@ function Workspace() {
         <PendingRerunBanner
           kind={pendingRerunKind}
           columns={pendingSchemaColumns}
-          sessionMode={sessionMode}
+          canRediscoverSchema={canRediscoverSchema}
           busy={rerunStarting}
           onReextract={() => requestReextraction(pendingRerunKind === 'schema' ? pendingSchemaColumns : undefined)}
           onRediscover={startSchemaRediscovery}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -266,6 +266,17 @@ export const loadAPI = {
     return response.data;
   },
 
+  /**
+   * Start schema rediscovery for an imported (UPLOAD-type) session — the
+   * equivalent of schematiqAPI.resume for a session that never went through
+   * /schematiq/configure. Only succeeds if the session's rows already
+   * reference resolvable source documents.
+   */
+  rediscoverImported: async (sessionId: string): Promise<{ message: string; session_id: string }> => {
+    const response = await api.post(`/load/rediscover/${sessionId}`);
+    return response.data;
+  },
+
   confirmWebSocketReady: async (sessionId: string): Promise<{ status: string; connections: number; session_id: string }> => {
     const response = await api.post(`/load/sessions/${sessionId}/confirm-websocket`);
     return response.data;


### PR DESCRIPTION
## Problem
Imported (dual-file/zip) sessions are SessionType.UPLOAD and never go through /schematiq/configure, so they have no config.json. The 'Rediscover schema & re-extract' banner was gated purely on sessionMode (the '?mode=load' URL param at page load), so even a project whose rows genuinely reference source documents was permanently blocked — and if the gate were simply removed, the click would 404 against /schematiq/resume, which is hard-scoped to SessionType.SCHEMATIQ.

## Solution
- New POST /load/rediscover/{session_id}: validates the session has real, resolvable source documents (reusing precheck_document_availability), synthesizes a ScheMatiQConfig from the session's existing query/observation_unit and release-mode LLM defaults, then runs prepare_resume + run_schematiq — the exact same pipeline every other rediscovery uses.
- schematiq_runner.py promotes the session from UPLOAD to SCHEMATIQ on successful completion, so subsequent reads pull from schematiq_work/ (where the pipeline writes) instead of the load-mode data dir (where nothing was written).
- Frontend gates on hasSourceDocuments (unitsAPI.getDocuments, the same row-level _source_document signal the extraction pipeline itself reads) instead of sessionMode, and refresh() detects the UPLOAD->SCHEMATIQ promotion to switch data-fetch paths without a page reload.

## Verify
- Applied on fresh clone of main (9b6ac3a): git apply --ignore-whitespace --check passes
- python -m py_compile passes on both backend files
- npx tsc --noEmit passes with no errors
- Merged cleanly alongside PR #425 (onRediscoveryStart / observation-unit-visibility fix), which landed on main mid-session