### PR TITLE
feat(chat): data_summary + find_rows (table-insight read tools)

### DIFF
--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -224,6 +224,153 @@ class ToolExecutor:
           "missing_definitions": missing_definitions,
       }
 
+  async def _load_table_rows(self, session_id: str) -> list[dict[str, Any]]:
+      # Canonical, deduplicated row list — the same source preview_data uses — so
+      # summaries and row searches agree with what the user sees. Cell values are
+      # kept raw (answer-dicts, including _confirmed_empty), which the coverage
+      # breakdown relies on. Paginated to avoid materializing huge tables at once.
+      from app.services.chat.deps import WORK_DIR
+
+      rows: list[dict[str, Any]] = []
+      page = 0
+      page_size = 200
+      while page < 500:  # hard cap: 100k rows
+          data = await query_get_data(session_id, WORK_DIR, page=page, page_size=page_size)
+          batch = [r.model_dump() for r in data.rows]
+          rows.extend(batch)
+          if len(batch) < page_size:
+              break
+          page += 1
+      return rows
+
+  async def _handle_data_summary(
+      self, session_id: str, session_mode: str, args: dict[str, Any]
+  ) -> dict[str, Any]:
+      # Read-only table-health overview: row count and, per column, how many cells
+      # are filled vs. empty (with the confirmed-empty subset broken out, since
+      # those are resolved gaps that filling will not help). Makes extract_cells /
+      # reprocess actionable by showing where the gaps are.
+      from app.services.reextraction_service import _is_empty_cell_value
+
+      session = session_manager.get_session(session_id)
+      column_names = (
+          [c.name for c in session.columns if c.name]
+          if session and session.columns
+          else []
+      )
+      rows = await self._load_table_rows(session_id)
+      total = len(rows)
+
+      if not column_names:  # fall back to columns seen in the data
+          seen: list[str] = []
+          for row in rows:
+              for key in (row.get("data") or {}):
+                  if key not in seen:
+                      seen.append(key)
+          column_names = seen
+
+      counts = {c: {"filled": 0, "empty": 0, "confirmed_empty": 0} for c in column_names}
+      for row in rows:
+          data = row.get("data") or {}
+          for col in column_names:
+              value = data.get(col)
+              if _is_empty_cell_value(value):
+                  counts[col]["empty"] += 1
+                  if isinstance(value, dict) and value.get("_confirmed_empty"):
+                      counts[col]["confirmed_empty"] += 1
+              else:
+                  counts[col]["filled"] += 1
+
+      columns = []
+      for col in column_names:
+          c = counts[col]
+          coverage = round(100 * c["filled"] / total) if total else 0
+          columns.append(
+              {
+                  "column": col,
+                  "filled": c["filled"],
+                  "empty": c["empty"],
+                  "confirmed_empty": c["confirmed_empty"],
+                  "coverage_pct": coverage,
+              }
+          )
+
+      skipped = (
+          len(session.statistics.skipped_documents)
+          if session and session.statistics and session.statistics.skipped_documents
+          else 0
+      )
+      return {
+          "total_rows": total,
+          "columns": columns,
+          "skipped_documents": skipped,
+      }
+
+  async def _handle_find_rows(
+      self, session_id: str, session_mode: str, args: dict[str, Any]
+  ) -> dict[str, Any]:
+      # Read-only: return the rows whose cell in `column` matches a predicate, so
+      # the agent can target rename_unit / merge_units / update_cell / extract_cells
+      # precisely instead of paging the whole table.
+      from app.services.reextraction_service import _is_empty_cell_value
+
+      column = (args.get("column") or "").strip()
+      if not column:
+          raise ValueError("'column' is required.")
+      match = (args.get("match") or "empty").strip().lower()
+      if match not in ("empty", "filled", "equals", "contains"):
+          raise ValueError("match must be one of: empty, filled, equals, contains.")
+      value = args.get("value")
+      if match in ("equals", "contains") and not (isinstance(value, str) and value.strip()):
+          raise ValueError(f"match '{match}' requires a non-empty 'value'.")
+      try:
+          limit = int(args.get("limit") or 50)
+      except (TypeError, ValueError):
+          limit = 50
+      limit = max(1, min(limit, 500))
+
+      def cell_text(v: Any) -> str:
+          if isinstance(v, dict):
+              answer = v.get("answer")
+              return answer if isinstance(answer, str) else ("" if answer is None else str(answer))
+          if v is None:
+              return ""
+          return v if isinstance(v, str) else str(v)
+
+      needle = value.strip().lower() if isinstance(value, str) else ""
+      rows = await self._load_table_rows(session_id)
+      matches: list[dict[str, Any]] = []
+      total_matched = 0
+      for row in rows:
+          v = (row.get("data") or {}).get(column)
+          if match == "empty":
+              ok = _is_empty_cell_value(v)
+          elif match == "filled":
+              ok = not _is_empty_cell_value(v)
+          elif match == "equals":
+              ok = cell_text(v).strip().lower() == needle
+          else:  # contains
+              ok = needle in cell_text(v).lower()
+          if ok:
+              total_matched += 1
+              if len(matches) < limit:
+                  matches.append(
+                      {
+                          "row": row.get("row_name") or row.get("unit_name"),
+                          "value": cell_text(v) or None,
+                      }
+                  )
+
+      return {
+          "column": column,
+          "match": match,
+          "value": value,
+          "count": total_matched,
+          "returned": len(matches),
+          "rows": matches,
+          "truncated": total_matched > len(matches),
+      }
+
   async def _handle_list_skipped_documents(
       self, session_id: str, session_mode: str, args: dict[str, Any]
   ) -> dict[str, Any]:

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -144,6 +144,58 @@ def _all_tools() -> list[ToolSpec]:
             handler="get_validation",
         ),
         ToolSpec(
+            name="data_summary",
+            description=(
+                "Table-health overview (read-only): the total row count and, for each "
+                "column, how many cells are filled vs. empty, the coverage percentage, "
+                "and how many of the empties are 'confirmed empty' (the model already "
+                "checked and found no value, so filling them will not help). Also "
+                "reports how many source documents were skipped. Use this to see where "
+                "the gaps are before running extract_cells or reprocess."
+            ),
+            parameters=EMPTY_PARAMS,
+            cost_class="cheap",
+            handler="data_summary",
+        ),
+        ToolSpec(
+            name="find_rows",
+            description=(
+                "Find the rows whose value in a given column matches a condition "
+                "(read-only). Use it to target other tools precisely — e.g. list the "
+                "rows missing a column before extract_cells, or find rows whose name "
+                "contains a string before rename_unit / merge_units. Returns matching "
+                "row names (and their value); large result sets are truncated to `limit`."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "column": {
+                        "type": "string",
+                        "description": "Column to test on each row.",
+                    },
+                    "match": {
+                        "type": "string",
+                        "enum": ["empty", "filled", "equals", "contains"],
+                        "description": (
+                            "How to test the cell: 'empty' / 'filled', or 'equals' / "
+                            "'contains' compared against `value`. Defaults to 'empty'."
+                        ),
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "Comparison text for match='equals' or 'contains'.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max rows to return (default 50, capped at 500).",
+                    },
+                },
+                "required": ["column"],
+            },
+            cost_class="cheap",
+            handler="find_rows",
+        ),
+        ToolSpec(
             name="list_skipped_documents",
             description=(
                 "List the source documents that were skipped during extraction and "
@@ -741,6 +793,8 @@ def tool_running_label(tool_name: str) -> str:
         "preview_data": "Loading data preview",
         "explain_cell": "Explaining cell",
         "get_validation": "Validating schema",
+        "data_summary": "Summarizing the table",
+        "find_rows": "Searching rows",
         "list_skipped_documents": "Listing skipped documents",
         "list_documents": "Listing documents",
         "list_reference_sources": "Listing reference documents",


### PR DESCRIPTION
## Problem
The chat could inspect single cells (explain_cell) and page rows (preview_data), but had no way to see table-wide coverage (per-column filled/empty) or to find the rows matching a condition. session.statistics only carries total_rows and skipped_documents — no per-column fill counts — so there was no way to know where the gaps are before running extract_cells/reprocess, and no way to target rename/merge/update_cell without paging the whole table.

## Solution
Two cheap, read-only tools (both session modes):
- data_summary: total rows and, per column, filled / empty / confirmed_empty / coverage_pct, plus skipped-document count.
- find_rows: rows whose value in a column matches empty | filled | equals | contains (+ value, limit); returns matching row names and values, truncating to limit.
Both read via query_get_data — the same deduplicated source preview_data uses — so results stay consistent with what the user sees, and raw cell dicts (with _confirmed_empty) are preserved for the coverage breakdown. A shared _load_table_rows paginates the read.

## Verify
- git apply --ignore-whitespace --check: clean on main (719516d)
- python -m py_compile on both files: passes
- tests/test_chat_registry_filtering.py: expensive set unchanged; names unique
- Registry invariants: both tools cheap, modes (schematiq, load), session_id not exposed; find_rows match enum [empty, filled, equals, contains], required [column]
- Stubbed integration tests: data_summary coverage math + confirmed_empty subset + skipped count; find_rows empty/filled/equals/contains (case-insensitive), limit truncation, and all validation errors
- Not run here: the live Supabase-backed read (query_get_data is the same path preview_data uses in production)