### PR TITLE
feat(import): reassemble runnable schematiq_config.json from complete export

### DIFF
--- a/backend/app/services/file_parser.py
+++ b/backend/app/services/file_parser.py
@@ -385,22 +385,48 @@ class FileParser:
         else:
             raise ValueError("Unsupported file format")
 
-        # Save documents_batch_size to schematiq_config.json if present (for loaded exports)
+        # Restore pipeline config from a complete export into schematiq_config.json,
+        # so a re-imported project is genuinely extraction-capable without the
+        # server synthesizing a config from RELEASE_CONFIG defaults at rediscover
+        # time. Only fields the export already carries are restored: the batch
+        # size, both LLM backends (from llm_configuration), and the query. This is
+        # the exact file and key shape the re-extraction path reads
+        # (ReextractionService._get_llm_from_session, "schematiq_config.json"
+        # priority) and that a later complete re-export reads back, so it
+        # round-trips. Backward compatible: absent fields are simply not written,
+        # and a malformed block never fails the import.
+        extracted_meta = result.get("extracted_metadata") or {}
+        imported_llm_config = extracted_meta.get("llm_config") or {}
+        config_updates: Dict[str, Any] = {}
         if result.get("documents_batch_size") is not None:
+            config_updates["documents_batch_size"] = result["documents_batch_size"]
+        if isinstance(imported_llm_config, dict):
+            for backend_key in ("schema_creation_backend", "value_extraction_backend"):
+                backend = imported_llm_config.get(backend_key)
+                if backend:
+                    config_updates[backend_key] = backend
+        if extracted_meta.get("query"):
+            config_updates["query"] = extracted_meta["query"]
+
+        if config_updates:
             schematiq_config_file = session_dir / "schematiq_config.json"
             try:
-                # Load existing config or create new one
+                # Load existing config or create new one, then merge the restored
+                # fields (the export is authoritative for a freshly imported session).
                 if schematiq_config_file.exists():
                     with open(schematiq_config_file) as f:
                         config = json.load(f)
                 else:
                     config = {}
-                config["documents_batch_size"] = result["documents_batch_size"]
+                config.update(config_updates)
                 with open(schematiq_config_file, 'w') as f:
                     json.dump(config, f, indent=2)
-                logger.debug("Saved documents_batch_size=%s to schematiq_config.json", result['documents_batch_size'])
+                logger.debug(
+                    "Restored pipeline config on import: keys=%s",
+                    sorted(config_updates.keys()),
+                )
             except Exception as e:
-                logger.debug("Could not save documents_batch_size to config: %s", e)
+                logger.debug("Could not persist imported config to schematiq_config.json: %s", e)
 
         return result
     

--- a/backend/tests/test_import_config_restore.py
+++ b/backend/tests/test_import_config_restore.py
@@ -1,0 +1,106 @@
+"""Tests for restoring a runnable schematiq_config.json on import.
+
+A complete-export project.json already carries the query, both LLM backends
+(under ``llm_configuration``), and ``documents_batch_size``. On import these must
+be reassembled into ``<data_dir>/<session_id>/schematiq_config.json`` — the exact
+file and key shape the re-extraction path reads
+(``ReextractionService._get_llm_from_session``) — so a re-imported project is
+extraction-capable with its ORIGINAL backends instead of RELEASE_CONFIG defaults
+synthesized at rediscover time.
+
+These drive the public ``FileParser.parse_file`` so they exercise the real import
+path end to end.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.services.file_parser import FileParser
+
+
+def _write_export(session_dir, payload):
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / "project.json").write_text(json.dumps(payload))
+
+
+def _complete_export():
+    return {
+        "query": "extract drug interactions",
+        "schema": {
+            "columns": [
+                {"name": "drug", "definition": "the drug", "rationale": ""},
+            ]
+        },
+        "llm_configuration": {
+            "schema_creation_backend": {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "temperature": 0,
+            },
+            "value_extraction_backend": {
+                "provider": "gemini",
+                "model": "gemini-3-flash",
+                "temperature": 0,
+            },
+        },
+        "metadata": {"documents_batch_size": 4, "total_documents": 3},
+        "data": [
+            {"row_name": "r1", "papers": ["a.pdf"], "data": {"drug": "aspirin"}},
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_complete_export_reassembles_runnable_config(tmp_path):
+    fp = FileParser(data_dir=str(tmp_path))
+    sid = "sess-complete"
+    _write_export(tmp_path / sid, _complete_export())
+
+    await fp.parse_file(sid)
+
+    cfg = json.loads((tmp_path / sid / "schematiq_config.json").read_text())
+    assert cfg["documents_batch_size"] == 4
+    assert cfg["query"] == "extract drug interactions"
+    assert cfg["schema_creation_backend"]["provider"] == "openai"
+    assert cfg["value_extraction_backend"]["model"] == "gemini-3-flash"
+
+
+@pytest.mark.asyncio
+async def test_old_export_without_backends_stays_backward_compatible(tmp_path):
+    # An export that predates llm_configuration: only documents_batch_size is
+    # persisted, exactly as before. No backends invented.
+    fp = FileParser(data_dir=str(tmp_path))
+    sid = "sess-old"
+    payload = _complete_export()
+    payload.pop("llm_configuration")
+    _write_export(tmp_path / sid, payload)
+
+    await fp.parse_file(sid)
+
+    cfg = json.loads((tmp_path / sid / "schematiq_config.json").read_text())
+    assert cfg["documents_batch_size"] == 4
+    assert "schema_creation_backend" not in cfg
+    assert "value_extraction_backend" not in cfg
+
+
+@pytest.mark.asyncio
+async def test_config_merge_preserves_unrelated_existing_keys(tmp_path):
+    # A pre-existing config on disk keeps its unrelated fields; the export's
+    # values win for the fields it carries (it is authoritative for the import).
+    fp = FileParser(data_dir=str(tmp_path))
+    sid = "sess-merge"
+    session_dir = tmp_path / sid
+    _write_export(session_dir, _complete_export())
+    (session_dir / "schematiq_config.json").write_text(
+        json.dumps({"max_keys_schema": 100, "documents_batch_size": 99})
+    )
+
+    await fp.parse_file(sid)
+
+    cfg = json.loads((session_dir / "schematiq_config.json").read_text())
+    assert cfg["max_keys_schema"] == 100          # unrelated key preserved
+    assert cfg["documents_batch_size"] == 4        # export value wins
+    assert cfg["schema_creation_backend"]["provider"] == "openai"


### PR DESCRIPTION
## Problem
A complete-export project.json already carries the query, both LLM backends (`llm_configuration`), and `documents_batch_size`. On import, only `documents_batch_size` was written to `schematiq_config.json`; the backends landed in session metadata only. So a re-imported project had no runnable config on disk, and the re-extraction / rediscovery path fell back to RELEASE_CONFIG defaults synthesized at run time — not the project's original backends.

## Solution
On import, restore a runnable `<data_dir>/<session_id>/schematiq_config.json` from fields the export already carries: `documents_batch_size`, both backends (`schema_creation_backend` / `value_extraction_backend`), and `query`. This is the exact file and key shape `ReextractionService._get_llm_from_session` reads (verified) and that a later complete re-export reads back, so it round-trips. Existing config on disk is merged (unrelated keys preserved; the export is authoritative for the fields it carries).

No export-format change: the reassembly uses only fields the export already emits, so no new block and no versioning decision (design §7.5) are needed. The consolidated/versioned `config` block from §4.3 is left as an optional cosmetic refactor.

## Backward compatibility
- Old export without `llm_configuration`: only `documents_batch_size` is written, exactly as before. No backends invented.
- Raw data import (no complete-export metadata): nothing written, as before.
- Malformed `llm_config`: tolerated (wrapped in try/except); never fails the import.

## Verify
- `git apply --ignore-whitespace --check` on a fresh clone of current main: clean.
- Line-ending audit after apply: file stays pure CRLF (2088 CRLF, 0 bare LF) — no mixed endings.
- `python -m py_compile` on both files: clean.
- Executed the real edited block against six scenarios (complete export reassembles all fields; batch-only stays backward compatible; raw import writes nothing; malformed llm_config tolerated; partial backends handled; pre-existing config merged with export values winning and unrelated keys preserved).
- New integration tests in `test_import_config_restore.py` drive the real `FileParser.parse_file`.