### PR TITLE
fix(continue-discovery): synchronous no-documents precheck

### DIFF
--- a/backend/app/services/continue_discovery_service.py
+++ b/backend/app/services/continue_discovery_service.py
@@ -890,6 +890,35 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
         if not session:
             raise ValueError(f"Session {session_id} not found")
 
+        # Fail fast, synchronously, when the chosen document source has no
+        # documents — instead of creating an operation and letting the background
+        # task raise "No documents available for schema discovery" later, which
+        # surfaces to the caller as an async operation failure rather than an
+        # immediate error. Uses this service's own directory conventions, so it
+        # cannot drift from what _prepare_documents will actually read. The check
+        # is permissive (it only blocks the clearly-empty case), so it never
+        # rejects a run that would otherwise have succeeded.
+        if document_source == "original":
+            availability = await self.get_available_documents(session_id)
+            if not availability.get("can_use_original"):
+                raise ValueError(
+                    "No source documents are available to continue discovery. "
+                    'Re-attach the originals via "Show source document", or import '
+                    "a project bundle that includes them, then try again."
+                )
+        elif document_source == "upload":
+            pending_dir = self._get_data_dir() / session_id / "pending_documents"
+            has_uploaded = pending_dir.is_dir() and any(
+                f.is_file() and not f.name.startswith(".")
+                for f in pending_dir.iterdir()
+            )
+            if not has_uploaded:
+                raise ValueError(
+                    "No uploaded documents were found for this session. Upload "
+                    "the documents first, then try again."
+                )
+        # 'cloud' requires a cloud_dataset, which _prepare_documents validates.
+
         # Create operation
         operation_id = str(uuid.uuid4())[:8]
         operation = ContinueDiscoveryOperation(

--- a/backend/tests/test_continue_discovery_precheck.py
+++ b/backend/tests/test_continue_discovery_precheck.py
@@ -1,0 +1,64 @@
+"""Tests for the synchronous document precheck in start_continue_discovery.
+
+Previously, when the chosen document source had no documents, the operation was
+created and the background task later raised "No documents available for schema
+discovery" — surfacing to the caller as an async operation failure rather than
+an immediate error. start_continue_discovery now checks availability up front and
+raises synchronously, before creating an operation.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.continue_discovery_service import ContinueDiscoveryService
+
+
+@pytest.fixture
+def service(tmp_path, monkeypatch):
+    session_manager = MagicMock()
+    session_manager.get_session.return_value = SimpleNamespace(
+        columns=[], schema_query="q", metadata=SimpleNamespace(cloud_dataset=None)
+    )
+    svc = ContinueDiscoveryService(None, session_manager)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(svc, "_get_data_dir", lambda: data_dir)
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_upload_source_without_documents_raises_synchronously(service):
+    # No pending_documents dir at all -> immediate error, no operation created.
+    with pytest.raises(ValueError, match="No uploaded documents"):
+        await service.start_continue_discovery(
+            session_id="s1", document_source="upload", llm_config={}
+        )
+    assert not service.active_operations
+
+
+@pytest.mark.asyncio
+async def test_upload_source_with_empty_pending_dir_raises(service):
+    pending = service._get_data_dir() / "s1" / "pending_documents"
+    pending.mkdir(parents=True)
+    (pending / ".keep").write_text("")  # dotfile must be ignored
+    with pytest.raises(ValueError, match="No uploaded documents"):
+        await service.start_continue_discovery(
+            session_id="s1", document_source="upload", llm_config={}
+        )
+    assert not service.active_operations
+
+
+@pytest.mark.asyncio
+async def test_original_source_unavailable_raises_synchronously(service, monkeypatch):
+    monkeypatch.setattr(
+        service,
+        "get_available_documents",
+        AsyncMock(return_value={"can_use_original": False}),
+    )
+    with pytest.raises(ValueError, match="No source documents are available"):
+        await service.start_continue_discovery(
+            session_id="s1", document_source="original", llm_config={}
+        )
+    assert not service.active_operations


### PR DESCRIPTION
## Problem
When the chosen document_source had no documents, start_continue_discovery created an operation and the background task later raised 'No documents available for schema discovery' — surfacing as an async operation failure rather than an immediate error.

## Solution
Precheck availability synchronously before creating the operation: get_available_documents().can_use_original for 'original', pending_documents/ contents for 'upload'. Uses the service's own directory conventions (no drift). Permissive by design (only blocks the clearly-empty case), so no run that would have succeeded is rejected. Fixes it for all callers; the chat handler is unchanged.

## Verify
- py_compile + pytest tests/test_continue_discovery_precheck.py (3 tests: upload-missing, upload-empty-dir, original-unavailable; each raises synchronously with no dangling operation). All pass.
- Backend-only.