### PR TITLE
feat(chat): gate continue_discovery on document availability

### DIFF
--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -676,8 +676,14 @@ def _all_tools() -> list[ToolSpec]:
             },
             cost_class="expensive",
             handler="continue_discovery",
-            hidden_in_load=True,
+            # Gated on document availability, identical to reextract/extract_cells:
+            # offered in schematiq always, and in load mode once source documents
+            # are present. The service resolves documents from the session-local
+            # documents/pending_documents dirs and builds its initial schema from
+            # session.columns, so it is session-type-agnostic; it raises clearly
+            # if no documents are found.
             session_modes=("schematiq",),
+            requires_documents=True,
         ),
         ToolSpec(
             name="reprocess",

--- a/backend/tests/test_chat_registry_filtering.py
+++ b/backend/tests/test_chat_registry_filtering.py
@@ -89,13 +89,13 @@ def test_extraction_tools_unlocked_in_load_mode_when_capable() -> None:
     load_capable = {
         t.name for t in get_tools_for_context("s1", "load", extraction_capable=True)
     }
-    # rediscover (full schema rebuild that re-evaluates skipped documents) is
-    # document-gated too, so it unlocks alongside reextract/extract_cells.
-    assert {"reextract", "extract_cells", "rediscover"} <= load_capable
-    # run_schematiq (its handler hard-requires a SCHEMATIQ session) and
-    # continue_discovery (separate service, not yet document-gated) are NOT
-    # flagged requires_documents, so they stay hidden even when capable.
-    assert {"run_schematiq", "continue_discovery"}.isdisjoint(load_capable)
+    # rediscover (full schema rebuild that re-evaluates skipped documents) and
+    # continue_discovery (extends the schema over more documents) are
+    # document-gated too, so they unlock alongside reextract/extract_cells.
+    assert {"reextract", "extract_cells", "rediscover", "continue_discovery"} <= load_capable
+    # run_schematiq (its handler hard-requires a SCHEMATIQ session) is NOT
+    # flagged requires_documents, so it stays hidden even when capable.
+    assert "run_schematiq" not in load_capable
 
 
 def test_extraction_tools_stay_hidden_in_load_mode_without_documents() -> None:


### PR DESCRIPTION
## Problem
continue_discovery was the last extraction tool still gated by session type (session_modes=('schematiq',) + hidden_in_load), the follow-up #446 explicitly deferred pending verification that its separate service works for imported (UPLOAD) sessions.

## Verification (why this is now safe)
- The service has no SessionType/UPLOAD/SCHEMATIQ gate.
- It builds the initial schema from session.columns (present on imported sessions), not a schematiq-only artifact.
- _prepare_documents resolves from session-local documents/ and pending_documents/ (where imported/re-attached files live); document_source='upload' already reads pending_documents/.
- It raises ValueError('No documents available for schema discovery') when empty — no silent no-op.

## Solution
Gate continue_discovery identically to reextract/extract_cells/rediscover: add requires_documents=True, remove the now-redundant hidden_in_load. Offered in schematiq always, in load only when source documents are available. No change to the service or handler.

## Verify
- git apply --ignore-whitespace --check on fresh main: clean; py_compile clean.
- Standalone gating: unlocked in capable load, hidden in doc-less load, schematiq unchanged.
- Updated test_extraction_tools_unlocked_in_load_mode_when_capable (continue_discovery moves to the unlocked set; run_schematiq stays hidden). Other tests assert the doc-less default-load case and still pass.
- MANUAL SMOKE TEST before merge: imported session with docs -> ask chat to continue_discovery -> confirm the schema extends from the documents.
- Backend-only.