### PR TITLE
fix(chat): surface skipped documents in load-mode sessions

### DIFF
--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -255,6 +255,16 @@ class ToolExecutor:
       # the same discovery the re-extraction precheck relies on, compacted to
       # names-by-status so the payload stays small.
       availability = await reextraction_service.precheck_document_availability(session_id)
+      # Skipped documents produce no rows, so they never appear in the row-based
+      # availability lists above. Surface them here (with reasons) so a document
+      # that was skipped during extraction is discoverable from the primary
+      # document listing instead of looking absent from the project.
+      session = session_manager.get_session(session_id)
+      skipped = (
+          session.statistics.skipped_documents
+          if session and session.statistics and session.statistics.skipped_documents
+          else []
+      )
       return {
           "status": "success",
           "total_documents": availability.get("total_documents", 0),
@@ -269,6 +279,10 @@ class ToolExecutor:
               doc["name"] for doc in availability.get("missing_documents", [])
           ],
           "rows_with_missing_docs": availability.get("rows_with_missing_docs", 0),
+          "skipped_documents": [
+              {"document": entry.document, "reason": entry.reason}
+              for entry in skipped
+          ],
       }
 
   async def _handle_list_reference_sources(

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -128,7 +128,10 @@ def _all_tools() -> list[ToolSpec]:
             parameters=EMPTY_PARAMS,
             cost_class="cheap",
             handler="list_skipped_documents",
-            session_modes=("schematiq",),
+            # Available in load mode too: this is a pure read of persisted
+            # statistics (skipped_documents survive export/import), unlike the
+            # extraction tools that genuinely need source documents. Imported
+            # sessions must be able to explain a "missing" document.
         ),
         ToolSpec(
             name="list_documents",
@@ -136,9 +139,11 @@ def _all_tools() -> list[ToolSpec]:
                 "List the source documents in this project and their availability "
                 "(local, cloud, or missing), plus row counts. These are the documents "
                 "that define table rows, NOT the external reference material listed by "
-                "list_reference_sources. Use this to answer what documents the project "
-                "contains, or to check whether documents are present before proposing a "
-                "re-extraction."
+                "list_reference_sources. Also reports documents that were skipped during "
+                "extraction (with reasons) under skipped_documents, so a document that "
+                "produced no rows is still discoverable here. Use this to answer what "
+                "documents the project contains, or to check whether documents are present "
+                "before proposing a re-extraction."
             ),
             parameters=EMPTY_PARAMS,
             cost_class="cheap",

--- a/backend/tests/test_chat_registry_filtering.py
+++ b/backend/tests/test_chat_registry_filtering.py
@@ -76,6 +76,17 @@ def test_schematiq_only_tools_hidden_in_load_mode() -> None:
     assert {"run_schematiq", "reextract", "continue_discovery"}.isdisjoint(load)
 
 
+def test_skipped_document_diagnostics_available_in_load_mode() -> None:
+    # Skipped-document visibility is a pure read of persisted statistics, which
+    # imported/load sessions carry (skipped_documents survive export/import).
+    # Unlike the extraction tools, it needs no source documents, so it must be
+    # reachable in load mode — otherwise the agent reports a skipped document as
+    # simply absent from the project.
+    load = {t.name for t in get_tools_for_context("s1", "load")}
+    assert "list_skipped_documents" in load
+    assert "list_documents" in load
+
+
 def test_no_session_exposes_only_entry_point_tools() -> None:
     names = {t.name for t in get_tools_for_context(None, "schematiq")}
     assert names == {"create_project", "import_project", "web_search"}


### PR DESCRIPTION
## Problem
In an imported (load-mode) session the agent cannot surface a document that was skipped during extraction. `list_skipped_documents` was gated to schematiq mode, and `list_documents` only reports row-defining docs — so a skipped doc looks simply absent, and the agent reports it as 'not present' (see CASA2025-06-27SCt).

## Solution
- Allow `list_skipped_documents` in load mode: it is a pure read of `session.statistics.skipped_documents`, which load sessions carry (skipped docs survive export/import). Extraction tools that need source documents stay schematiq-only.
- Add a `skipped_documents` field (name + reason) to `list_documents` output so a skipped doc is discoverable from the primary listing in either mode; update the tool description accordingly.
- Add a registry test locking skipped-doc diagnostics into load mode.

## Verify
- `python -m pytest backend/tests/test_chat_registry_filtering.py -q`
- In a load-mode session, ask about a skipped document → agent can now call list_skipped_documents / see it under list_documents' skipped_documents.