### PR TITLE
fix(workspace): gate imported-session rediscovery on real document availability

### DIFF
--- a/frontend/src/pages/Workspace/hooks/useReextraction.ts
+++ b/frontend/src/pages/Workspace/hooks/useReextraction.ts
@@ -266,6 +266,28 @@ export function useReextraction({
 
     setRerunStarting(true);
     try {
+      // The enabled-state gate (canRediscoverSchema) only confirms the rows
+      // reference source documents by name. An imported project can carry those
+      // names without the underlying files being retrievable (a dual-file
+      // import saves no raw documents; a bundle may ship without a documents/
+      // folder). Confirm real availability against the same precheck the
+      // backend uses BEFORE the destructive optimistic clear below, so a run
+      // that is bound to 404/400 does not blank the Schema tab on its way out.
+      // A failing precheck falls through to the authoritative backend gate.
+      if (sessionMode === 'load') {
+        const availability = await schemaAPI
+          .precheckDocuments(sessionId, { operation_type: 'reextraction' })
+          .catch(() => null);
+        if (availability && !availability.can_proceed) {
+          toast({
+            title: 'Rediscovery needs source documents',
+            description: 'No source documents are available for this project. Add the original source documents from the Documents tab, then try again.',
+            variant: 'destructive',
+          });
+          return;
+        }
+      }
+
       const chatPendingCleared = await cancelChatPendingIfAny();
       if (!chatPendingCleared) {
         toast({

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -588,12 +588,14 @@ function Workspace() {
   });
 
   // sessionMode reflects only the '?mode=load' URL param captured at page load,
-  // not whether the session's data actually has source documents to rediscover
-  // from. `documents` (unitsAPI.getDocuments) reflects the real, row-level
-  // _source_document data — the same signal the re-extraction pipeline itself
-  // reads — so an imported project whose rows already carry _source_document
-  // (e.g. a dual-file/zip import) is correctly treated as having source docs,
-  // independent of whether the raw files were also re-attached for preview.
+  // not whether the session can actually be rediscovered. `documents`
+  // (unitsAPI.getDocuments) counts the distinct _source_document NAMES carried
+  // by the rows — a necessary but not sufficient signal: a project can
+  // reference document names whose underlying files are not retrievable (a
+  // dual-file import stores no raw documents; a bundle may ship without a
+  // documents/ folder). This cheap check only gates the button's enabled
+  // state; the actual file availability the pipeline needs is confirmed by the
+  // precheck in startSchemaRediscovery (and, authoritatively, by the backend).
   const hasSourceDocuments = (documents?.totalDocuments ?? 0) > 0;
 
   const {


### PR DESCRIPTION
## Problem
The Rediscover-schema button for imported (load-mode) sessions is enabled whenever the rows carry any _source_document names (documents.totalDocuments > 0). That count is metadata only: get_source_documents counts distinct source-document names, while the pipeline's real gate (discover_papers -> can_proceed) requires the underlying files to be retrievable locally or in the cloud. For an import with no retrievable files (a dual-file import saves no raw documents; a bundle may ship without a documents/ folder), the button is enabled but clicking it runs the optimistic schema clear and then hits a backend 400, briefly blanking the Schema tab on a run that was always doomed. An inline comment also wrongly claimed totalDocuments is "the same signal the re-extraction pipeline itself reads".

## Solution
Before the destructive optimistic clear in startSchemaRediscovery, load-mode rediscovery now runs schemaAPI.precheckDocuments (the same availability check re-extraction uses, and the same signal the backend enforces). If can_proceed is false, it shows a clear "add source documents" message and aborts without clearing the schema. If the precheck itself errors, it falls through to the authoritative backend gate, matching the existing re-extraction behavior. The misleading comment is corrected to describe totalDocuments as a necessary-but-not-sufficient name count. The button's enabled state is unchanged.

## Verify
- git apply --ignore-whitespace --check on a fresh clone: applies clean.
- ( cd frontend && npx tsc --noEmit ): passes, no type errors.
- Manual: an imported session whose files are not retrievable now shows the message on click without blanking the Schema tab; a bundle imported with a documents/ folder still rediscovers as before.