### PR TITLE
fix(export): bundle skipped and on-disk source documents

### DIFF
--- a/backend/app/services/document_files.py
+++ b/backend/app/services/document_files.py
@@ -50,26 +50,47 @@ async def gather_source_documents(session, session_id: str) -> List[Tuple[str, b
     Order mirrors the viewer: local files first, then the session's cloud dataset
     in Supabase storage. Documents that cannot be located are silently skipped
     (the bundle still imports; those previews simply stay unavailable).
+
+    Row-backed documents (``get_source_documents``) are only part of the story: a
+    document that was skipped during extraction has no rows, and a file the user
+    re-attached via "Show source document" lands on disk without necessarily being
+    referenced by a row. Both must still travel inside the bundle so a re-imported
+    project can preview them and re-run discovery against them. We therefore also
+    include the session's skipped-document names (for cloud lookup) and sweep the
+    local document dirs for any on-disk file not already gathered.
     """
     try:
         names = [d["name"] for d in unit_view_service.get_source_documents(session_id)]
     except Exception:
         names = []
 
+    # Skipped documents have no rows, so append their names too (deduped below).
+    try:
+        stats = getattr(session, "statistics", None)
+        for skipped in (stats.skipped_documents if stats and stats.skipped_documents else []):
+            doc_name = getattr(skipped, "document", None)
+            if doc_name:
+                names.append(doc_name)
+    except Exception:
+        pass
+
     out: List[Tuple[str, bytes]] = []
-    seen: set = set()
+    seen_stems: set = set()
     cloud_dataset = getattr(session.metadata, "cloud_dataset", None)
     storage = None
 
+    def _record(filename: str, content: bytes) -> None:
+        out.append((filename, content))
+        seen_stems.add(Path(filename).stem.lower())
+
     for name in names:
-        if not name or name in seen:
+        if not name or Path(name).stem.lower() in seen_stems:
             continue
-        seen.add(name)
 
         local = _find_local_document(session_id, name)
         if local is not None:
             try:
-                out.append((local.name, local.read_bytes()))
+                _record(local.name, local.read_bytes())
                 continue
             except Exception:
                 pass
@@ -82,6 +103,24 @@ async def gather_source_documents(session, session_id: str) -> List[Tuple[str, b
             except Exception:
                 content = None
             if content:
-                out.append((name, content))
+                _record(name, content)
+
+    # Sweep the local document dirs for any on-disk file not yet gathered. This
+    # captures re-attached originals and skipped documents whose files exist
+    # locally but are not referenced by any row.
+    for base in candidate_data_dirs():
+        for sub in ("documents", "pending_documents"):
+            doc_dir = base / session_id / sub
+            if not doc_dir.is_dir():
+                continue
+            for f in sorted(doc_dir.iterdir()):
+                if not f.is_file() or f.name.startswith("."):
+                    continue
+                if f.stem.lower() in seen_stems:
+                    continue
+                try:
+                    _record(f.name, f.read_bytes())
+                except Exception:
+                    pass
 
     return out

--- a/backend/tests/test_bundle_gather_documents.py
+++ b/backend/tests/test_bundle_gather_documents.py
@@ -1,0 +1,81 @@
+"""Tests for gather_source_documents (project bundle export).
+
+The bundle must round-trip every source file that physically exists for a
+session — not just documents referenced by table rows. In particular a
+previously-skipped document (no rows) and a file re-attached via "Show source
+document" (lands in pending_documents/) must be included so a re-imported
+project can preview them and re-run discovery against them.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import document_files
+
+
+@pytest.fixture
+def patched_dirs(tmp_path, monkeypatch):
+    monkeypatch.setattr(document_files, "candidate_data_dirs", lambda: [tmp_path])
+    # No cloud, and only one row-backed document reported by the unit view.
+    monkeypatch.setattr(
+        document_files.unit_view_service,
+        "get_source_documents",
+        lambda session_id: [{"name": "OtherDoc.txt", "row_count": 3}],
+    )
+
+    def _no_storage():
+        raise RuntimeError("cloud not configured in test")
+
+    monkeypatch.setattr(document_files, "get_storage", _no_storage)
+    return tmp_path
+
+
+def _session_with_skipped(*skipped_names):
+    return SimpleNamespace(
+        statistics=SimpleNamespace(
+            skipped_documents=[
+                SimpleNamespace(document=n) for n in skipped_names
+            ]
+        ),
+        metadata=SimpleNamespace(cloud_dataset=None),
+    )
+
+
+async def test_bundle_includes_skipped_and_on_disk_documents(patched_dirs):
+    session_id = "sess-bundle"
+    docs = patched_dirs / session_id / "documents"
+    pending = patched_dirs / session_id / "pending_documents"
+    docs.mkdir(parents=True)
+    pending.mkdir(parents=True)
+
+    (docs / "OtherDoc.txt").write_bytes(b"row-backed")
+    # Skipped document re-attached via "Show source document" (no rows).
+    (pending / "CASA2025-06-27SCt.txt").write_bytes(b"skipped re-attached")
+    # A file on disk that is neither row-backed nor recorded as skipped.
+    (docs / "RandomExtra.txt").write_bytes(b"orphan on disk")
+
+    session = _session_with_skipped("CASA2025-06-27SCt")
+    result = await document_files.gather_source_documents(session, session_id)
+    names = sorted(name for name, _ in result)
+
+    assert "OtherDoc.txt" in names          # row-backed (existing behavior)
+    assert "CASA2025-06-27SCt.txt" in names  # skipped, re-attached (new)
+    assert "RandomExtra.txt" in names        # on-disk orphan (new)
+    # Deduped: the row-backed doc is included exactly once.
+    assert names.count("OtherDoc.txt") == 1
+
+
+async def test_bundle_dedups_skipped_name_against_row_backed(patched_dirs):
+    """A skipped name that also resolves on disk is not double-added."""
+    session_id = "sess-dedup"
+    docs = patched_dirs / session_id / "documents"
+    docs.mkdir(parents=True)
+    (docs / "OtherDoc.txt").write_bytes(b"row-backed")
+
+    # Same stem listed as skipped too — must not appear twice.
+    session = _session_with_skipped("OtherDoc")
+    result = await document_files.gather_source_documents(session, session_id)
+    names = [name for name, _ in result]
+
+    assert names.count("OtherDoc.txt") == 1


### PR DESCRIPTION
## Problem
The project bundle (export format=bundle) gathered source files from get_source_documents, which lists only documents that have table rows. A previously-skipped document (no rows) — or a file re-attached via 'Show source document', which lands in pending_documents/ without a row — was left out of the bundle, so a re-imported project could not preview it or re-run discovery against it.

## Solution
gather_source_documents now also (1) appends the session's skipped-document names so cloud lookup covers them, and (2) sweeps the local documents/ and pending_documents/ dirs across candidate data dirs, adding any on-disk file not already gathered, deduped by stem. Plain JSON export stays data-only by design (a JSON should not embed document bytes); full round-trip is the bundle's job.

## Verify
- python -m py_compile backend/app/services/document_files.py backend/tests/test_bundle_gather_documents.py
- python -m pytest backend/tests/test_bundle_gather_documents.py (skipped + on-disk docs bundled; dedup)
- Backend-only.