### PR TITLE
fix(rediscover): use persisted backends instead of RELEASE_CONFIG defaults

### DIFF
--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -996,8 +996,9 @@ async def rediscover_imported_session(session_id: str, background_tasks: Backgro
     does not make rediscovery possible for a session with no documents behind
     its data.
     """
-    from app.core.config import RELEASE_CONFIG, LLM_CALL_GLOBAL_LIMIT, DEVELOPER_MODE
-    from app.models.schematiq import ScheMatiQConfig, LLMConfig
+    from app.core.config import LLM_CALL_GLOBAL_LIMIT, DEVELOPER_MODE
+    from app.models.schematiq import ScheMatiQConfig
+    from app.services.rediscovery_config import build_rediscovery_backends
     from schematiq.core.llm_call_tracker import QuotaExceededError
     # Both are module-level singletons constructed in routes/schematiq.py, shared
     # across the app the same way app.main imports schematiq_runner from there.
@@ -1043,22 +1044,18 @@ async def rediscover_imported_session(session_id: str, background_tasks: Backgro
                 raise HTTPException(status_code=429, detail=QUOTA_EXCEEDED_USER_MESSAGE)
 
         # Build a minimal, valid ScheMatiQConfig for this existing session.
+        # Prefer the project's persisted backends (restored on import from a
+        # complete export) so rediscovery uses the ORIGINAL models rather than
+        # RELEASE_CONFIG defaults; fall back to defaults for an older import.
         # docs_path is left unset: resolve_docs_paths() already auto-detects
         # session-local pending_documents/documents before falling back to it,
         # which is exactly where an imported project's bundled files live.
+        schema_backend, value_backend = build_rediscovery_backends(session, session_id)
         config = ScheMatiQConfig(
             query=session.schema_query or "",
             docs_path=None,
-            schema_creation_backend=LLMConfig(
-                provider=RELEASE_CONFIG["llm_provider"],
-                model=RELEASE_CONFIG["schema_creation_model"],
-                temperature=RELEASE_CONFIG["llm_temperature"],
-            ),
-            value_extraction_backend=LLMConfig(
-                provider=RELEASE_CONFIG["llm_provider"],
-                model=RELEASE_CONFIG["value_extraction_model"],
-                temperature=RELEASE_CONFIG["llm_temperature"],
-            ),
+            schema_creation_backend=schema_backend,
+            value_extraction_backend=value_backend,
             output_path="outputs/rediscovered_output.json",
         )
         await schematiq_runner.save_config(session_id, config)

--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -1142,8 +1142,8 @@ class ToolExecutor:
       # a SCHEMATIQ session already has a runnable config.json from
       # /schematiq/configure and must NOT have it overwritten with defaults; an
       # UPLOAD session has none, so we synthesize one exactly like the route.
-      from app.core.config import RELEASE_CONFIG
-      from app.models.schematiq import ScheMatiQConfig, LLMConfig
+      from app.models.schematiq import ScheMatiQConfig
+      from app.services.rediscovery_config import build_rediscovery_backends
       from schematiq.core.llm_call_tracker import QuotaExceededError
 
       set_session_context(session_id)
@@ -1184,22 +1184,18 @@ class ToolExecutor:
               ) from exc
 
       if session.type == SessionType.UPLOAD:
-          # Imported session: no runnable config.json exists, so synthesize one
-          # (docs_path unset — resolve_docs_paths auto-detects the session-local
-          # pending_documents/documents where imported files live).
+          # Imported session: no runnable config.json exists, so synthesize one.
+          # Prefer the project's persisted backends (restored on import from a
+          # complete export) so rediscovery uses the ORIGINAL models rather than
+          # RELEASE_CONFIG defaults; fall back to defaults for an older import.
+          # docs_path unset — resolve_docs_paths auto-detects the session-local
+          # pending_documents/documents where imported files live.
+          schema_backend, value_backend = build_rediscovery_backends(session, session_id)
           config = ScheMatiQConfig(
               query=session.schema_query or "",
               docs_path=None,
-              schema_creation_backend=LLMConfig(
-                  provider=RELEASE_CONFIG["llm_provider"],
-                  model=RELEASE_CONFIG["schema_creation_model"],
-                  temperature=RELEASE_CONFIG["llm_temperature"],
-              ),
-              value_extraction_backend=LLMConfig(
-                  provider=RELEASE_CONFIG["llm_provider"],
-                  model=RELEASE_CONFIG["value_extraction_model"],
-                  temperature=RELEASE_CONFIG["llm_temperature"],
-              ),
+              schema_creation_backend=schema_backend,
+              value_extraction_backend=value_backend,
               output_path="outputs/rediscovered_output.json",
           )
           await schematiq_runner.save_config(session_id, config)

--- a/backend/app/services/rediscovery_config.py
+++ b/backend/app/services/rediscovery_config.py
@@ -1,0 +1,99 @@
+"""Resolve the LLM backends for a rediscovery run.
+
+Both rediscovery entrypoints — the chat ``rediscover`` tool and
+``POST /load/rediscover`` — build a ``ScheMatiQConfig`` for an imported session
+before kicking off the pipeline. Historically both synthesized the backends from
+``RELEASE_CONFIG`` defaults, which discards the project's ORIGINAL models. Once a
+complete-export bundle is re-imported, the project's real backends are persisted
+in ``schematiq_config.json`` (and in session metadata), so a rediscovery run
+should prefer those and fall back to defaults only when nothing was persisted.
+
+Release-mode enforcement still happens later in the pipeline
+(``enforce_release_llm_config``); this module only restores fidelity where the
+pipeline honors the config (``ALLOW_LLM_CONFIG``), matching how a natively
+configured schematiq session already behaves.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional, Tuple
+
+from app.core.config import DEFAULT_DATA_DIR, RELEASE_CONFIG
+from app.models.schematiq import LLMConfig
+
+logger = logging.getLogger(__name__)
+
+# Fields we are willing to carry from a persisted backend dict into an LLMConfig.
+# (api_key is intentionally excluded — it is resolved separately at run time.)
+_LLM_FIELDS = ("provider", "model", "temperature", "max_output_tokens", "context_window_size")
+
+
+def _backend_from_dict(raw) -> Optional[LLMConfig]:
+    """Build an LLMConfig from a persisted backend dict, or None if unusable."""
+    if not isinstance(raw, dict):
+        return None
+    if not raw.get("provider"):  # provider is the one required field
+        return None
+    fields = {k: raw[k] for k in _LLM_FIELDS if raw.get(k) is not None}
+    try:
+        return LLMConfig(**fields)
+    except Exception as e:  # malformed persisted value: fall through to default
+        logger.debug("Ignoring malformed persisted backend %s: %s", raw, e)
+        return None
+
+
+def _persisted_llm_configuration(session, session_id: str) -> dict:
+    """Return the persisted ``llm_configuration``-shaped dict for a session.
+
+    Order: session metadata first (mirrors the re-extraction resolver's Priority
+    1), then the on-disk ``schematiq_config.json`` written on import by the
+    complete-export round-trip and by ``/schematiq/configure``.
+    """
+    try:
+        extracted = getattr(session.metadata, "extracted_schema", None) or {}
+        cfg = extracted.get("llm_configuration") if isinstance(extracted, dict) else None
+        if isinstance(cfg, dict) and (
+            cfg.get("schema_creation_backend") or cfg.get("value_extraction_backend")
+        ):
+            return cfg
+    except Exception as e:
+        logger.debug("Could not read llm_configuration from session metadata: %s", e)
+
+    try:
+        config_file = Path(DEFAULT_DATA_DIR) / session_id / "schematiq_config.json"
+        if config_file.exists():
+            with open(config_file) as f:
+                data = json.load(f)
+            if data.get("schema_creation_backend") or data.get("value_extraction_backend"):
+                return data
+    except Exception as e:
+        logger.debug("Could not read schematiq_config.json for %s: %s", session_id, e)
+
+    return {}
+
+
+def _release_backend(is_schema_creation: bool) -> LLMConfig:
+    return LLMConfig(
+        provider=RELEASE_CONFIG["llm_provider"],
+        model=(
+            RELEASE_CONFIG["schema_creation_model"]
+            if is_schema_creation
+            else RELEASE_CONFIG["value_extraction_model"]
+        ),
+        temperature=RELEASE_CONFIG["llm_temperature"],
+    )
+
+
+def build_rediscovery_backends(session, session_id: str) -> Tuple[LLMConfig, LLMConfig]:
+    """Return ``(schema_creation_backend, value_extraction_backend)`` for a run.
+
+    Prefers the project's persisted backends so a re-imported project rediscovers
+    with its original models; falls back to RELEASE_CONFIG per backend when
+    nothing usable was persisted (e.g. an older import), which reproduces the
+    previous behavior exactly.
+    """
+    cfg = _persisted_llm_configuration(session, session_id)
+    schema_backend = _backend_from_dict(cfg.get("schema_creation_backend")) or _release_backend(True)
+    value_backend = _backend_from_dict(cfg.get("value_extraction_backend")) or _release_backend(False)
+    return schema_backend, value_backend

--- a/backend/tests/test_rediscovery_config.py
+++ b/backend/tests/test_rediscovery_config.py
@@ -1,0 +1,86 @@
+"""Tests for rediscovery backend resolution.
+
+Both rediscovery entrypoints build a ScheMatiQConfig before running the pipeline.
+They must prefer the project's persisted backends (restored on import from a
+complete export) so a re-imported project rediscovers with its ORIGINAL models,
+falling back to RELEASE_CONFIG defaults only when nothing usable was persisted.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from app.core.config import RELEASE_CONFIG
+from app.services.rediscovery_config import build_rediscovery_backends
+
+
+def _session(extracted_schema=None):
+    return SimpleNamespace(metadata=SimpleNamespace(extracted_schema=extracted_schema))
+
+
+def _write_config(tmp_path, session_id, obj):
+    d = tmp_path / session_id
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "schematiq_config.json").write_text(json.dumps(obj))
+
+
+ORIG_SCHEMA = {"provider": "openai", "model": "gpt-4o", "temperature": 0.2}
+ORIG_VALUE = {"provider": "together", "model": "mixtral", "temperature": 0}
+
+
+def test_no_persisted_config_uses_release_defaults(monkeypatch, tmp_path):
+    monkeypatch.setattr("app.services.rediscovery_config.DEFAULT_DATA_DIR", str(tmp_path))
+    schema, value = build_rediscovery_backends(_session(), "sess-none")
+    assert schema.model == RELEASE_CONFIG["schema_creation_model"]
+    assert value.model == RELEASE_CONFIG["value_extraction_model"]
+
+
+def test_persisted_config_restores_original_models(monkeypatch, tmp_path):
+    monkeypatch.setattr("app.services.rediscovery_config.DEFAULT_DATA_DIR", str(tmp_path))
+    _write_config(
+        tmp_path,
+        "sess-file",
+        {"schema_creation_backend": ORIG_SCHEMA, "value_extraction_backend": ORIG_VALUE},
+    )
+    schema, value = build_rediscovery_backends(_session(), "sess-file")
+    assert (schema.provider, schema.model) == ("openai", "gpt-4o")
+    assert (value.provider, value.model) == ("together", "mixtral")
+
+
+def test_session_metadata_takes_priority_over_file(monkeypatch, tmp_path):
+    monkeypatch.setattr("app.services.rediscovery_config.DEFAULT_DATA_DIR", str(tmp_path))
+    _write_config(
+        tmp_path,
+        "sess-meta",
+        {"schema_creation_backend": ORIG_SCHEMA, "value_extraction_backend": ORIG_VALUE},
+    )
+    meta = {
+        "llm_configuration": {
+            "schema_creation_backend": {"provider": "gemini", "model": "meta-schema"},
+            "value_extraction_backend": {"provider": "gemini", "model": "meta-value"},
+        }
+    }
+    schema, value = build_rediscovery_backends(_session(meta), "sess-meta")
+    assert schema.model == "meta-schema"
+    assert value.model == "meta-value"
+
+
+def test_partial_persisted_falls_back_per_backend(monkeypatch, tmp_path):
+    monkeypatch.setattr("app.services.rediscovery_config.DEFAULT_DATA_DIR", str(tmp_path))
+    _write_config(tmp_path, "sess-partial", {"value_extraction_backend": ORIG_VALUE})
+    schema, value = build_rediscovery_backends(_session(), "sess-partial")
+    assert schema.model == RELEASE_CONFIG["schema_creation_model"]  # missing -> default
+    assert (value.provider, value.model) == ("together", "mixtral")  # present -> original
+
+
+def test_malformed_persisted_backends_are_safe(monkeypatch, tmp_path):
+    monkeypatch.setattr("app.services.rediscovery_config.DEFAULT_DATA_DIR", str(tmp_path))
+    _write_config(
+        tmp_path,
+        "sess-bad",
+        {"schema_creation_backend": {"model": "no-provider"}, "value_extraction_backend": "oops"},
+    )
+    schema, value = build_rediscovery_backends(_session(), "sess-bad")
+    assert schema.model == RELEASE_CONFIG["schema_creation_model"]
+    assert value.model == RELEASE_CONFIG["value_extraction_model"]


### PR DESCRIPTION
## Problem
Both rediscovery entrypoints — the chat `rediscover` tool (#449) and `POST /load/rediscover` — synthesize a ScheMatiQConfig for an imported session using `RELEASE_CONFIG` defaults. The pipeline honors those backends whenever `ALLOW_LLM_CONFIG` is set (the default; `enforce_release_llm_config` only overrides them when it is off), so a re-imported project is rediscovered with default models rather than its ORIGINAL ones — even though #448 now persists the original backends into `schematiq_config.json` on import. The two entrypoints also duplicated the same synthesis.

## Solution
Add `app/services/rediscovery_config.py` with `build_rediscovery_backends(session, session_id)`, which resolves `(schema_creation_backend, value_extraction_backend)` preferring the persisted config, per backend: session metadata (`extracted_schema.llm_configuration`) -> on-disk `schematiq_config.json` (written on import and by `/schematiq/configure`) -> `RELEASE_CONFIG` default. Malformed/partial sources fall through safely. Both entrypoints now call it, removing the duplicated synthesis.

## Backward compatibility
Older imports with no persisted backends resolve to `RELEASE_CONFIG` for both backends — byte-for-byte the previous behavior. Release-mode enforcement is unchanged (still applied later by `enforce_release_llm_config`); this only restores fidelity where the pipeline already honors the config.

## Verify
- `git apply --ignore-whitespace --check` on a fresh clone of current main: clean.
- `python -m py_compile` on all four files: clean; no unused imports left behind.
- Executed the real helper against six scenarios: no persisted -> defaults; persisted file -> original models; metadata wins over file; partial -> per-backend fallback; malformed -> safe defaults; unknown fields dropped.
- New unit tests in `test_rediscovery_config.py`.