### PR TITLE
feat(chat): continue_discovery document_source (extract Documents-tab uploads)

### DIFF
--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -777,12 +777,17 @@ class ToolExecutor:
   async def _handle_continue_discovery(
       self, session_id: str, session_mode: str, args: dict[str, Any]
   ) -> dict[str, Any]:
+      document_source = (args.get("document_source") or "original").strip().lower()
+      if document_source not in ("original", "upload"):
+          raise ValueError(
+              "document_source must be 'original' or 'upload'."
+          )
       llm_config = load_user_llm_config(session_id)
       await concurrency_limiter.acquire(session_id, "continue_discovery")
       try:
           result = await continue_discovery_service.start_continue_discovery(
               session_id=session_id,
-              document_source="original",
+              document_source=document_source,
               llm_config=llm_config,
           )
       except Exception:

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -519,8 +519,28 @@ def _all_tools() -> list[ToolSpec]:
         ),
         ToolSpec(
             name="continue_discovery",
-            description="Extend schema discovery with more documents (expensive).",
-            parameters=EMPTY_PARAMS,
+            description=(
+                "Extend schema discovery by extracting from more documents (expensive). "
+                "By default it continues over the project's original source documents. "
+                "Pass document_source='upload' to instead extract the documents the user "
+                "just added through the Documents tab (the upload itself happens there; "
+                "this only runs the extraction on the already-added files)."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "document_source": {
+                        "type": "string",
+                        "enum": ["original", "upload"],
+                        "description": (
+                            "'original' (default) continues over the project's source "
+                            "documents; 'upload' extracts documents added via the "
+                            "Documents tab."
+                        ),
+                    },
+                },
+                "required": [],
+            },
             cost_class="expensive",
             handler="continue_discovery",
             hidden_in_load=True,


### PR DESCRIPTION
## Problem
Documents added mid-session through the Documents tab could only be extracted from the UI. The chat continue_discovery tool was hardcoded to document_source='original', so there was no way to say 'extract the files I just added' in chat — even though start_continue_discovery already supports document_source in {original, upload, cloud}.

## Solution
Expose an optional document_source parameter on continue_discovery (enum: original | upload; default original, preserving current behavior). 'upload' runs extraction over the documents already staged via the Documents tab; the byte upload itself stays in the UI. The handler validates the value before acquiring the concurrency slot (invalid input never leaks a slot). cloud is intentionally omitted (it needs a cloud_dataset argument). No frontend change: continue_discovery is already in the mutation/rerun sets.

## Verify
- git apply --ignore-whitespace --check: clean on main (be3fc89)
- python -m py_compile on both files: passes
- tests/test_chat_registry_filtering.py: expensive set unchanged; names unique
- Registry invariants: continue_discovery stays expensive, params {document_source} enum [original, upload], session_id not exposed, schematiq-only/hidden_in_load
- Handler tests: default->original, upload passthrough, case-insensitive, invalid value rejected before slot acquire (no leak)
- Coexists cleanly with the two other open branches (explain_cell/reference-rows and rename_unit)
- Not run here: the live document_source='upload' extraction (unchanged pipeline; only an existing parameter was surfaced)