### PR TITLE
feat(chat): diagnostic tools for skipped and missing documents

### DIFF
--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -224,6 +224,53 @@ class ToolExecutor:
           "missing_definitions": missing_definitions,
       }
 
+  async def _handle_list_skipped_documents(
+      self, session_id: str, session_mode: str, args: dict[str, Any]
+  ) -> dict[str, Any]:
+      # Surface documents that produced no rows during extraction, with the
+      # recorded reason. Neither reextract nor reprocess re-includes these, so the
+      # agent needs this to explain a "missing" document instead of proposing a
+      # re-run that cannot bring it back.
+      session = session_manager.get_session(session_id)
+      if not session:
+          raise ValueError("Session not found")
+      skipped = (
+          session.statistics.skipped_documents
+          if session.statistics and session.statistics.skipped_documents
+          else []
+      )
+      return {
+          "status": "success",
+          "count": len(skipped),
+          "skipped_documents": [
+              {"document": entry.document, "reason": entry.reason}
+              for entry in skipped
+          ],
+      }
+
+  async def _handle_list_documents(
+      self, session_id: str, session_mode: str, args: dict[str, Any]
+  ) -> dict[str, Any]:
+      # Report the source documents that define rows and their availability. Uses
+      # the same discovery the re-extraction precheck relies on, compacted to
+      # names-by-status so the payload stays small.
+      availability = await reextraction_service.precheck_document_availability(session_id)
+      return {
+          "status": "success",
+          "total_documents": availability.get("total_documents", 0),
+          "total_rows": availability.get("total_rows", 0),
+          "local_documents": [
+              doc["name"] for doc in availability.get("local_documents", [])
+          ],
+          "cloud_documents": [
+              doc["name"] for doc in availability.get("cloud_documents", [])
+          ],
+          "missing_documents": [
+              doc["name"] for doc in availability.get("missing_documents", [])
+          ],
+          "rows_with_missing_docs": availability.get("rows_with_missing_docs", 0),
+      }
+
   async def _handle_list_reference_sources(
       self, session_id: str, session_mode: str, args: dict[str, Any]
   ) -> dict[str, Any]:

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -114,6 +114,37 @@ def _all_tools() -> list[ToolSpec]:
             handler="get_validation",
         ),
         ToolSpec(
+            name="list_skipped_documents",
+            description=(
+                "List the source documents that were skipped during extraction and "
+                "the recorded reason for each — documents that produced no table rows "
+                "because no matching observation unit was found in them. Use this FIRST "
+                "when the user asks why a document is missing, has no data, or was not "
+                "extracted. A skipped document will NOT be re-included by reextract or "
+                "reprocess (both keep skipped documents skipped); re-including one "
+                "requires changing the observation unit so the document matches. Read "
+                "the reason and explain it to the user before proposing any re-run."
+            ),
+            parameters=EMPTY_PARAMS,
+            cost_class="cheap",
+            handler="list_skipped_documents",
+            session_modes=("schematiq",),
+        ),
+        ToolSpec(
+            name="list_documents",
+            description=(
+                "List the source documents in this project and their availability "
+                "(local, cloud, or missing), plus row counts. These are the documents "
+                "that define table rows, NOT the external reference material listed by "
+                "list_reference_sources. Use this to answer what documents the project "
+                "contains, or to check whether documents are present before proposing a "
+                "re-extraction."
+            ),
+            parameters=EMPTY_PARAMS,
+            cost_class="cheap",
+            handler="list_documents",
+        ),
+        ToolSpec(
             name="list_reference_sources",
             description=(
                 "List the external reference documents the user attached to this "
@@ -362,7 +393,9 @@ def _all_tools() -> list[ToolSpec]:
                 "when omitted it defaults to the edited/new columns only (scope='edited_only'). "
                 "Does not touch other columns or the observation unit unless scope='all'. Use "
                 "this for a targeted refresh after add_column/edit_column; use `reprocess` to "
-                "refresh the entire table."
+                "refresh the entire table. Does NOT re-include a document that was skipped "
+                "during extraction (skipped documents stay skipped): if the user asks about a "
+                "missing document, call list_skipped_documents first."
             ),
             parameters={
                 "type": "object",
@@ -405,7 +438,10 @@ def _all_tools() -> list[ToolSpec]:
                 "Re-run value extraction for the ENTIRE table — every column — from the source "
                 "documents (expensive). When `columns` is omitted it re-extracts all columns "
                 "(scope='all'). Use this for a full refresh of every value; prefer `reextract` "
-                "when you only changed specific columns and want to refresh just those."
+                "when you only changed specific columns and want to refresh just those. Does "
+                "NOT re-include a document that was skipped during extraction (skipped "
+                "documents stay skipped): if the user asks about a missing document, call "
+                "list_skipped_documents first."
             ),
             parameters={
                 "type": "object",
@@ -515,6 +551,8 @@ def tool_running_label(tool_name: str) -> str:
         "edit_observation_unit": "Updating observation unit definition",
         "preview_data": "Loading data preview",
         "get_validation": "Validating schema",
+        "list_skipped_documents": "Listing skipped documents",
+        "list_documents": "Listing documents",
         "list_reference_sources": "Listing reference documents",
         "read_reference_source": "Reading reference document",
         "add_column": "Adding column",


### PR DESCRIPTION
Problem: When a user asks why a document has no data, the chat agent cannot tell them. Skipped documents are recorded on session statistics with a reason, but no tool surfaces them, and neither reextract nor reprocess can re-include a skipped document. In practice the agent offered those two operations for a skipped file, neither of which could bring it back.

Solution: Add two cheap, read-only chat tools. list_skipped_documents returns each skipped document and its recorded reason (schematiq sessions only). list_documents reports the project's source documents by availability (local/cloud/missing) with row counts, reusing the re-extraction precheck. The reextract and reprocess tool descriptions now tell the agent that skipped documents stay skipped and to call list_skipped_documents first when asked about a missing document.

Verify: Fresh clone, git apply --ignore-whitespace --check passes. python -m py_compile passes for both files. Registry invariants hold: tool names unique, expensive set unchanged (run_schematiq/reextract/continue_discovery/reprocess), new tools are cheap, session_id not exposed to the model, handler names match dispatch. No frontend changes.