### PR TITLE
feat(chat): add rediscover tool for imported (load) sessions

### DIFF
--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -1126,6 +1126,95 @@ class ToolExecutor:
           raise
       return result
 
+  async def _handle_rediscover(
+      self, session_id: str, session_mode: str, args: dict[str, Any]
+  ) -> dict[str, Any]:
+      # Chat entry point for imported (UPLOAD) schema rediscovery. Mirrors the
+      # sequence in POST /load/rediscover exactly (that endpoint backs the
+      # workspace "Rediscover schema" button); the only difference is that we
+      # surface gate failures as ValueError (the chat executor renders them as
+      # tool errors) and spawn the pipeline as an asyncio task instead of via
+      # FastAPI BackgroundTasks. Unlike reprocess, rediscovery re-evaluates
+      # previously-skipped documents, so it is the path for pulling a skipped
+      # document into the table.
+      from app.core.config import RELEASE_CONFIG
+      from app.models.schematiq import ScheMatiQConfig, LLMConfig
+
+      set_session_context(session_id)
+      session = session_manager.get_session(session_id)
+      if not session:
+          raise ValueError("Session not found.")
+      if session.type != SessionType.UPLOAD:
+          raise ValueError(
+              "Rediscovery is only available for imported projects."
+          )
+      if not session.observation_unit:
+          raise ValueError(
+              "This project has no observation unit configured. Set one before "
+              "rediscovering."
+          )
+
+      # Same availability gate the UI button and /load/rediscover use: rediscovery
+      # is only meaningful if the project's rows resolve to real source documents
+      # (local pending_documents/documents, or the session's cloud dataset).
+      paper_discovery = await reextraction_service.discover_papers(session_id)
+      availability = await reextraction_service.precheck_document_availability(
+          session_id,
+          operation_type="reextraction",
+          paper_discovery=paper_discovery,
+      )
+      if not availability.get("can_proceed", False):
+          raise ValueError(
+              "No source documents are available for this project. Open a row and "
+              'use "Show source document" to re-attach the original files, then '
+              "try again."
+          )
+
+      if not DEVELOPER_MODE:
+          schematiq_runner.check_global_quota(LLM_CALL_GLOBAL_LIMIT)
+
+      # docs_path is left unset: resolve_docs_paths() auto-detects session-local
+      # pending_documents/documents before falling back to it, which is exactly
+      # where an imported project's (re-attached) files live.
+      config = ScheMatiQConfig(
+          query=session.schema_query or "",
+          docs_path=None,
+          schema_creation_backend=LLMConfig(
+              provider=RELEASE_CONFIG["llm_provider"],
+              model=RELEASE_CONFIG["schema_creation_model"],
+              temperature=RELEASE_CONFIG["llm_temperature"],
+          ),
+          value_extraction_backend=LLMConfig(
+              provider=RELEASE_CONFIG["llm_provider"],
+              model=RELEASE_CONFIG["value_extraction_model"],
+              temperature=RELEASE_CONFIG["llm_temperature"],
+          ),
+          output_path="outputs/rediscovered_output.json",
+      )
+      await schematiq_runner.save_config(session_id, config)
+
+      # Mark this run as an observation-unit rediscovery so prepare_resume clears
+      # prior schema/data artifacts and seeds initial_observation_unit from
+      # session.observation_unit, exactly like the SCHEMATIQ-session flow.
+      session = session_manager.get_session(session_id)
+      session.metadata.pending_observation_unit_rediscovery = True
+      session_manager.update_session(session)
+
+      await concurrency_limiter.acquire(session_id, "schematiq")
+      try:
+          await schematiq_runner.prepare_resume(session_id)
+      except Exception:
+          await concurrency_limiter.release(session_id)
+          raise
+      asyncio.create_task(self._run_schematiq_task(session_id))
+      return {
+          "status": "started",
+          "message": (
+              "Schema rediscovery started. Previously-skipped documents will be "
+              "re-evaluated under the current observation unit."
+          ),
+      }
+
   async def _handle_web_search(
       self, session_id: str, session_mode: str, args: dict[str, Any]
   ) -> dict[str, Any]:

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -699,6 +699,31 @@ def _all_tools() -> list[ToolSpec]:
             handler="reprocess",
         ),
         ToolSpec(
+            name="rediscover",
+            description=(
+                "Re-run schema and observation-unit discovery for an IMPORTED "
+                "project from its source documents (expensive). Unlike `reprocess`, "
+                "this DOES re-evaluate documents that were previously skipped, so "
+                "it is the way to pull a skipped document into the table once its "
+                "source file is available and/or the observation unit has been "
+                "updated to match it (call edit_observation_unit first if the unit "
+                "does not fit the document). It re-runs discovery over the whole "
+                "project — schema and rows are rebuilt from scratch — so always "
+                "confirm with the user before running it. Requires the source "
+                "documents to be available; if they are not, tell the user to "
+                "re-attach the originals via \"Show source document\" first, then "
+                "retry. Only for imported (load) sessions."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+            cost_class="expensive",
+            handler="rediscover",
+            session_modes=("load",),
+        ),
+        ToolSpec(
             name="web_search",
             description="Search the web for external information (planned, not yet available).",
             parameters={
@@ -840,5 +865,6 @@ def tool_running_label(tool_name: str) -> str:
         "extract_cells": "Filling cells",
         "continue_discovery": "Starting continue discovery",
         "reprocess": "Starting reprocessing",
+        "rediscover": "Rediscovering schema",
     }
     return labels.get(tool_name, f"Running {tool_name}")

--- a/backend/tests/test_chat_tool_registry.py
+++ b/backend/tests/test_chat_tool_registry.py
@@ -44,3 +44,12 @@ def test_function_declarations_skip_unavailable():
     declarations = to_function_declarations(tools)
     names = {decl.name for decl in declarations}
     assert "web_search" not in names
+
+
+def test_load_mode_includes_rediscover_but_schematiq_does_not():
+    """rediscover is the load-mode path to re-evaluate skipped documents; in
+    schematiq mode run_schematiq/reextract already cover that, so it is hidden."""
+    load = {t.name for t in get_tools_for_context("session-1", "load")}
+    sch = {t.name for t in get_tools_for_context("session-1", "schematiq")}
+    assert "rediscover" in load
+    assert "rediscover" not in sch


### PR DESCRIPTION
## Problem
In an imported (load-mode) session the chat agent has no tool that can re-extract a previously-skipped document. reprocess — the only extraction tool advertised in load mode — explicitly keeps skipped documents skipped, and extract_cells/reextract/continue_discovery are gated to schematiq mode. So re-attaching a file via 'Show source document' cannot be acted on from chat, even though the UI 'Rediscover schema' button (POST /load/rediscover) can do it.

## Solution
Add a load-only, expensive 'rediscover' chat tool. Its handler mirrors the proven /load/rediscover sequence exactly (validate UPLOAD + observation unit, gate on precheck_document_availability, quota check, synthesize config, set pending_observation_unit_rediscovery, prepare_resume, spawn run_schematiq via asyncio) — differing only in surfacing gate failures as tool errors and spawning as an asyncio task instead of BackgroundTasks. cost_class=expensive triggers the existing confirmation card. The existing route is left untouched to avoid risk to the UI path; a future refactor can unify them.

## Verify
- python -m py_compile backend/app/services/chat/tool_registry.py backend/app/services/chat/tool_executor.py backend/tests/test_chat_tool_registry.py
- python -m pytest backend/tests/test_chat_tool_registry.py (adds: rediscover is load-only)
- MANUAL SMOKE TEST on a real imported session before merge: update the observation unit, ensure a source doc is available, ask the chat to run rediscover, confirm the skipped document is re-evaluated.
- Backend-only.