### PR TITLE
feat(chat): merge_units tool for combining duplicate unit rows

### DIFF
--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -594,6 +594,51 @@ class ToolExecutor:
           unit_name=args["unit_name"],
       )
 
+  async def _handle_merge_units(
+      self, session_id: str, session_mode: str, args: dict[str, Any]
+  ) -> dict[str, Any]:
+      # Wire the existing By Unit view merge (unit_view_service.merge_units) to the
+      # chat. It relabels the source rows to a single target unit name (strategy
+      # 'rename'), keeping their data. The service is synchronous and touches the
+      # storage backend, so run it off the event loop.
+      session = session_manager.get_session(session_id)
+      if not session:
+          raise ValueError("Session not found")
+      raw_units = args.get("units") or []
+      units = [u.strip() for u in raw_units if isinstance(u, str) and u.strip()]
+      if len(units) < 2:
+          raise ValueError("merge_units needs at least two distinct row names in 'units'.")
+      target = (args.get("target_name") or units[0]).strip()
+      if not target:
+          raise ValueError("Target unit name cannot be empty.")
+
+      from app.models.unit import MergeUnitsRequest
+      from app.services.unit_view_service import unit_view_service
+
+      request = MergeUnitsRequest(source_units=units, target_unit=target, strategy="rename")
+      loop = asyncio.get_running_loop()
+      response = await loop.run_in_executor(
+          None, unit_view_service.merge_units, session_id, request
+      )
+
+      if response.success and response.rows_affected:
+          # Data-only change: row_completed makes the workspace silently re-fetch
+          # rows. Best-effort — a streaming hiccup must never fail the merge.
+          try:
+              await websocket_manager.broadcast_row_completed(
+                  session_id,
+                  {"operation": "merge_units", "target_unit": target},
+              )
+          except Exception:  # streaming is best-effort
+              pass
+
+      return {
+          "status": "success" if response.success else "error",
+          "message": response.message,
+          "target_unit": target,
+          "rows_affected": response.rows_affected,
+      }
+
   async def _handle_export_table(
       self, session_id: str, session_mode: str, args: dict[str, Any]
   ) -> dict[str, Any]:

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -330,6 +330,44 @@ def _all_tools() -> list[ToolSpec]:
             handler="remove_unit",
         ),
         ToolSpec(
+            name="merge_units",
+            description=(
+                "Merge two or more table rows that represent the SAME observation unit "
+                "under different names into one row, keeping their data. Use this when "
+                "the same entity appears as separate rows (for example the same judge "
+                "listed once by full name and once as 'Judge X'). This merges DATA ROWS, "
+                "not schema columns (use merge_columns for columns) and not the "
+                "observation unit definition (use edit_observation_unit for that). Get "
+                "the exact row names from preview_data first. Pass the row names in "
+                "`units` (at least two) and optionally a `target_name` for the merged "
+                "row; when omitted the first name in `units` is used."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "units": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 2,
+                        "description": (
+                            "Row / observation-unit names to merge (at least two), "
+                            "exactly as shown by preview_data."
+                        ),
+                    },
+                    "target_name": {
+                        "type": "string",
+                        "description": (
+                            "Name for the merged row. Defaults to the first name in "
+                            "`units`."
+                        ),
+                    },
+                },
+                "required": ["units"],
+            },
+            cost_class="cheap",
+            handler="merge_units",
+        ),
+        ToolSpec(
             name="export_table",
             description="Export the table (csv, rich csv with excerpts, or schema only).",
             parameters={
@@ -524,6 +562,7 @@ def tool_running_label(tool_name: str) -> str:
         "update_cell": "Updating cell",
         "add_unit": "Adding observation unit",
         "remove_unit": "Removing observation unit",
+        "merge_units": "Merging observation units",
         "export_table": "Preparing export",
         "run_schematiq": "Starting ScheMatiQ extraction",
         "reextract": "Starting re-extraction",

--- a/frontend/src/pages/Workspace/constants.ts
+++ b/frontend/src/pages/Workspace/constants.ts
@@ -151,6 +151,7 @@ export const CHAT_MUTATION_TOOLS = new Set([
   'update_cell',
   'add_unit',
   'remove_unit',
+  'merge_units',
   'edit_observation_unit',
   'run_schematiq',
   'reextract',


### PR DESCRIPTION
Problem: The same observation unit sometimes appears as separate rows under different names (for example a judge listed once by full name and once as 'Judge X'). The By Unit view can merge these, but the chat agent has no way to, so a user working in chat cannot fix duplicate rows.

Solution: Expose the existing unit_view_service.merge_units through a new cheap chat tool, merge_units. It takes the row names to merge (at least two) and an optional target_name (defaults to the first), relabels the source rows to the target unit (strategy 'rename', keeping their data), and broadcasts row_completed so the workspace silently refreshes. The synchronous service call runs off the event loop. merge_units is added to CHAT_MUTATION_TOOLS so the table refreshes after the chat call, mirroring merge_columns.

Verify: Fresh clone. git apply --ignore-whitespace --check passes. python -m py_compile passes for both backend files. npx tsc --noEmit passes with no errors. Registry invariants hold: 25 tools, unique names, expensive set unchanged, merge_units is cheap with required=['units'] and minItems=2, session_id not exposed to the model.