### PR TITLE
fix(chat): cloud-backed imported sessions are extraction-capable

### DIFF
--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -164,19 +164,27 @@ class ChatAgentService:
         Mirrors the frontend rule
         ``canRediscoverSchema = sessionMode == 'schematiq' || hasSourceDocuments``:
         schematiq sessions are always capable; a load (imported) session becomes
-        capable once its source documents are present. Uses a cheap, synchronous
-        local-disk check so it can run per message. Documents that live only in
-        cloud storage are not seen here (a known limitation); the downstream
-        gated extraction path performs the full local+cloud availability
-        precheck and returns a clear message, so an over-eager offer degrades to
-        a precise error rather than a silent no-op.
+        capable once its source documents are reachable. Cheap and synchronous so
+        it can run per message: a local-disk check, plus a cloud-dataset check for
+        imported projects whose source files live only in Supabase
+        (``session.metadata.cloud_dataset``) and are read from there by the gated
+        extraction path. If neither is present the extraction tools stay hidden.
         """
         if session_mode != "load":
             return True
         if not session_id:
             return False
         try:
-            return reextraction_service.has_local_source_documents(session_id)
+            if reextraction_service.has_local_source_documents(session_id):
+                return True
+            # Cloud-backed imported session: the source files live only in the
+            # session's Supabase dataset, which the local-disk check can't see.
+            # precheck_document_availability resolves and reads them from there
+            # (via session.metadata.cloud_dataset), so such a session is capable
+            # too — otherwise the extraction tools would never be offered for a
+            # cloud-only import even though the pipeline can run.
+            session = session_manager.get_session(session_id)
+            return bool(session and session.metadata and session.metadata.cloud_dataset)
         except Exception:  # pragma: no cover - defensive; the gate must never crash chat
             logger.debug(
                 "extraction-capability check failed for %s", session_id, exc_info=True

--- a/backend/tests/test_extraction_capability.py
+++ b/backend/tests/test_extraction_capability.py
@@ -1,0 +1,74 @@
+"""Tests for the chat extraction-capability gate.
+
+`ChatAgentService._extraction_capable` decides whether the document-backed
+extraction tools are offered. schematiq sessions are always capable; a load
+(imported) session is capable when its source documents are reachable — either
+present on local disk, or only in the session's Supabase dataset
+(`cloud_dataset`), which the pipeline reads from directly.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.chat import agent_service as agent_module
+from app.services.chat.agent_service import ChatAgentService
+
+cap = ChatAgentService._extraction_capable
+
+
+def test_schematiq_is_always_capable():
+    assert cap("s1", "schematiq") is True
+    # Even with no session id, schematiq is capable (no session-doc dependency).
+    assert cap(None, "schematiq") is True
+
+
+def test_load_without_session_is_not_capable():
+    assert cap(None, "load") is False
+
+
+def test_load_with_local_documents_is_capable(monkeypatch):
+    monkeypatch.setattr(
+        agent_module.reextraction_service,
+        "has_local_source_documents",
+        lambda sid: True,
+    )
+    assert cap("s1", "load") is True
+
+
+def test_load_cloud_only_is_capable(monkeypatch):
+    # No local files, but the session has a Supabase dataset the pipeline reads.
+    monkeypatch.setattr(
+        agent_module.reextraction_service,
+        "has_local_source_documents",
+        lambda sid: False,
+    )
+    session = SimpleNamespace(metadata=SimpleNamespace(cloud_dataset="nes_full_text"))
+    monkeypatch.setattr(
+        agent_module.session_manager, "get_session", lambda sid: session
+    )
+    assert cap("s1", "load") is True
+
+
+def test_load_without_any_documents_is_not_capable(monkeypatch):
+    monkeypatch.setattr(
+        agent_module.reextraction_service,
+        "has_local_source_documents",
+        lambda sid: False,
+    )
+    session = SimpleNamespace(metadata=SimpleNamespace(cloud_dataset=None))
+    monkeypatch.setattr(
+        agent_module.session_manager, "get_session", lambda sid: session
+    )
+    assert cap("s1", "load") is False
+
+
+def test_gate_never_crashes_chat(monkeypatch):
+    # Any failure in the capability check must degrade to "not capable", never raise.
+    def _boom(sid):
+        raise RuntimeError("storage down")
+
+    monkeypatch.setattr(
+        agent_module.reextraction_service, "has_local_source_documents", _boom
+    )
+    assert cap("s1", "load") is False


### PR DESCRIPTION
## Problem
_extraction_capable used only has_local_source_documents (local disk). A load session whose source files live only in Supabase (session.metadata.cloud_dataset) was therefore never extraction-capable, so the chat never offered reextract/extract_cells/rediscover/continue_discovery — even though precheck_document_availability resolves those files from cloud and the pipeline can run. This was the documented known limitation of the availability gate.

## Solution
In load mode, also return capable when session.metadata.cloud_dataset is set (cheap, synchronous, uses data already on the session). The downstream gated path still runs the full local+cloud precheck, so an over-eager offer degrades to a clear error, never a silent no-op.

## Verify
- py_compile + pytest tests/test_extraction_capability.py (schematiq always; local; cloud-only; neither; never-crashes).
- Backend-only.