### PR TITLE
fix(chat): advertise only callable tools to the model per session mode

### DIFF
--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -22,6 +22,7 @@ from .session_store import ChatSessionState, PendingToolCall, chat_session_store
 from .tool_executor import tool_executor
 from .tool_registry import (
     TOOL_BY_NAME,
+    available_tools_prompt_addendum,
     get_tools_for_context,
     to_function_declarations,
     tool_running_label,
@@ -426,7 +427,7 @@ class ChatAgentService:
             tool_config=types.ToolConfig(
                 function_calling_config=types.FunctionCallingConfig(mode="AUTO"),
             ),
-            system_instruction=CHAT_SYSTEM_PROMPT,
+            system_instruction=CHAT_SYSTEM_PROMPT + available_tools_prompt_addendum(tools),
         )
         client = self._get_genai_client()
         resolved_model = model or CHAT_MODEL

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -718,6 +718,32 @@ def to_public_tool_list(tools: list[ToolSpec]) -> list[dict[str, Any]]:
     ]
 
 
+def available_tools_prompt_addendum(tools: list[ToolSpec]) -> str:
+    """A mode-aware system-prompt footer naming the tools that are callable now.
+
+    The static chat system prompt names tools (reextract, extract_cells,
+    run_schematiq, continue_discovery, ...) that ``get_tools_for_context``
+    filters out in load mode, because imported/load sessions have no source
+    documents to extract from. Without this footer the model follows the static
+    prompt and offers such a tool, then contradicts itself when the call turns
+    out to be unavailable. Built from the SAME tool list as
+    ``to_function_declarations`` (only ``available`` tools are callable) so the
+    advertised set can never drift from what the model can actually call.
+    """
+    names = sorted(tool.name for tool in tools if tool.available)
+    if not names:
+        return ""
+    return (
+        "\n\nTools available in THIS session: "
+        + ", ".join(names)
+        + ".\nUse and offer ONLY these tools. If a request would require a tool "
+        "that is not listed here — for example re-running extraction or "
+        "rediscovering the schema in an imported (load) session, which has no "
+        "source documents — tell the user plainly that it is not available in "
+        "this session instead of offering or attempting it."
+    )
+
+
 def to_function_declarations(tools: list[ToolSpec]) -> list[Any]:
     if types is None:
         raise ImportError("google-genai is required for function declarations")

--- a/backend/tests/test_chat_registry_filtering.py
+++ b/backend/tests/test_chat_registry_filtering.py
@@ -12,6 +12,7 @@ from app.services.chat.tool_registry import (
     TOOL_BY_NAME,
     ToolSpec,
     _all_tools,
+    available_tools_prompt_addendum,
     get_tools_for_context,
     to_function_declarations,
     to_public_tool_list,
@@ -85,6 +86,24 @@ def test_skipped_document_diagnostics_available_in_load_mode() -> None:
     load = {t.name for t in get_tools_for_context("s1", "load")}
     assert "list_skipped_documents" in load
     assert "list_documents" in load
+
+
+def test_prompt_addendum_advertises_only_callable_tools() -> None:
+    # The static system prompt names extraction tools; in load mode those are
+    # filtered out of the function declarations. The addendum must advertise
+    # exactly the callable set so the model never offers a tool it cannot call.
+    load_addendum = available_tools_prompt_addendum(get_tools_for_context("s1", "load"))
+    assert "list_skipped_documents" in load_addendum
+    assert "list_documents" in load_addendum
+    for unavailable_in_load in ("reextract", "extract_cells", "run_schematiq", "continue_discovery"):
+        assert unavailable_in_load not in load_addendum
+    # web_search is declared-but-unavailable everywhere; it must never be
+    # advertised as callable.
+    schematiq_addendum = available_tools_prompt_addendum(
+        get_tools_for_context("s1", "schematiq")
+    )
+    assert "web_search" not in schematiq_addendum
+    assert "reextract" in schematiq_addendum
 
 
 def test_no_session_exposes_only_entry_point_tools() -> None:


### PR DESCRIPTION
## Problem
CHAT_SYSTEM_PROMPT is static and names tools like reextract / extract_cells / run_schematiq, but the function declarations passed to Gemini are mode-filtered. In a load-mode (imported) session the model follows the prompt, offers or attempts an unavailable tool, and then reports it as 'not a supported tool' — a self-contradiction (see the CASA2025-06-27SCt transcript).

## Solution
Add available_tools_prompt_addendum(tools) in tool_registry, built from the same list to_function_declarations uses (only available tools), and append it to system_instruction in _create_gemini_chat. It names the callable tools for this session and instructs the model to offer only those, telling the user plainly when a request needs a tool unavailable in the current mode.

## Verify
- python -m pytest backend/tests/test_chat_registry_filtering.py -q
- In a load-mode session, the model no longer offers reextract/extract_cells and explains they need a schematiq session with source documents.