### PR TITLE
fix(reextraction): gate document-scoped runs on scoped docs only

### DIFF
--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -1041,6 +1041,52 @@ class ReextractionService(WebSocketBroadcasterMixin):
             return None, None
         return empty_columns, docs_with_empties
 
+    def _scoped_documents_availability(
+        self,
+        session_id: str,
+        scoped_stems: List[str],
+        availability: Dict[str, Any],
+    ) -> Dict[str, List[str]]:
+        """Split a document-scoped run's targets into available vs. missing.
+
+        A whole-project availability precheck fails as soon as *any* of the
+        project's documents is unreachable, which wrongly blocks a run that only
+        targets a specific document (e.g. ``extract_cells`` on a single skipped
+        file). When a scope is requested we only care whether the *scoped*
+        documents are reachable.
+
+        A scoped stem counts as available when either:
+          - a matching file exists on disk in one of the session's document
+            directories (matched by name or stem — this is what a re-attach via
+            "Show source document" writes to ``pending_documents/``), or
+          - the whole-project precheck already classified it local or cloud.
+
+        Returns ``{"available": [...], "missing": [...]}`` of stems.
+        """
+        wanted = {s for s in scoped_stems if s}
+
+        # Stems the whole-project precheck already found (by stem, tolerating
+        # ".txt"/extension differences between the row reference and the file).
+        reachable: Set[str] = set()
+        for bucket in ("local_documents", "cloud_documents"):
+            for doc in availability.get(bucket) or []:
+                name = doc.get("name")
+                if name:
+                    reachable.add(Path(name).stem)
+
+        # On-disk files (covers skipped documents with no rows and freshly
+        # re-attached originals, which the row-based precheck never sees).
+        for local_dir in self._get_session_document_dirs(session_id):
+            if not local_dir.exists():
+                continue
+            for f in local_dir.iterdir():
+                if f.is_file() and not f.name.startswith('.'):
+                    reachable.add(f.stem)
+
+        available = sorted(s for s in wanted if s in reachable)
+        missing = sorted(s for s in wanted if s not in reachable)
+        return {"available": available, "missing": missing}
+
     async def start_gated_reextraction(
         self,
         session_id: str,
@@ -1110,7 +1156,24 @@ class ReextractionService(WebSocketBroadcasterMixin):
             operation_type="reextraction",
             paper_discovery=paper_discovery,
         )
-        if not availability.get("can_proceed", False):
+        if scoped_documents:
+            # Document-scoped run (e.g. extract_cells on a single skipped file):
+            # gate only on the requested documents, not the whole project, so a
+            # targeted re-extraction is not blocked by unrelated documents that
+            # happen to be unreachable. A skipped document re-attached via "Show
+            # source document" lands on disk and is picked up here.
+            scoped_avail = self._scoped_documents_availability(
+                session_id, scoped_documents, availability
+            )
+            scoped_missing = scoped_avail["missing"]
+            if scoped_missing:
+                raise ValueError(
+                    f"{len(scoped_missing)} source document(s) are unavailable: "
+                    f"{', '.join(scoped_missing)}. Open a row from one of them and "
+                    "use \"Show source document\" to re-attach the file, then try "
+                    "again."
+                )
+        elif not availability.get("can_proceed", False):
             missing = availability.get("missing_documents") or []
             if missing:
                 raise ValueError(

--- a/backend/tests/test_reextraction_scoped_availability.py
+++ b/backend/tests/test_reextraction_scoped_availability.py
@@ -1,0 +1,85 @@
+"""Tests for document-scoped availability gating in re-extraction.
+
+A whole-project availability precheck must not block a run that only targets a
+specific document (e.g. ``extract_cells`` on a single previously-skipped file).
+When a document scope is requested, only the scoped documents' availability
+should gate the run.
+"""
+
+from unittest.mock import MagicMock
+
+from app.services.reextraction_service import ReextractionService
+
+
+def _make_service() -> ReextractionService:
+    return ReextractionService(
+        websocket_manager=MagicMock(),
+        session_manager=MagicMock(),
+    )
+
+
+def _availability(local=None, cloud=None, missing=None) -> dict:
+    """Shape a precheck_document_availability-style result for tests."""
+    return {
+        "local_documents": [{"name": n} for n in (local or [])],
+        "cloud_documents": [{"name": n} for n in (cloud or [])],
+        "missing_documents": [{"name": n} for n in (missing or [])],
+        "can_proceed": bool(local or cloud),
+    }
+
+
+def test_scoped_doc_on_disk_is_available_despite_missing_project(tmp_path, monkeypatch):
+    """A re-attached skipped file on disk counts as available even when the
+    rest of the project is unreachable (the CASA re-attach case)."""
+    monkeypatch.chdir(tmp_path)
+    session_id = "sess-scope"
+    # Simulate a "Show source document" re-attach landing in pending_documents/.
+    pending = tmp_path / "data" / session_id / "pending_documents"
+    pending.mkdir(parents=True)
+    (pending / "CASA2025-06-27SCt.txt").write_text("opinion text", encoding="utf-8")
+
+    service = _make_service()
+    # Whole project: everything else is missing (mirrors the 102-missing error).
+    availability = _availability(missing=[f"doc_{i}" for i in range(101)])
+
+    result = service._scoped_documents_availability(
+        session_id, ["CASA2025-06-27SCt"], availability
+    )
+
+    assert result["available"] == ["CASA2025-06-27SCt"]
+    assert result["missing"] == []
+
+
+def test_scoped_doc_available_from_cloud_precheck(tmp_path, monkeypatch):
+    """A scoped stem the whole-project precheck already classified cloud/local
+    counts as available even if it is not on the local filesystem."""
+    monkeypatch.chdir(tmp_path)
+    session_id = "sess-cloud"
+    (tmp_path / "data" / session_id).mkdir(parents=True)
+
+    service = _make_service()
+    availability = _availability(cloud=["CASA2025-06-27SCt.txt"], missing=["other"])
+
+    result = service._scoped_documents_availability(
+        session_id, ["CASA2025-06-27SCt"], availability
+    )
+
+    assert result["available"] == ["CASA2025-06-27SCt"]
+    assert result["missing"] == []
+
+
+def test_scoped_doc_truly_missing_is_reported(tmp_path, monkeypatch):
+    """A scoped document that is neither on disk nor in the precheck is missing."""
+    monkeypatch.chdir(tmp_path)
+    session_id = "sess-missing"
+    (tmp_path / "data" / session_id).mkdir(parents=True)
+
+    service = _make_service()
+    availability = _availability(local=["something_else"])
+
+    result = service._scoped_documents_availability(
+        session_id, ["CASA2025-06-27SCt"], availability
+    )
+
+    assert result["missing"] == ["CASA2025-06-27SCt"]
+    assert result["available"] == []


### PR DESCRIPTION
## Problem
extract_cells targeting a single document (e.g. a skipped file like CASA2025-06-27SCt) failed with "102 source document(s) are unavailable". start_gated_reextraction ran precheck_document_availability over the WHOLE project; can_proceed is False as soon as any one document is unreachable, so the scoped run was blocked by the other ~101 documents. Re-attaching the file via "Show source document" (which writes to pending_documents/) had no effect because the gate never looked at the scope.

## Solution
When a document scope is requested, gate only on the scoped documents via a new _scoped_documents_availability helper. A scoped stem counts as available if it is on disk in the session's document dirs (what a Show-source-document re-attach writes) or already classified local/cloud by the precheck. Only genuinely-missing scoped docs raise, now with the document name and a Show-source-document re-attach hint. Whole-project (unscoped) behavior is unchanged.

## Verify
- python -m py_compile backend/app/services/reextraction_service.py backend/tests/test_reextraction_scoped_availability.py
- python -m pytest backend/tests/test_reextraction_scoped_availability.py (3 tests: on-disk / cloud / truly-missing)
- Backend-only; no frontend change.