### PR TITLE
fix(export): bundle skipped and on-disk source documents

### DIFF
--- a/backend/app/services/document_files.py
+++ b/backend/app/services/document_files.py
@@ -7,12 +7,23 @@ data dirs first, then the Supabase ``datasets`` bucket under the session's
 ``cloud_dataset``. Returns originals (no PDF->text conversion) so re-imported
 bundles preview natively.
 
+The bundled set is the UNION of three sources, so a re-imported project can
+become extraction-capable rather than merely previewable:
+  1. Row-referenced documents (``unit_view_service.get_source_documents``).
+  2. Documents skipped during extraction
+     (``session.statistics.skipped_documents``) — these carry no rows, so they
+     are invisible to (1), yet they are exactly the files a user re-imports in
+     order to retry them.
+  3. Any remaining source file present on local disk under the session's
+     ``documents/`` / ``pending_documents/`` dirs that (1) and (2) missed
+     (e.g. uploaded-but-not-yet-extracted files).
+
 NOTE: ``_find_local_document`` duplicates the helper of the same name in
 ``app.api.routes.units``; a future refactor can fold both onto this module.
 """
 
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Iterator, List, Optional, Tuple
 
 from app.services.data_utils import candidate_data_dirs
 from app.services.unit_view_service import unit_view_service
@@ -44,6 +55,37 @@ def _find_local_document(session_id: str, name: str) -> Optional[Path]:
     return None
 
 
+def _iter_local_documents(session_id: str) -> Iterator[Path]:
+    """Yield every source file on local disk for a session.
+
+    Searches documents/ and pending_documents/ across every candidate data dir,
+    the same locations as ``_find_local_document``. De-duplicates by filename so
+    the same file discovered under multiple candidate roots is yielded once.
+    """
+    seen_names: set = set()
+    for base in candidate_data_dirs():
+        for sub in ("documents", "pending_documents"):
+            doc_dir = base / session_id / sub
+            if not doc_dir.is_dir():
+                continue
+            for f in sorted(doc_dir.iterdir()):
+                if f.is_file() and not f.name.startswith(".") and f.name not in seen_names:
+                    seen_names.add(f.name)
+                    yield f
+
+
+def _skipped_document_names(session) -> List[str]:
+    """Filenames of documents skipped during extraction (they carry no rows)."""
+    stats = getattr(session, "statistics", None) if session else None
+    skipped = getattr(stats, "skipped_documents", None) or []
+    names: List[str] = []
+    for doc in skipped:
+        raw = doc.get("document") if isinstance(doc, dict) else getattr(doc, "document", None)
+        if raw:
+            names.append(Path(raw).name)
+    return names
+
+
 async def gather_source_documents(session, session_id: str) -> List[Tuple[str, bytes]]:
     """Return ``(filename, original_bytes)`` for each source document in a session.
 
@@ -56,8 +98,13 @@ async def gather_source_documents(session, session_id: str) -> List[Tuple[str, b
     except Exception:
         names = []
 
+    # Skipped documents carry no rows, so get_source_documents never lists them;
+    # add them explicitly so a re-imported project can retry them.
+    names.extend(_skipped_document_names(session))
+
     out: List[Tuple[str, bytes]] = []
-    seen: set = set()
+    seen: set = set()       # requested names already processed
+    added: set = set()      # actual filenames placed into the bundle
     cloud_dataset = getattr(session.metadata, "cloud_dataset", None)
     storage = None
 
@@ -69,7 +116,9 @@ async def gather_source_documents(session, session_id: str) -> List[Tuple[str, b
         local = _find_local_document(session_id, name)
         if local is not None:
             try:
-                out.append((local.name, local.read_bytes()))
+                content = local.read_bytes()
+                out.append((local.name, content))
+                added.add(local.name)
                 continue
             except Exception:
                 pass
@@ -83,5 +132,19 @@ async def gather_source_documents(session, session_id: str) -> List[Tuple[str, b
                 content = None
             if content:
                 out.append((name, content))
+                added.add(name)
+
+    # Sweep any remaining on-disk source files that neither the rows nor the
+    # skipped list referenced (e.g. uploaded-but-not-yet-extracted files). Local
+    # bytes only; keyed by the actual filename so nothing already bundled above
+    # is duplicated.
+    for local in _iter_local_documents(session_id):
+        if local.name in added:
+            continue
+        added.add(local.name)
+        try:
+            out.append((local.name, local.read_bytes()))
+        except Exception:
+            pass
 
     return out

--- a/backend/tests/test_document_files_bundle.py
+++ b/backend/tests/test_document_files_bundle.py
@@ -1,0 +1,109 @@
+"""Tests for bundle source-document collection.
+
+Focus on the additive behavior introduced so a re-imported bundle carries the
+files needed to become extraction-capable: skipped documents (which have no
+rows) and on-disk-only files (uploaded but not yet extracted). These exercise
+the pure-filesystem helpers directly, so they need no LLM, no storage backend,
+and no FastAPI import chain.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.services import document_files
+
+
+def _make_session(skipped=None, cloud_dataset=None):
+    stats = SimpleNamespace(
+        skipped_documents=[
+            SimpleNamespace(document=name) for name in (skipped or [])
+        ]
+    )
+    metadata = SimpleNamespace(cloud_dataset=cloud_dataset)
+    return SimpleNamespace(statistics=stats, metadata=metadata)
+
+
+def _seed_docs(root: Path, session_id: str, sub: str, filenames):
+    doc_dir = root / "data" / session_id / sub
+    doc_dir.mkdir(parents=True, exist_ok=True)
+    for name in filenames:
+        (doc_dir / name).write_bytes(f"bytes::{name}".encode())
+    return doc_dir
+
+
+def test_iter_local_documents_covers_both_dirs_and_dedupes(tmp_path, monkeypatch):
+    session_id = "s1"
+    _seed_docs(tmp_path, session_id, "documents", ["a.pdf", "b.pdf"])
+    _seed_docs(tmp_path, session_id, "pending_documents", ["c.pdf", "a.pdf"])
+    # A hidden file must be ignored.
+    (tmp_path / "data" / session_id / "documents" / ".DS_Store").write_bytes(b"x")
+
+    monkeypatch.setattr(
+        document_files, "candidate_data_dirs", lambda: [tmp_path / "data"]
+    )
+
+    found = sorted(p.name for p in document_files._iter_local_documents(session_id))
+    # a.pdf appears in both dirs but is yielded once; hidden file excluded.
+    assert found == ["a.pdf", "b.pdf", "c.pdf"]
+
+
+def test_skipped_document_names_from_models_and_dicts():
+    session = _make_session(skipped=["/tmp/x/skipped_one.pdf", "skipped_two.txt"])
+    assert document_files._skipped_document_names(session) == [
+        "skipped_one.pdf",
+        "skipped_two.txt",
+    ]
+    # dict-shaped skipped entries are handled too, and a None session is safe.
+    dict_session = SimpleNamespace(
+        statistics=SimpleNamespace(skipped_documents=[{"document": "d.pdf"}])
+    )
+    assert document_files._skipped_document_names(dict_session) == ["d.pdf"]
+    assert document_files._skipped_document_names(None) == []
+
+
+async def test_gather_bundles_skipped_and_on_disk_docs(tmp_path, monkeypatch):
+    session_id = "s1"
+    # rowed.pdf is referenced by rows; skipped.pdf was skipped (no rows);
+    # orphan.pdf is on disk but referenced by neither.
+    _seed_docs(
+        tmp_path, session_id, "documents", ["rowed.pdf", "skipped.pdf", "orphan.pdf"]
+    )
+    monkeypatch.setattr(
+        document_files, "candidate_data_dirs", lambda: [tmp_path / "data"]
+    )
+    # Only rowed.pdf is row-referenced.
+    monkeypatch.setattr(
+        document_files.unit_view_service,
+        "get_source_documents",
+        lambda sid: [{"name": "rowed.pdf", "row_count": 2}],
+    )
+
+    session = _make_session(skipped=["skipped.pdf"])
+    out = await document_files.gather_source_documents(session, session_id)
+
+    names = sorted(name for name, _ in out)
+    assert names == ["orphan.pdf", "rowed.pdf", "skipped.pdf"]
+    # Bytes are the originals, one entry per file (no duplicates).
+    assert len(out) == 3
+    assert dict(out)["skipped.pdf"] == b"bytes::skipped.pdf"
+
+
+async def test_gather_is_superset_never_drops_rowed_docs(tmp_path, monkeypatch):
+    # Regression guard: adding skipped/on-disk collection must not remove the
+    # row-referenced documents that were always bundled.
+    session_id = "s2"
+    _seed_docs(tmp_path, session_id, "documents", ["only_rowed.pdf"])
+    monkeypatch.setattr(
+        document_files, "candidate_data_dirs", lambda: [tmp_path / "data"]
+    )
+    monkeypatch.setattr(
+        document_files.unit_view_service,
+        "get_source_documents",
+        lambda sid: [{"name": "only_rowed.pdf", "row_count": 1}],
+    )
+    session = _make_session()  # no skipped docs
+
+    out = await document_files.gather_source_documents(session, session_id)
+    assert [name for name, _ in out] == ["only_rowed.pdf"]


### PR DESCRIPTION
## Problem
The portable project bundle (`export format=bundle`) builds its document list from `unit_view_service.get_source_documents`, which counts documents *by rows*. Documents skipped during extraction carry no rows, so they were never bundled — and neither were uploaded-but-not-yet-extracted files on disk. A re-imported project therefore could not become extraction-capable for exactly the documents a user re-imports to retry.

## Solution
`gather_source_documents` now bundles the UNION of three sources, a strict superset of today:
1. Row-referenced documents (unchanged).
2. Skipped documents, read from `session.statistics.skipped_documents` (new helper `_skipped_document_names`, handles both model and dict shapes).
3. Any remaining on-disk source file under the session's `documents/` / `pending_documents/` dirs (new helper `_iter_local_documents`), via a final local-only sweep.

Deduplication tracks the actual bundled filename (not just the requested name), so a document resolved by stem-match is not re-added by the sweep. Both export routes (`schematiq.py`, `load.py`) call this one helper, so both are fixed by the single-file change.

## Verify
- `git apply --ignore-whitespace --check` on a fresh clone of current main: clean.
- `python -m py_compile` on both files: clean.
- Logic checks against the edited module (no LLM/storage needed): iter dedupes across both dirs and skips hidden files; skipped names parsed from models and dicts (None-safe); gather bundles skipped + on-disk + rowed once each; superset guard shows rowed docs are never dropped; stem-matched doc bundled once (not duplicated by the sweep).
- New unit tests in `test_document_files_bundle.py` cover all of the above.