### PR TITLE
feat(chat): explain_cell + row-scoped reference fill + confirmed-empty guard

### DIFF
--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -340,10 +340,121 @@ class ToolExecutor:
   ) -> dict[str, Any]:
       # Delegate to the background fill service: it runs one model call per row and
       # streams cells as they complete, returning immediately so a whole-column
-      # fill never blocks (or times out) the chat turn.
+      # fill never blocks (or times out) the chat turn. `rows` optionally scopes the
+      # fill to specific observation-unit / row names.
       return await reference_fill_service.start_fill(
-          session_id, args.get("column"), args.get("reference_id")
+          session_id,
+          args.get("column"),
+          args.get("reference_id"),
+          rows=args.get("rows"),
       )
+
+  async def _handle_explain_cell(
+      self, session_id: str, session_mode: str, args: dict[str, Any]
+  ) -> dict[str, Any]:
+      # Read-only: classify one cell so the agent knows whether filling would help.
+      from app.services.data_utils import (
+          get_extraction_column_value,
+          resolve_session_data_files,
+      )
+      from app.services.reextraction_service import _is_empty_cell_value
+
+      row_name = (args.get("row") or "").strip()
+      column = (args.get("column") or "").strip()
+      if not row_name or not column:
+          raise ValueError("Both 'row' and 'column' are required.")
+
+      def _row_id(row: dict[str, Any]) -> Optional[str]:
+          return row.get("_row_name") or row.get("row_name") or row.get("_unit_name")
+
+      def _papers(row: dict[str, Any]) -> list[str]:
+          return row.get("_papers") or row.get("papers") or []
+
+      data_files = await resolve_session_data_files(session_id)
+      matched: Optional[dict[str, Any]] = None
+      for path in data_files:
+          try:
+              with open(path, "r") as handle:
+                  for line in handle:
+                      if not line.strip():
+                          continue
+                      try:
+                          row = json.loads(line)
+                      except json.JSONDecodeError:
+                          continue
+                      if _row_id(row) == row_name:
+                          matched = row
+                          break
+          except OSError:
+              continue
+          if matched is not None:
+              break
+
+      documents = [Path(p).stem for p in _papers(matched)] if matched else []
+
+      # Was the owning document skipped entirely?
+      session = session_manager.get_session(session_id)
+      skipped = {}
+      if session and session.statistics and session.statistics.skipped_documents:
+          skipped = {
+              Path(s.document).stem: s.reason
+              for s in session.statistics.skipped_documents
+          }
+
+      if matched is None:
+          skip_hit = next((skipped[d] for d in documents if d in skipped), None)
+          if documents and skip_hit is not None:
+              return {
+                  "row": row_name,
+                  "column": column,
+                  "state": "document_skipped",
+                  "reason": skip_hit,
+                  "documents": documents,
+              }
+          return {
+              "row": row_name,
+              "column": column,
+              "state": "row_not_found",
+              "message": (
+                  "No row with that name was found. Check the name via preview_data."
+              ),
+          }
+
+      value = get_extraction_column_value(matched, column)
+      if not _is_empty_cell_value(value):
+          excerpts = value.get("excerpts") if isinstance(value, dict) else None
+          answer = value.get("answer") if isinstance(value, dict) else value
+          return {
+              "row": row_name,
+              "column": column,
+              "state": "has_value",
+              "value": answer,
+              "excerpts": excerpts or [],
+              "documents": documents,
+          }
+
+      confirmed = isinstance(value, dict) and bool(value.get("_confirmed_empty"))
+      skip_hit = next((skipped[d] for d in documents if d in skipped), None)
+      if skip_hit is not None:
+          return {
+              "row": row_name,
+              "column": column,
+              "state": "document_skipped",
+              "reason": skip_hit,
+              "documents": documents,
+          }
+      return {
+          "row": row_name,
+          "column": column,
+          "state": "confirmed_empty" if confirmed else "not_extracted",
+          "message": (
+              "The model inspected the source for this cell and found no value; "
+              "re-extraction is unlikely to fill it."
+              if confirmed
+              else "No extraction has produced a value yet; extract_cells can fill it."
+          ),
+          "documents": documents,
+      }
 
   async def _handle_add_column(
       self, session_id: str, session_mode: str, args: dict[str, Any]

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -107,6 +107,36 @@ def _all_tools() -> list[ToolSpec]:
             handler="preview_data",
         ),
         ToolSpec(
+            name="explain_cell",
+            description=(
+                "Explain the state of a single cell (read-only): whether it has a "
+                "value and where that value came from, or — if it is empty — why. "
+                "Distinguishes three empty cases so you know whether filling it will "
+                "help: 'confirmed_empty' (the model already inspected the source and "
+                "found no value, so re-extracting is unlikely to help), 'not_extracted' "
+                "(no extraction has produced a value yet, so extract_cells can fill it), "
+                "and 'document_skipped' (the source document was skipped entirely — see "
+                "list_skipped_documents). For filled cells it returns the value plus any "
+                "source excerpts. Use row/column names from preview_data."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "row": {
+                        "type": "string",
+                        "description": "Observation-unit / row name (as shown by preview_data).",
+                    },
+                    "column": {
+                        "type": "string",
+                        "description": "Column name to inspect.",
+                    },
+                },
+                "required": ["row", "column"],
+            },
+            cost_class="cheap",
+            handler="explain_cell",
+        ),
+        ToolSpec(
             name="get_validation",
             description="Validate the schema for duplicate names, missing definitions, and other issues.",
             parameters=EMPTY_PARAMS,
@@ -193,7 +223,8 @@ def _all_tools() -> list[ToolSpec]:
                 "the reference (so it works even for references too large to read at "
                 "once) and fills each row as it completes. Use this instead of many "
                 "individual update_cell calls when populating a whole column from a "
-                "reference. Get the reference id from list_reference_sources."
+                "reference. Pass `rows` to fill only specific rows instead of the "
+                "whole column. Get the reference id from list_reference_sources."
             ),
             parameters={
                 "type": "object",
@@ -205,6 +236,14 @@ def _all_tools() -> list[ToolSpec]:
                     "reference_id": {
                         "type": "string",
                         "description": "Reference document id from list_reference_sources.",
+                    },
+                    "rows": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "Optional observation-unit / row names to fill (as shown by "
+                            "preview_data). Omit to fill every row in the column."
+                        ),
                     },
                 },
                 "required": ["column", "reference_id"],
@@ -473,7 +512,10 @@ def _all_tools() -> list[ToolSpec]:
                 "with only_empty=true (the default) to fill every empty cell, or add "
                 "documents/rows/columns to narrow the scope. A document listed in "
                 "`documents` that was previously skipped is re-evaluated, so this also "
-                "retries skipped documents. Get exact names from list_documents, "
+                "retries skipped documents. Cells the model already inspected and "
+                "confirmed have no value are left alone by only_empty; set "
+                "only_empty=false to force those (and filled cells) to be re-extracted. "
+                "Get exact names from list_documents, "
                 "list_skipped_documents, or preview_data first."
             ),
             parameters={
@@ -644,6 +686,7 @@ def tool_running_label(tool_name: str) -> str:
         "get_observation_unit": "Loading observation unit",
         "edit_observation_unit": "Updating observation unit definition",
         "preview_data": "Loading data preview",
+        "explain_cell": "Explaining cell",
         "get_validation": "Validating schema",
         "list_skipped_documents": "Listing skipped documents",
         "list_documents": "Listing documents",

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -59,6 +59,21 @@ def _is_empty_cell_value(value: Any) -> bool:
     return False
 
 
+def _is_fillable_gap(value: Any) -> bool:
+    """True when a cell is an unresolved gap worth an extraction attempt.
+
+    A cell the model explicitly confirmed empty (``_confirmed_empty``) is treated
+    as resolved, not a gap: only_empty runs skip it so we do not re-bill the model
+    on cells it already judged. Callers that want to retry those cells anyway use
+    only_empty=false, which bypasses the gap check entirely.
+    """
+    if not _is_empty_cell_value(value):
+        return False
+    if isinstance(value, dict) and value.get("_confirmed_empty"):
+        return False
+    return True
+
+
 class ReextractionOperation:
     """Tracks a running re-extraction operation."""
     def __init__(
@@ -1006,7 +1021,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                             paper_stems & doc_filter if doc_filter is not None else paper_stems
                         )
                         for col in columns:
-                            if _is_empty_cell_value(get_extraction_column_value(row, col)):
+                            if _is_fillable_gap(get_extraction_column_value(row, col)):
                                 empty_columns.add(col)
                                 docs_with_empties.update(scope_stems)
             except Exception as e:  # unreadable file -> fall back to no narrowing
@@ -1968,7 +1983,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                             remove_column_keys_in_row(row, old_name)
                         extracted_value = get_extraction_column_value(extracted, col_name)
                         if extracted_value is not None:
-                            if only_empty and not _is_empty_cell_value(
+                            if only_empty and not _is_fillable_gap(
                                 get_extraction_column_value(row, col_name)
                             ):
                                 continue  # never overwrite a filled cell
@@ -2049,7 +2064,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                                 extracted, col_name
                             )
                             if extracted_value is not None:
-                                if only_empty and not _is_empty_cell_value(
+                                if only_empty and not _is_fillable_gap(
                                     get_extraction_column_value(row, col_name)
                                 ):
                                     continue  # never overwrite a filled cell

--- a/backend/app/services/reference_fill_service.py
+++ b/backend/app/services/reference_fill_service.py
@@ -169,16 +169,25 @@ class ReferenceFillService:
     # ---- public API -------------------------------------------------------
 
     async def start_fill(
-        self, session_id: str, column: str, reference_id: str
+        self, session_id: str, column: str, reference_id: str,
+        rows: Optional[list[str]] = None,
     ) -> dict[str, Any]:
         """Validate the request, then start the fill in the background.
 
         Returns immediately with the operation id and the number of rows to fill.
+        When ``rows`` is given, only those observation-unit / row names are filled;
+        otherwise every row in the column is filled.
         """
         column = (column or "").strip()
         reference_id = (reference_id or "").strip()
         if not column or not reference_id:
             raise ValueError("Both 'column' and 'reference_id' are required.")
+
+        # Capture the requested row names before the `rows` local is reassigned to the
+        # loaded row dicts below.
+        requested_row_names = {
+            r.strip() for r in (rows or []) if isinstance(r, str) and r.strip()
+        }
 
         session = self._sessions.get_session(session_id)
         if not session:
@@ -196,9 +205,21 @@ class ReferenceFillService:
         if not reference_text.strip():
             raise ValueError(f"Reference '{ref.filename}' is empty.")
 
-        rows = await self._load_all_rows(session_id)
-        if not rows:
+        loaded_rows = await self._load_all_rows(session_id)
+        if not loaded_rows:
             raise ValueError("No rows to fill.")
+
+        if requested_row_names:
+            loaded_rows = [
+                r for r in loaded_rows
+                if (r.get("unit_name") or r.get("row_name")) in requested_row_names
+            ]
+            if not loaded_rows:
+                raise ValueError(
+                    "None of the requested rows were found. Check the names via "
+                    "preview_data."
+                )
+        rows = loaded_rows
 
         column_obj = next(
             (c for c in session.columns if c.name == column), None


### PR DESCRIPTION
## Problem
Three gaps after extract_cells (#434): the chat cannot explain why a specific cell is empty (only whole documents, via list_skipped_documents); fill_column_from_reference is whole-column only; and extract_cells(only_empty=true) re-bills the model on cells it already confirmed empty.

## Solution
- explain_cell (cheap, read-only, both modes): classifies one cell as has_value / confirmed_empty / not_extracted / document_skipped, returning the value + excerpts when present and the skip reason when the source was skipped. Reads raw rows via resolve_session_data_files; reuses _is_empty_cell_value.
- fill_column_from_reference: new optional rows param scopes the background fill to specific observation-unit / row names (matched on the same unit_name/row_name identity used by the fill loop and preview_data).
- only_empty guard: new _is_fillable_gap treats _confirmed_empty cells as resolved, so extract_cells(only_empty=true) skips them in both selection and merge; only_empty=false still forces re-extraction. _is_empty_cell_value stays a pure emptiness check.

## Verify
- git apply --ignore-whitespace --check: clean on main (be3fc89)
- python -m py_compile on all four backend files: passes
- tests/test_chat_registry_filtering.py: expensive set unchanged {run_schematiq, reextract, extract_cells, continue_discovery, reprocess}; names unique
- Registry invariants: 29 tools; explain_cell cheap in (schematiq, load), params {row, column}; fill_column_from_reference gains rows, required unchanged
- Stubbed integration test of _handle_explain_cell: all four states + not-found + validation
- Unit tests: _is_fillable_gap skips _confirmed_empty; empty-cell selection ignores confirmed-empty
- Not run here: the live reference-fill LLM path (unchanged engine; only row filtering added)