### PR TITLE
feat(chat): full schema rediscovery from chat

### DIFF
--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -1126,6 +1126,109 @@ class ToolExecutor:
           raise
       return result
 
+  async def _handle_rediscover(
+      self, session_id: str, session_mode: str, args: dict[str, Any]
+  ) -> dict[str, Any]:
+      # Full schema + observation-unit rediscovery from chat. Mirrors the proven
+      # POST /load/rediscover sequence (which backs the workspace "Rediscover
+      # schema" button): set pending_observation_unit_rediscovery so
+      # prepare_resume clears prior schema/data and re-seeds the observation
+      # unit, then run the pipeline — which re-evaluates previously-skipped
+      # documents. Differences from the route: gate failures surface as
+      # ValueError (rendered as a tool error), and the run is spawned as an
+      # asyncio task instead of via FastAPI BackgroundTasks.
+      #
+      # Works for both session types. The only mode-specific step is the config:
+      # a SCHEMATIQ session already has a runnable config.json from
+      # /schematiq/configure and must NOT have it overwritten with defaults; an
+      # UPLOAD session has none, so we synthesize one exactly like the route.
+      from app.core.config import RELEASE_CONFIG
+      from app.models.schematiq import ScheMatiQConfig, LLMConfig
+      from schematiq.core.llm_call_tracker import QuotaExceededError
+
+      set_session_context(session_id)
+      session = session_manager.get_session(session_id)
+      if not session:
+          raise ValueError("Session not found.")
+      if not session.observation_unit:
+          raise ValueError(
+              "This project has no observation unit configured. Set one "
+              "(edit_observation_unit) before rediscovering."
+          )
+
+      # Same availability gate reextraction and /load/rediscover use. The tool is
+      # only advertised when the session looks extraction-capable, but that
+      # signal is local-disk only, so re-check the authoritative predicate
+      # (local + cloud) here before starting an expensive run.
+      paper_discovery = await reextraction_service.discover_papers(session_id)
+      availability = await reextraction_service.precheck_document_availability(
+          session_id,
+          operation_type="reextraction",
+          paper_discovery=paper_discovery,
+      )
+      if not availability.get("can_proceed", False):
+          raise ValueError(
+              "No source documents are available for this project. Open a row and "
+              'use "Show source document" to re-attach the original files, then '
+              "try again."
+          )
+
+      if not DEVELOPER_MODE:
+          try:
+              schematiq_runner.check_global_quota(LLM_CALL_GLOBAL_LIMIT)
+          except QuotaExceededError as exc:
+              from app.core.email_alerts import send_quota_exceeded_alert
+              send_quota_exceeded_alert(total_used=exc.used)
+              raise ValueError(
+                  "The global usage limit has been reached. Please try again later."
+              ) from exc
+
+      if session.type == SessionType.UPLOAD:
+          # Imported session: no runnable config.json exists, so synthesize one
+          # (docs_path unset — resolve_docs_paths auto-detects the session-local
+          # pending_documents/documents where imported files live).
+          config = ScheMatiQConfig(
+              query=session.schema_query or "",
+              docs_path=None,
+              schema_creation_backend=LLMConfig(
+                  provider=RELEASE_CONFIG["llm_provider"],
+                  model=RELEASE_CONFIG["schema_creation_model"],
+                  temperature=RELEASE_CONFIG["llm_temperature"],
+              ),
+              value_extraction_backend=LLMConfig(
+                  provider=RELEASE_CONFIG["llm_provider"],
+                  model=RELEASE_CONFIG["value_extraction_model"],
+                  temperature=RELEASE_CONFIG["llm_temperature"],
+              ),
+              output_path="outputs/rediscovered_output.json",
+          )
+          await schematiq_runner.save_config(session_id, config)
+      # else SCHEMATIQ: keep the existing config.json written by /schematiq/configure.
+
+      session = session_manager.get_session(session_id)
+      session.metadata.pending_observation_unit_rediscovery = True
+      session_manager.update_session(session)
+
+      try:
+          await schematiq_runner.prepare_resume(session_id)
+      except RuntimeError as e:
+          msg = str(e)
+          if "already has an active operation" in msg or "Timed out waiting" in msg:
+              raise ValueError(
+                  "The pipeline is still stopping. Wait a few seconds and try again."
+              ) from e
+          raise
+
+      asyncio.create_task(self._run_schematiq_task(session_id))
+      return {
+          "status": "started",
+          "message": (
+              "Schema rediscovery started. The schema and rows are being rebuilt "
+              "from the source documents under the current observation unit; "
+              "previously-skipped documents are re-evaluated."
+          ),
+      }
+
   async def _handle_web_search(
       self, session_id: str, session_mode: str, args: dict[str, Any]
   ) -> dict[str, Any]:

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -705,6 +705,34 @@ def _all_tools() -> list[ToolSpec]:
             handler="reprocess",
         ),
         ToolSpec(
+            name="rediscover",
+            description=(
+                "Re-run full schema and observation-unit discovery from the "
+                "source documents (expensive). This rebuilds the schema and "
+                "re-discovers rows across the WHOLE project from scratch under "
+                "the current observation unit, so — unlike reextract/reprocess — "
+                "it re-evaluates documents that were previously skipped. Use it "
+                "to pull a skipped document into the table, or after "
+                "edit_observation_unit when the unit definition changed and the "
+                "table should be rebuilt to match. Because it discards the "
+                "current schema and rows and re-extracts everything, always "
+                "confirm with the user first. Requires the source documents to "
+                "be available; if they are not, tell the user to re-attach the "
+                "originals via \"Show source document\" first, then retry."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+            cost_class="expensive",
+            handler="rediscover",
+            # Same gating as reextract/extract_cells: offered in schematiq always,
+            # and in load mode once source documents are available.
+            session_modes=("schematiq",),
+            requires_documents=True,
+        ),
+        ToolSpec(
             name="web_search",
             description="Search the web for external information (planned, not yet available).",
             parameters={
@@ -863,5 +891,6 @@ def tool_running_label(tool_name: str) -> str:
         "extract_cells": "Filling cells",
         "continue_discovery": "Starting continue discovery",
         "reprocess": "Starting reprocessing",
+        "rediscover": "Rediscovering schema",
     }
     return labels.get(tool_name, f"Running {tool_name}")

--- a/backend/tests/test_chat_rediscover.py
+++ b/backend/tests/test_chat_rediscover.py
@@ -1,0 +1,131 @@
+"""Tests for the chat `rediscover` handler.
+
+`rediscover` triggers a full schema/observation-unit rebuild from source
+documents (the same operation as POST /load/rediscover and the workspace
+"Rediscover schema" button), re-evaluating previously-skipped documents. These
+tests drive the handler with mocked I/O to assert the gate and the
+per-session-type config handling, without running the real pipeline.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.session import (
+    ObservationUnitInfo,
+    SessionMetadata,
+    SessionStatus,
+    SessionType,
+    VisualizationSession,
+)
+from app.services.chat import tool_executor as te_module
+from app.services.chat.tool_executor import ToolExecutor
+
+
+@pytest.fixture
+def executor() -> ToolExecutor:
+    return ToolExecutor()
+
+
+def _make_session(session_manager, session_type: SessionType) -> VisualizationSession:
+    session = VisualizationSession(
+        id=f"rediscover-{session_type.value}",
+        type=session_type,
+        status=SessionStatus.COMPLETED,
+        metadata=SessionMetadata(source="test"),
+        columns=[],
+        schema_query="judges voting on immigration policy",
+        observation_unit=ObservationUnitInfo(name="Judge", definition="A single judge"),
+    )
+    session_manager.create_session(session)
+    return session
+
+
+@pytest.fixture
+def wired(monkeypatch, executor):
+    """Mock the heavy deps the handler pulls from .deps and never run a pipeline."""
+    reext = MagicMock()
+    reext.discover_papers = AsyncMock(return_value={})
+    reext.precheck_document_availability = AsyncMock(
+        return_value={"can_proceed": True}
+    )
+    runner = MagicMock()
+    runner.check_global_quota = MagicMock()
+    runner.save_config = AsyncMock()
+    runner.prepare_resume = AsyncMock()
+    monkeypatch.setattr(te_module, "reextraction_service", reext)
+    monkeypatch.setattr(te_module, "schematiq_runner", runner)
+    # Do not spawn the real pipeline task.
+    monkeypatch.setattr(executor, "_run_schematiq_task", AsyncMock())
+    # Force the quota path to run (DEVELOPER_MODE off) so check_global_quota is exercised.
+    monkeypatch.setattr(te_module, "DEVELOPER_MODE", False)
+    return reext, runner
+
+
+@pytest.mark.asyncio
+async def test_rediscover_upload_synthesizes_config(
+    executor, wired, session_manager_fixture
+):
+    reext, runner = wired
+    session = _make_session(session_manager_fixture, SessionType.UPLOAD)
+
+    result = await executor.execute("rediscover", session.id, "load", {})
+
+    assert result["status"] == "started"
+    # UPLOAD has no runnable config.json, so the handler synthesizes and saves one.
+    runner.save_config.assert_awaited_once()
+    runner.prepare_resume.assert_awaited_once()
+    executor._run_schematiq_task.assert_awaited_once_with(session.id)
+
+
+@pytest.mark.asyncio
+async def test_rediscover_schematiq_preserves_existing_config(
+    executor, wired, session_manager_fixture
+):
+    reext, runner = wired
+    session = _make_session(session_manager_fixture, SessionType.SCHEMATIQ)
+
+    result = await executor.execute("rediscover", session.id, "schematiq", {})
+
+    assert result["status"] == "started"
+    # SCHEMATIQ already has a config.json from /schematiq/configure; it must not
+    # be overwritten with RELEASE_CONFIG defaults.
+    runner.save_config.assert_not_awaited()
+    runner.prepare_resume.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rediscover_rejected_without_documents(
+    executor, wired, session_manager_fixture
+):
+    reext, runner = wired
+    reext.precheck_document_availability = AsyncMock(
+        return_value={"can_proceed": False}
+    )
+    session = _make_session(session_manager_fixture, SessionType.UPLOAD)
+
+    with pytest.raises(ValueError, match="No source documents are available"):
+        await executor.execute("rediscover", session.id, "load", {})
+
+    runner.prepare_resume.assert_not_awaited()
+    executor._run_schematiq_task.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rediscover_requires_observation_unit(
+    executor, wired, session_manager_fixture
+):
+    reext, runner = wired
+    session = VisualizationSession(
+        id="rediscover-no-ou",
+        type=SessionType.UPLOAD,
+        status=SessionStatus.COMPLETED,
+        metadata=SessionMetadata(source="test"),
+        columns=[],
+        schema_query="q",
+        observation_unit=None,
+    )
+    session_manager_fixture.create_session(session)
+
+    with pytest.raises(ValueError, match="observation unit"):
+        await executor.execute("rediscover", session.id, "load", {})

--- a/backend/tests/test_chat_registry_filtering.py
+++ b/backend/tests/test_chat_registry_filtering.py
@@ -34,6 +34,9 @@ EXPECTED_EXPENSIVE = {
     "extract_cells",
     "continue_discovery",
     "reprocess",
+    # Full schema rediscovery from chat: rebuilds schema + rows across the whole
+    # project, so it must stay behind the confirmation gate.
+    "rediscover",
 }
 
 
@@ -86,7 +89,9 @@ def test_extraction_tools_unlocked_in_load_mode_when_capable() -> None:
     load_capable = {
         t.name for t in get_tools_for_context("s1", "load", extraction_capable=True)
     }
-    assert {"reextract", "extract_cells"} <= load_capable
+    # rediscover (full schema rebuild that re-evaluates skipped documents) is
+    # document-gated too, so it unlocks alongside reextract/extract_cells.
+    assert {"reextract", "extract_cells", "rediscover"} <= load_capable
     # run_schematiq (its handler hard-requires a SCHEMATIQ session) and
     # continue_discovery (separate service, not yet document-gated) are NOT
     # flagged requires_documents, so they stay hidden even when capable.
@@ -98,7 +103,7 @@ def test_extraction_tools_stay_hidden_in_load_mode_without_documents() -> None:
     # behaves exactly as before: no extraction tools. This is the strict
     # subset that guarantees no behavior change for existing doc-less imports.
     load_incapable = {t.name for t in get_tools_for_context("s1", "load")}
-    assert {"reextract", "extract_cells"}.isdisjoint(load_incapable)
+    assert {"reextract", "extract_cells", "rediscover"}.isdisjoint(load_incapable)
     assert get_tools_for_context("s1", "load") == get_tools_for_context(
         "s1", "load", extraction_capable=False
     )


### PR DESCRIPTION
## Problem
#446 unlocked reextract/extract_cells in load mode when documents are available, but deliberately left out full schema rediscovery (rebuild schema + rows, re-evaluating previously-skipped documents). Only the UI 'Rediscover schema' button (POST /load/rediscover) could do that; the chat could not.

## Solution
Add a 'rediscover' chat tool, gated via the existing requires_documents/extraction_capable mechanism (identical to reextract: shown in schematiq always, in load only when source documents are available). Its handler mirrors the proven /load/rediscover sequence (set pending_observation_unit_rediscovery, prepare_resume, run_schematiq), surfacing gate failures as tool errors and spawning via asyncio instead of BackgroundTasks. Works for both session types: UPLOAD synthesizes a config.json (as the route does); SCHEMATIQ reuses the existing config.json from /schematiq/configure and does not overwrite it. cost_class=expensive keeps the confirmation gate.

## Verify
- git apply --ignore-whitespace --check on fresh main: clean; py_compile clean on all four files.
- Registry parity checks: rediscover shown in schematiq always, in load only when extraction_capable (matches reextract).
- Tests: EXPECTED_EXPENSIVE + unlock/hidden tests updated in test_chat_registry_filtering.py; new test_chat_rediscover.py covers UPLOAD-synthesizes-config, SCHEMATIQ-preserves-config, rejected-without-documents, requires-observation-unit.
- MANUAL SMOKE TEST before merge: imported session with docs -> ask chat to rediscover -> confirm -> schema/rows rebuilt and the skipped document is re-evaluated.
- Backend-only.