### PR TITLE
fix(reextraction): keep previously-skipped docs through only_empty narrowing

### DIFF
--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -1134,22 +1134,44 @@ class ReextractionService(WebSocketBroadcasterMixin):
         if rows:
             scoped_rows = [r.strip() for r in rows if isinstance(r, str) and r.strip()] or None
 
+        # Previously-skipped documents have no rows yet, so the empty-cell scan
+        # finds nothing for them. Re-including a skipped document is a
+        # re-discovery ("create rows"), not a gap-fill, so it must survive the
+        # only_empty narrowing below instead of being treated as "nothing to do".
+        skipped_scope: Set[str] = set()
+        if scoped_documents:
+            all_skipped = {
+                Path(s.document).stem
+                for s in (
+                    session.statistics.skipped_documents
+                    if session and session.statistics and session.statistics.skipped_documents
+                    else []
+                )
+            }
+            skipped_scope = {d for d in scoped_documents if d in all_skipped}
+
         if only_empty:
             empty_columns, docs_with_empties = self._find_empty_target_cells(
                 session_id, resolved, scoped_documents, scoped_rows
             )
             if empty_columns is not None:
-                if not empty_columns:
+                if not empty_columns and not skipped_scope:
                     raise ValueError(
                         "No empty cells to fill in the selected scope."
                     )
                 # Narrow the extraction to columns/documents that actually have
                 # gaps (cost). The merge guard enforces the empty-only rule.
-                resolved = [c for c in resolved if c in empty_columns]
+                # Skipped documents in scope are kept regardless: they have no
+                # rows to compare against and are re-discovered from scratch.
+                if empty_columns:
+                    resolved = [c for c in resolved if c in empty_columns]
                 if scoped_documents is None:
                     scoped_documents = sorted(docs_with_empties)
                 else:
-                    scoped_documents = [d for d in scoped_documents if d in docs_with_empties]
+                    scoped_documents = [
+                        d for d in scoped_documents
+                        if d in docs_with_empties or d in skipped_scope
+                    ]
 
         availability = await self.precheck_document_availability(
             session_id,

--- a/backend/tests/test_reextraction_scoped_availability.py
+++ b/backend/tests/test_reextraction_scoped_availability.py
@@ -6,8 +6,18 @@ When a document scope is requested, only the scoped documents' availability
 should gate the run.
 """
 
-from unittest.mock import MagicMock
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
 
+from app.models.session import (
+    ColumnInfo,
+    DataStatistics,
+    SessionMetadata,
+    SessionStatus,
+    SessionType,
+    SkippedDocumentInfo,
+    VisualizationSession,
+)
 from app.services.reextraction_service import ReextractionService
 
 
@@ -83,3 +93,94 @@ def test_scoped_doc_truly_missing_is_reported(tmp_path, monkeypatch):
 
     assert result["missing"] == ["CASA2025-06-27SCt"]
     assert result["available"] == []
+
+
+# --------------------------------------------------------------------------- #
+# only_empty narrowing must preserve previously-skipped docs (end-to-end).
+#
+# extract_cells defaults only_empty=True. A previously-skipped document has no
+# rows, so the empty-cell scan finds nothing for it; without special handling
+# the run would raise "No empty cells to fill" before reaching the availability
+# gate, so re-discovering a skipped document (the CASA case) would be blocked.
+# --------------------------------------------------------------------------- #
+
+def _session_with_skipped(skipped_names: list[str]) -> VisualizationSession:
+    return VisualizationSession(
+        id="sess-skip",
+        type=SessionType.SCHEMATIQ,
+        status=SessionStatus.COMPLETED,
+        metadata=SessionMetadata(source="test", created=datetime.now()),
+        columns=[ColumnInfo(name="ruling_type", definition="Ruling")],
+        statistics=DataStatistics(
+            total_rows=0,
+            total_columns=1,
+            total_documents=1,
+            completeness=0.0,
+            column_stats=[],
+            skipped_documents=[
+                SkippedDocumentInfo(document=n, reason="Broader legal ruling")
+                for n in skipped_names
+            ],
+        ),
+    )
+
+
+def _wire(service: ReextractionService, availability: dict) -> None:
+    service.capture_and_save_baseline = AsyncMock()
+    service.resolve_reextraction_columns = AsyncMock(return_value=["ruling_type"])
+    service.discover_papers = AsyncMock(return_value={
+        "total_rows": 0, "rows_with_papers": 0, "available_papers": [],
+        "missing_papers": [], "paper_to_rows": {}, "cloud_papers": {},
+        "local_papers": [], "session_document_count": 0,
+    })
+    service.precheck_document_availability = AsyncMock(return_value=availability)
+    service.start_reextraction = AsyncMock(return_value={"status": "started"})
+
+
+async def test_only_empty_scoped_skipped_doc_proceeds():
+    """extract_cells (only_empty=True) on a previously-skipped document must NOT
+    raise 'No empty cells' — it has no rows and is re-discovered from scratch."""
+    session = _session_with_skipped(["CASA2025-06-27SCt"])
+    sm = MagicMock()
+    sm.get_session.return_value = session
+    service = ReextractionService(MagicMock(), sm)
+    _wire(service, {
+        "local_documents": [{"name": "CASA2025-06-27SCt"}],
+        "cloud_documents": [], "missing_documents": [], "can_proceed": True,
+    })
+    service._project_document_stems = MagicMock(return_value={"CASA2025-06-27SCt"})
+    service._find_empty_target_cells = MagicMock(return_value=(set(), set()))
+
+    result = await service.start_gated_reextraction(
+        "sess-skip", columns=None, scope="all",
+        documents=["CASA2025-06-27SCt"], only_empty=True,
+    )
+
+    assert result == {"status": "started"}
+    service.start_reextraction.assert_awaited_once()
+    assert service.start_reextraction.await_args.kwargs["documents"] == ["CASA2025-06-27SCt"]
+
+
+async def test_only_empty_scoped_nonskipped_doc_with_no_gaps_still_raises():
+    """A non-skipped scoped doc with no empty cells keeps the original guard."""
+    session = _session_with_skipped([])  # nothing skipped
+    sm = MagicMock()
+    sm.get_session.return_value = session
+    service = ReextractionService(MagicMock(), sm)
+    _wire(service, {
+        "local_documents": [{"name": "SomeDoc"}],
+        "cloud_documents": [], "missing_documents": [], "can_proceed": True,
+    })
+    service._project_document_stems = MagicMock(return_value={"SomeDoc"})
+    service._find_empty_target_cells = MagicMock(return_value=(set(), set()))
+
+    raised = False
+    try:
+        await service.start_gated_reextraction(
+            "sess-skip", columns=None, scope="all",
+            documents=["SomeDoc"], only_empty=True,
+        )
+    except ValueError as e:
+        raised = "No empty cells" in str(e)
+    assert raised
+    service.start_reextraction.assert_not_awaited()


### PR DESCRIPTION
## Problem
Follow-up to #442. extract_cells defaults only_empty=True. A previously-skipped document (e.g. CASA2025-06-27SCt) has no rows, so _find_empty_target_cells returns no empty cells for it and start_gated_reextraction raised 'No empty cells to fill in the selected scope.' BEFORE reaching the scoped-availability gate added in #442. Re-discovering a skipped document is a create-rows operation, not a gap-fill, so it was blocked.

## Solution
Compute skipped_scope = scoped documents that appear in session.statistics.skipped_documents. In the only_empty branch: do not raise when the scope consists solely of skipped docs; keep skipped docs in scoped_documents through the narrowing; keep all columns for a pure-skipped run (re-discovery), while non-skipped docs retain the original empty-only narrowing. Whole-project (unscoped) behavior is unchanged.

## Verify
- python -m py_compile backend/app/services/reextraction_service.py backend/tests/test_reextraction_scoped_availability.py
- python -m pytest backend/tests/test_reextraction_scoped_availability.py (adds 2 async tests: skipped-doc proceeds; non-skipped no-gaps still raises)
- Backend-only; no frontend change.