### PR TITLE
fix(workspace): label imported-session rediscovery step for direct current_step readers

### DIFF
--- a/frontend/src/pages/Workspace/helpers.ts
+++ b/frontend/src/pages/Workspace/helpers.ts
@@ -290,11 +290,22 @@ export function schemaFromLoadSession(session: VisualizationSession | null): Sch
 export function statusFromLoadSession(session: VisualizationSession | null): ScheMatiQStatus | null {
   if (!session) return null;
   const completed = session.status === 'completed' || session.status === 'schema_extracted';
+  // status='processing' on an UPLOAD-type session only happens mid schema
+  // rediscovery (see /load/rediscover) — a plain import never reaches it (it
+  // uses 'processing_documents'). The raw status string otherwise reads as an
+  // internal state name, not something meant for the bottom-bar step label or
+  // the project-details "Current step" row, both of which read current_step
+  // directly.
+  const currentStep = completed
+    ? 'Imported project loaded'
+    : session.status === 'processing'
+      ? 'Rediscovering schema…'
+      : session.status;
   return {
     session_id: session.id,
     status: session.status,
     progress: completed ? 1 : 0,
-    current_step: completed ? 'Imported project loaded' : session.status,
+    current_step: currentStep,
     steps_completed: completed ? 1 : 0,
     total_steps: 1,
     schema_completed: Boolean(session.columns?.length),


### PR DESCRIPTION
## Problem
PR #429 mapped an imported (UPLOAD-type) session's status='processing' to the label "Rediscovering schema…" in the derived status useMemo in Workspace/index.tsx. But two surfaces read status.current_step directly rather than that memo: the bottom-bar status text (bottombarStatus) and the "Current step" row in ProjectDetailsDialog. For a load-mode session mid rediscovery, statusFromLoadSession set current_step to the raw session.status, so those two surfaces showed "processing" while the top label showed "Rediscovering schema…" — a visible inconsistency.

## Solution
statusFromLoadSession now maps status='processing' to "Rediscovering schema…" in current_step, matching the index.tsx label. An UPLOAD session only reaches status='processing' via /load/rediscover; a plain import (or add-documents) uses 'processing_documents', a distinct value the exact-match check does not catch, so initial imports are unaffected.

## Verify
- git apply --ignore-whitespace --check on a fresh main clone: applies clean.
- ( cd frontend && npx tsc --noEmit ): passes, no type errors.
- Backend SessionStatus confirms PROCESSING = "processing" and PROCESSING_DOCUMENTS = "processing_documents" are distinct.