### PR TITLE
feat(chat): gate extraction tools on document availability, not session type

### DIFF
--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -17,7 +17,13 @@ from app.core.config import (
 from app.services import websocket_manager
 from schematiq.core.llm_call_tracker import LLMCallTracker, QuotaExceededError
 
-from .deps import CHAT_MODEL, get_gemini_api_key, schematiq_runner, session_manager
+from .deps import (
+    CHAT_MODEL,
+    get_gemini_api_key,
+    reextraction_service,
+    schematiq_runner,
+    session_manager,
+)
 from .session_store import ChatSessionState, PendingToolCall, chat_session_store
 from .tool_executor import tool_executor
 from .tool_registry import (
@@ -149,6 +155,32 @@ class ChatAgentService:
         except Exception as exc:
             logger.debug("Could not record chat LLM usage: %s", exc)
 
+    @staticmethod
+    def _extraction_capable(session_id: Optional[str], session_mode: str) -> bool:
+        """Whether document-backed extraction tools should be offered.
+
+        Mirrors the frontend rule
+        ``canRediscoverSchema = sessionMode == 'schematiq' || hasSourceDocuments``:
+        schematiq sessions are always capable; a load (imported) session becomes
+        capable once its source documents are present. Uses a cheap, synchronous
+        local-disk check so it can run per message. Documents that live only in
+        cloud storage are not seen here (a known limitation); the downstream
+        gated extraction path performs the full local+cloud availability
+        precheck and returns a clear message, so an over-eager offer degrades to
+        a precise error rather than a silent no-op.
+        """
+        if session_mode != "load":
+            return True
+        if not session_id:
+            return False
+        try:
+            return reextraction_service.has_local_source_documents(session_id)
+        except Exception:  # pragma: no cover - defensive; the gate must never crash chat
+            logger.debug(
+                "extraction-capability check failed for %s", session_id, exc_info=True
+            )
+            return False
+
     async def list_tools(
         self,
         session_id: Optional[str],
@@ -156,7 +188,11 @@ class ChatAgentService:
     ) -> list[dict[str, Any]]:
         from .tool_registry import to_public_tool_list
 
-        tools = get_tools_for_context(session_id, session_mode)
+        tools = get_tools_for_context(
+            session_id,
+            session_mode,
+            extraction_capable=self._extraction_capable(session_id, session_mode),
+        )
         return to_public_tool_list(tools)
 
     async def send_message(
@@ -418,7 +454,11 @@ class ChatAgentService:
     ) -> tuple[Any, Any]:
         from google.genai import types
 
-        tools = get_tools_for_context(session_id, session_mode)
+        tools = get_tools_for_context(
+            session_id,
+            session_mode,
+            extraction_capable=self._extraction_capable(session_id, session_mode),
+        )
         declarations = to_function_declarations(tools)
         tool = types.Tool(function_declarations=declarations)
         config = types.GenerateContentConfig(

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -25,6 +25,10 @@ class ToolSpec:
     requires_session: bool = True
     session_modes: tuple[str, ...] = ("schematiq", "load")
     hidden_in_load: bool = False
+    # Document-backed extraction tools: offered outside their declared
+    # session_modes (i.e. in load mode) only when the session's source documents
+    # are available. See get_tools_for_context's extraction_capable parameter.
+    requires_documents: bool = False
 
 
 EMPTY_PARAMS: dict[str, Any] = {"type": "object", "properties": {}, "required": []}
@@ -584,6 +588,7 @@ def _all_tools() -> list[ToolSpec]:
             cost_class="expensive",
             handler="reextract",
             session_modes=("schematiq",),
+            requires_documents=True,
         ),
         ToolSpec(
             name="extract_cells",
@@ -643,6 +648,7 @@ def _all_tools() -> list[ToolSpec]:
             cost_class="expensive",
             handler="extract_cells",
             session_modes=("schematiq",),
+            requires_documents=True,
         ),
         ToolSpec(
             name="continue_discovery",
@@ -739,8 +745,21 @@ TOOL_BY_NAME: dict[str, ToolSpec] = {tool.name: tool for tool in _all_tools()}
 def get_tools_for_context(
     session_id: Optional[str],
     session_mode: str = "schematiq",
+    extraction_capable: bool = False,
 ) -> list[ToolSpec]:
-    """Return tools available for the current workspace context."""
+    """Return tools available for the current workspace context.
+
+    ``extraction_capable`` unlocks the document-backed extraction tools (those
+    flagged ``requires_documents``) outside their declared ``session_modes`` —
+    in practice, in ``load`` mode once the session's source documents are
+    available. This mirrors the frontend rule
+    ``canRediscoverSchema = sessionMode == 'schematiq' || hasSourceDocuments``:
+    the correct gate for extraction is document availability, not session type.
+
+    It defaults to ``False`` so every existing caller keeps today's mode-only
+    gating, and it affects ONLY ``requires_documents`` tools — every other tool
+    stays gated exactly as before.
+    """
     tools: list[ToolSpec] = []
     for tool in _all_tools():
         if not tool.available:
@@ -749,9 +768,13 @@ def get_tools_for_context(
             continue
         if tool.requires_session and not session_id:
             continue
-        if session_id and session_mode not in tool.session_modes:
+        # A document-backed extraction tool is offered outside its declared
+        # session_modes (and past hidden_in_load) only when the session is
+        # extraction-capable — i.e. load mode with source documents present.
+        doc_unlocked = tool.requires_documents and extraction_capable
+        if session_id and session_mode not in tool.session_modes and not doc_unlocked:
             continue
-        if session_id and session_mode == "load" and tool.hidden_in_load:
+        if session_id and session_mode == "load" and tool.hidden_in_load and not doc_unlocked:
             continue
         tools.append(tool)
     return tools
@@ -774,11 +797,11 @@ def available_tools_prompt_addendum(tools: list[ToolSpec]) -> str:
     """A mode-aware system-prompt footer naming the tools that are callable now.
 
     The static chat system prompt names tools (reextract, extract_cells,
-    run_schematiq, continue_discovery, ...) that ``get_tools_for_context``
-    filters out in load mode, because imported/load sessions have no source
-    documents to extract from. Without this footer the model follows the static
-    prompt and offers such a tool, then contradicts itself when the call turns
-    out to be unavailable. Built from the SAME tool list as
+    run_schematiq, continue_discovery, ...) that ``get_tools_for_context`` may
+    filter out for this session — e.g. extraction tools in a load session with
+    no source documents available. Without this footer the model follows the
+    static prompt and offers such a tool, then contradicts itself when the call
+    turns out to be unavailable. Built from the SAME tool list as
     ``to_function_declarations`` (only ``available`` tools are callable) so the
     advertised set can never drift from what the model can actually call.
     """
@@ -790,9 +813,9 @@ def available_tools_prompt_addendum(tools: list[ToolSpec]) -> str:
         + ", ".join(names)
         + ".\nUse and offer ONLY these tools. If a request would require a tool "
         "that is not listed here — for example re-running extraction or "
-        "rediscovering the schema in an imported (load) session, which has no "
-        "source documents — tell the user plainly that it is not available in "
-        "this session instead of offering or attempting it."
+        "rediscovering the schema when the session has no source documents "
+        "available — tell the user plainly that it is not available in this "
+        "session instead of offering or attempting it."
     )
 
 

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -478,6 +478,20 @@ class ReextractionService(WebSocketBroadcasterMixin):
                         filenames.append(f.name)
         return filenames
 
+    def has_local_source_documents(self, session_id: str) -> bool:
+        """Cheap synchronous check: are any source documents present on disk?
+
+        Used by the chat tool gate to decide whether the document-backed
+        extraction tools should be offered in load mode, matching the frontend's
+        ``hasSourceDocuments`` rule. Local-only by design so it can run per
+        message; documents that live only in cloud storage are not seen here.
+        The downstream gated extraction path (``start_gated_reextraction``)
+        performs the full local+cloud availability precheck, so a tool offered
+        on this signal still fails with a clear message if the files turn out to
+        be unreachable — never a silent no-op.
+        """
+        return bool(self._collect_session_document_filenames(session_id))
+
     async def discover_papers(self, session_id: str) -> Dict[str, Any]:
         """
         Discover papers associated with table rows in storage.

--- a/backend/tests/test_chat_registry_filtering.py
+++ b/backend/tests/test_chat_registry_filtering.py
@@ -77,6 +77,53 @@ def test_schematiq_only_tools_hidden_in_load_mode() -> None:
     assert {"run_schematiq", "reextract", "continue_discovery"}.isdisjoint(load)
 
 
+def test_extraction_tools_unlocked_in_load_mode_when_capable() -> None:
+    # The correct gate for extraction is document availability, not session
+    # type: a load (imported) session whose source documents are available must
+    # offer the document-backed extraction tools, matching the frontend rule
+    # canRediscoverSchema = schematiq || hasSourceDocuments. Only tools flagged
+    # requires_documents are unlocked.
+    load_capable = {
+        t.name for t in get_tools_for_context("s1", "load", extraction_capable=True)
+    }
+    assert {"reextract", "extract_cells"} <= load_capable
+    # run_schematiq (its handler hard-requires a SCHEMATIQ session) and
+    # continue_discovery (separate service, not yet document-gated) are NOT
+    # flagged requires_documents, so they stay hidden even when capable.
+    assert {"run_schematiq", "continue_discovery"}.isdisjoint(load_capable)
+
+
+def test_extraction_tools_stay_hidden_in_load_mode_without_documents() -> None:
+    # Without documents (extraction_capable defaults False) the load session
+    # behaves exactly as before: no extraction tools. This is the strict
+    # subset that guarantees no behavior change for existing doc-less imports.
+    load_incapable = {t.name for t in get_tools_for_context("s1", "load")}
+    assert {"reextract", "extract_cells"}.isdisjoint(load_incapable)
+    assert get_tools_for_context("s1", "load") == get_tools_for_context(
+        "s1", "load", extraction_capable=False
+    )
+
+
+def test_extraction_capable_never_changes_schematiq_mode() -> None:
+    # schematiq is always extraction-capable; the flag must not add or remove
+    # anything there.
+    base = {t.name for t in get_tools_for_context("s1", "schematiq")}
+    capable = {
+        t.name for t in get_tools_for_context("s1", "schematiq", extraction_capable=True)
+    }
+    assert base == capable
+
+
+def test_capable_load_addendum_advertises_extraction_tools() -> None:
+    # When the tools are unlocked, the mode-aware footer must advertise them so
+    # the model actually offers them (parity with the callable declaration set).
+    addendum = available_tools_prompt_addendum(
+        get_tools_for_context("s1", "load", extraction_capable=True)
+    )
+    assert "reextract" in addendum
+    assert "extract_cells" in addendum
+
+
 def test_skipped_document_diagnostics_available_in_load_mode() -> None:
     # Skipped-document visibility is a pure read of persisted statistics, which
     # imported/load sessions carry (skipped_documents survive export/import).


### PR DESCRIPTION
## Problem
The chat agent decides which extraction tools it may offer from the *session mode* (`schematiq` vs `load`), not from whether the session can actually be extracted. In `load` mode every extraction tool is hidden, so once a project is imported the chat cannot re-extract a document even after the user re-attaches its source file via "Show source document". The `load`/`schematiq` split is no longer a valid proxy for extraction capability. The frontend already models the correct rule: `canRediscoverSchema = sessionMode === 'schematiq' || hasSourceDocuments`. The chat layer had not caught up.

## Solution
Move the extraction gate from session type to document availability (design doc Patch 2, Option B).

- `ToolSpec` gains a `requires_documents` flag; `reextract` and `extract_cells` are marked with it. Both already funnel through `start_gated_reextraction`, which gates on document availability (not session type) and returns clear user-facing errors — so unlocking them in load mode is provably safe.
- `get_tools_for_context` gains an `extraction_capable` parameter (default `False`). A `requires_documents` tool is offered outside its declared `session_modes` only when `extraction_capable` is true. Every other tool keeps today's gating exactly.
- `agent_service._extraction_capable()` computes the signal, mirroring the frontend rule: schematiq is always capable; load becomes capable once source documents are present, via a cheap synchronous local-disk check (`reextraction_service.has_local_source_documents`). Wired into both `list_tools` and the Gemini chat build.
- The mode-aware prompt addendum wording is made availability-based instead of asserting load sessions never have documents.

Deliberately excluded from the document gate:
- `run_schematiq` — its handler hard-requires `SessionType.SCHEMATIQ`; unlocking it in load mode would fail confusingly.
- `continue_discovery` — routes through a separate service; document-source resolution for UPLOAD needs its own verification. Left as a follow-up.

Known limitation (Option B): the availability signal is local-disk only, so cloud-only documents are not seen at gate time. Re-attached docs land on local disk and are picked up. The change is a strict superset of today's behavior — no path that works today changes its result.

## Verify
- `git apply --ignore-whitespace --check` on a fresh clone of current main: clean.
- `python -m py_compile` on all four touched files: clean.
- Registry logic checks (standalone, no LLM): load without docs unchanged; capable load unlocks `reextract`+`extract_cells` only; schematiq unchanged by the flag; `reprocess` unchanged; no-session context unaffected; addendum parity; `requires_documents` flags correct.
- New unit tests in `test_chat_registry_filtering.py` cover unlock, backward-compat, schematiq invariance, and addendum parity.

**Pre-merge manual smoke test (design §7.1, cannot be automated here):** import a bundle with docs + config, re-attach a source doc, ask chat to re-extract a skipped document, confirm rows appear; then repeat on a doc-less import and confirm the tools stay hidden.