### PR TITLE
feat(chat): rename_unit — rename a row/observation unit in place

### DIFF
--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -686,6 +686,42 @@ class ToolExecutor:
           "rows_affected": response.rows_affected,
       }
 
+  async def _handle_rename_unit(
+      self, session_id: str, session_mode: str, args: dict[str, Any]
+  ) -> dict[str, Any]:
+      # Rename one row / observation unit in place via unit_view_service.rename_unit,
+      # which reuses the merge relabel path (keeps data, records _original_units).
+      # The service is synchronous and touches storage, so run it off the loop.
+      old_name = (args.get("old_name") or "").strip()
+      new_name = (args.get("new_name") or "").strip()
+      if not old_name or not new_name:
+          raise ValueError("Both 'old_name' and 'new_name' are required.")
+
+      from app.services.unit_view_service import unit_view_service
+
+      loop = asyncio.get_running_loop()
+      response = await loop.run_in_executor(
+          None, unit_view_service.rename_unit, session_id, old_name, new_name
+      )
+
+      if response.success and response.rows_affected:
+          # Data-only change: row_completed makes the workspace silently re-fetch rows.
+          try:
+              await websocket_manager.broadcast_row_completed(
+                  session_id,
+                  {"operation": "rename_unit", "old_name": old_name, "new_name": new_name},
+              )
+          except Exception:  # streaming is best-effort
+              pass
+
+      return {
+          "status": "success" if response.success else "error",
+          "message": response.message,
+          "old_name": old_name,
+          "new_name": new_name,
+          "rows_affected": response.rows_affected,
+      }
+
   async def _handle_export_table(
       self, session_id: str, session_mode: str, args: dict[str, Any]
   ) -> dict[str, Any]:

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -399,6 +399,34 @@ def _all_tools() -> list[ToolSpec]:
             handler="merge_units",
         ),
         ToolSpec(
+            name="rename_unit",
+            description=(
+                "Rename a single table row / observation unit, keeping all of its "
+                "data. Use this when a row's label is wrong or inconsistent and you "
+                "want to change just its name (not merge it with another row — use "
+                "merge_units for that, and edit_observation_unit to change the unit "
+                "definition). Get the exact current name from preview_data first. Note: "
+                "if you rename to a name that already exists, the two rows will share "
+                "that name (an effective merge)."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "old_name": {
+                        "type": "string",
+                        "description": "Current row / unit name, exactly as shown by preview_data.",
+                    },
+                    "new_name": {
+                        "type": "string",
+                        "description": "New name for the row / unit.",
+                    },
+                },
+                "required": ["old_name", "new_name"],
+            },
+            cost_class="cheap",
+            handler="rename_unit",
+        ),
+        ToolSpec(
             name="export_table",
             description="Export the table (csv, rich csv with excerpts, or schema only).",
             parameters={
@@ -657,6 +685,7 @@ def tool_running_label(tool_name: str) -> str:
         "add_unit": "Adding observation unit",
         "remove_unit": "Removing observation unit",
         "merge_units": "Merging observation units",
+        "rename_unit": "Renaming row",
         "export_table": "Preparing export",
         "run_schematiq": "Starting ScheMatiQ extraction",
         "reextract": "Starting re-extraction",

--- a/backend/app/services/unit_view_service.py
+++ b/backend/app/services/unit_view_service.py
@@ -484,6 +484,82 @@ class UnitViewService:
             rows_affected=rows_affected
         )
 
+    def rename_unit(self, session_id: str, old_name: str, new_name: str) -> MergeUnitsResponse:
+        """Rename one observation unit / row in place, preserving its data.
+
+        Reuses the same load/save path as merge_units. Any identity field on a
+        matching row (``_row_name`` / ``row_name`` / ``_unit_name`` / ``unit_name``)
+        whose value equals *old_name* (case-insensitive) is set to *new_name*; when
+        the unit-name field is renamed the previous name is recorded in
+        ``_original_units`` for undo, mirroring merge_units. Renaming to a name that
+        already exists effectively merges into it, which is the expected behavior.
+        """
+        old_name = (old_name or "").strip()
+        new_name = (new_name or "").strip()
+        if not old_name or not new_name:
+            return MergeUnitsResponse(
+                success=False,
+                message="Both the current name and the new name are required.",
+                rows_affected=0,
+            )
+        if old_name == new_name:
+            return MergeUnitsResponse(
+                success=False,
+                message="The new name is the same as the current name.",
+                rows_affected=0,
+            )
+
+        rows = self._load_all_rows(session_id)
+        if not rows:
+            return MergeUnitsResponse(
+                success=False, message="No data found for session", rows_affected=0
+            )
+
+        old_lower = old_name.lower()
+        id_fields = ("_row_name", "row_name", "_unit_name", "unit_name")
+        rows_affected = 0
+        for row in rows:
+            touched = False
+            for field in id_fields:
+                value = row.get(field)
+                if isinstance(value, str) and value.strip().lower() == old_lower:
+                    if field in ("_unit_name", "unit_name"):
+                        original_units = row.get("_original_units", [])
+                        if not original_units:
+                            original_units = [value]
+                        elif value not in original_units:
+                            original_units.append(value)
+                        row["_original_units"] = original_units
+                    row[field] = new_name
+                    touched = True
+            if touched:
+                rows_affected += 1
+
+        if rows_affected == 0:
+            return MergeUnitsResponse(
+                success=False,
+                message=f"No rows found for '{old_name}'.",
+                rows_affected=0,
+            )
+
+        self._save_all_rows(session_id, rows)
+
+        updated_summary = self.get_units_summary(session_id)
+        renamed_unit = next(
+            (u for u in updated_summary.units if u.name == new_name), None
+        )
+
+        logger.info(
+            f"Session {session_id}: Renamed unit '{old_name}' to '{new_name}', "
+            f"{rows_affected} rows affected"
+        )
+        return MergeUnitsResponse(
+            success=True,
+            message=f"Renamed '{old_name}' to '{new_name}' ({rows_affected} row(s)).",
+            merged_unit=renamed_unit,
+            rows_affected=rows_affected,
+        )
+
     def _select_best_name(self, names: List[str]) -> str:
         """Pick the best name from a group: prefer non-all-caps, then longest."""
         non_caps = [n for n in names if n != n.upper() or n == n.lower()]

--- a/frontend/src/pages/Workspace/constants.ts
+++ b/frontend/src/pages/Workspace/constants.ts
@@ -152,6 +152,7 @@ export const CHAT_MUTATION_TOOLS = new Set([
   'add_unit',
   'remove_unit',
   'merge_units',
+  'rename_unit',
   'edit_observation_unit',
   'run_schematiq',
   'reextract',


### PR DESCRIPTION
## Problem
There was no way to rename a single row / observation unit from chat without losing its data (the only path was remove_unit + add_unit). merge_units can relabel, but MergeUnitsRequest hard-requires >=2 source units.

## Solution
New cheap chat tool rename_unit {old_name, new_name}. It calls a new unit_view_service.rename_unit that reuses the merge relabel path (_load_all_rows / _save_all_rows / get_units_summary): every identity field on a matching row (_row_name / row_name / _unit_name / unit_name) equal to old_name (case-insensitive) is set to new_name, with the previous unit name recorded in _original_units for undo, exactly as merge_units does. Row data is preserved. Renaming to an existing name is an effective merge (documented). Available in both schematiq and load modes; runs off the event loop and broadcasts row_completed for a silent refresh.

## Verify
- git apply --ignore-whitespace --check: clean on main (be3fc89)
- ( cd frontend && npx tsc --noEmit ): passes
- python -m py_compile on all three backend files: passes
- tests/test_chat_registry_filtering.py: expensive set unchanged; names unique
- Registry invariants: rename_unit is cheap, modes (schematiq, load), params {old_name, new_name}, session_id not exposed
- Unit tests: both-field rename + _original_units provenance + data preserved, case-insensitive match, not-found, empty/identical validation, multi-row unit
- Not run here: the live storage round-trip (unchanged _save_all_rows path already used by merge_units in production)