### PR TITLE
refactor(session): route SessionType gates through a capability layer

### DIFF
--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -16,6 +16,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from app.models.session import VisualizationSession, SessionType, SessionMetadata, PaginatedData, SessionStatus, FilterSortRequest
+from app.services.session_capabilities import has_live_pipeline, is_imported
 from app.models.upload import (
     ColumnMappingRequest, CompatibilityCheck
 )
@@ -741,7 +742,7 @@ async def extract_schema(session_id: str, query: str = ""):
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
 
-        if session.type != SessionType.UPLOAD:
+        if not is_imported(session):
             raise HTTPException(status_code=400, detail="Schema extraction only available for upload sessions")
 
         # Ensure session data is processed
@@ -813,11 +814,11 @@ async def add_documents(session_id: str, files: List[UploadFile] = File(...), by
 
         # Allow both upload sessions (various states) and ScheMatiQ sessions (created or completed)
         is_valid_upload_session = (
-            session.type == SessionType.UPLOAD and
+            is_imported(session) and
             session.status in [SessionStatus.SCHEMA_EXTRACTED, SessionStatus.COMPLETED, SessionStatus.DOCUMENTS_UPLOADED]
         )
         is_valid_schematiq_session = (
-            session.type == SessionType.SCHEMATIQ and
+            has_live_pipeline(session) and
             session.status in [SessionStatus.CREATED, SessionStatus.COMPLETED, SessionStatus.STOPPED]
         )
 
@@ -1010,7 +1011,7 @@ async def rediscover_imported_session(session_id: str, background_tasks: Backgro
         session = session_manager.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
-        if session.type != SessionType.UPLOAD:
+        if not is_imported(session):
             raise HTTPException(
                 status_code=400,
                 detail=f"Rediscovery via this endpoint is only for imported sessions (type='{session.type}').",
@@ -1170,7 +1171,7 @@ async def remove_uploaded_document(session_id: str, request: RemoveDocumentReque
         # Update session status if no more documents
         if not session.metadata.uploaded_documents:
             # Revert to previous state
-            if session.type == SessionType.UPLOAD:
+            if is_imported(session):
                 session.status = SessionStatus.COMPLETED if session.statistics else SessionStatus.SCHEMA_EXTRACTED
             else:
                 session.status = SessionStatus.COMPLETED
@@ -1220,11 +1221,11 @@ async def add_cloud_documents(session_id: str, request: CloudDocumentRequest):
 
         # Validate session status
         is_valid_upload_session = (
-            session.type == SessionType.UPLOAD and
+            is_imported(session) and
             session.status in [SessionStatus.SCHEMA_EXTRACTED, SessionStatus.COMPLETED, SessionStatus.DOCUMENTS_UPLOADED]
         )
         is_valid_schematiq_session = (
-            session.type == SessionType.SCHEMATIQ and
+            has_live_pipeline(session) and
             session.status == SessionStatus.COMPLETED
         )
 
@@ -1367,11 +1368,11 @@ async def process_documents(session_id: str, background_tasks: BackgroundTasks, 
         
         # Allow both upload sessions (with documents) and ScheMatiQ sessions (completed or with documents uploaded)
         is_valid_upload_session = (
-            session.type == SessionType.UPLOAD and
+            is_imported(session) and
             session.status in [SessionStatus.DOCUMENTS_UPLOADED, SessionStatus.COMPLETED]
         )
         is_valid_schematiq_session = (
-            session.type == SessionType.SCHEMATIQ and
+            has_live_pipeline(session) and
             session.status in [SessionStatus.COMPLETED, SessionStatus.DOCUMENTS_UPLOADED]
         )
 
@@ -1549,7 +1550,7 @@ async def get_processing_status(session_id: str):
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
         
-        if session.type != SessionType.UPLOAD:
+        if not is_imported(session):
             raise HTTPException(status_code=400, detail="Processing status only available for upload sessions")
         
         # Build status response

--- a/backend/app/api/routes/schematiq.py
+++ b/backend/app/api/routes/schematiq.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from fastapi.responses import StreamingResponse
 
 from app.models.session import VisualizationSession, SessionType, SessionStatus, SessionMetadata, FilterSortRequest
+from app.services.session_capabilities import has_live_pipeline
 from app.models.schematiq import ScheMatiQConfig, ScheMatiQStatus, CostEstimate, CostEstimateRequest, PhaseEstimate, DocumentStats
 from app.services.schematiq_runner import ScheMatiQRunner
 from app.services.pipeline.data_query import session_data_read_failed
@@ -284,7 +285,7 @@ async def run_schematiq(session_id: str, background_tasks: BackgroundTasks):
     """Start ScheMatiQ execution."""
     try:
         session = session_manager.get_session(session_id)
-        if not session or session.type != SessionType.SCHEMATIQ:
+        if not has_live_pipeline(session):
             raise HTTPException(status_code=404, detail="ScheMatiQ session not found")
 
         # Pre-check global LLM quota before starting background task.
@@ -329,7 +330,7 @@ async def resume_schematiq(session_id: str, background_tasks: BackgroundTasks):
     """
     try:
         session = session_manager.get_session(session_id)
-        if not session or session.type != SessionType.SCHEMATIQ:
+        if not has_live_pipeline(session):
             raise HTTPException(status_code=404, detail="ScheMatiQ session not found")
 
         allowed_statuses = {

--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -12,7 +12,8 @@ from typing import Any, Optional
 from app.core.config import DEFAULT_DATA_DIR, DEVELOPER_MODE, LLM_CALL_GLOBAL_LIMIT
 from app.core.logging_utils import set_session_context
 from app.models.modification import ModificationAction
-from app.models.session import ColumnInfo, SessionType
+from app.models.session import ColumnInfo
+from app.services.session_capabilities import has_live_pipeline, is_imported
 from app.services import concurrency_limiter, session_manager
 from app.services.data_utils import _resolve_source_document, canonicalize_column_name
 from app.services.pipeline.data_query import get_data as query_get_data
@@ -1025,7 +1026,7 @@ class ToolExecutor:
       self, session_id: str, session_mode: str, args: dict[str, Any]
   ) -> dict[str, Any]:
       session = session_manager.get_session(session_id)
-      if not session or session.type != SessionType.SCHEMATIQ:
+      if not has_live_pipeline(session):
           raise ValueError("ScheMatiQ session not found")
       if not DEVELOPER_MODE:
           schematiq_runner.check_global_quota(LLM_CALL_GLOBAL_LIMIT)
@@ -1183,7 +1184,7 @@ class ToolExecutor:
                   "The global usage limit has been reached. Please try again later."
               ) from exc
 
-      if session.type == SessionType.UPLOAD:
+      if is_imported(session):
           # Imported session: no runnable config.json exists, so synthesize one.
           # Prefer the project's persisted backends (restored on import from a
           # complete export) so rediscovery uses the ORIGINAL models rather than

--- a/backend/app/services/pubmed_enrichment_service.py
+++ b/backend/app/services/pubmed_enrichment_service.py
@@ -17,7 +17,8 @@ from typing import Dict, List, Optional, Set
 import requests
 
 from app.core.config import DEFAULT_DATA_DIR
-from app.models.session import SessionType, VisualizationSession
+from app.models.session import VisualizationSession
+from app.services.session_capabilities import is_imported
 from app.services.session_manager import SessionManager
 
 logger = logging.getLogger(__name__)
@@ -231,7 +232,7 @@ class PubMedEnrichmentService:
         if not session or not doc_name:
             return False
         meta = session.metadata
-        if session.type == SessionType.UPLOAD and not meta.cloud_dataset:
+        if is_imported(session) and not meta.cloud_dataset:
             return False
         if doc_name in set(meta.pubmed_link_suppressed_stems):
             return False

--- a/backend/app/services/session_capabilities.py
+++ b/backend/app/services/session_capabilities.py
@@ -1,0 +1,47 @@
+"""Capability predicates for a session — the single place that reads SessionType.
+
+Phase A of the SessionType-removal plan: every gate that used to compare
+``session.type`` directly now asks one of these predicates instead. The bodies
+currently just wrap the type check, so behavior is identical; centralizing the
+reads here means a later switch to state-based signals (does the session have a
+live pipeline? are its documents available?) becomes a one-file change rather
+than a hunt across the codebase.
+
+Guideline: do NOT re-introduce ``session.type == ...`` comparisons at call
+sites. Add or extend a predicate here instead. Session *creation* and
+*serialization* sites legitimately set/record the raw type and are out of scope.
+"""
+
+from typing import Optional
+
+from app.models.session import SessionType, VisualizationSession
+
+
+def has_live_pipeline(session: Optional[VisualizationSession]) -> bool:
+    """Whether the session is backed by a live ScheMatiQ pipeline run.
+
+    True for pipeline (``SCHEMATIQ``) sessions — including imported sessions that
+    were promoted after a rediscovery run, which by then own a self-sufficient
+    ``schematiq_work/{id}`` output. Gates that need pipeline artifacts use this:
+    the pipeline-only endpoints, ``run_schematiq``, and the ``rediscover`` config
+    reuse-vs-synthesize branch.
+
+    A ``None`` session yields ``False`` so callers can drop separate null guards.
+    Phase B will switch the body to a state check (presence of the session's
+    pipeline output) so it no longer depends on the persisted type.
+    """
+    return bool(session) and session.type == SessionType.SCHEMATIQ
+
+
+def is_imported(session: Optional[VisualizationSession]) -> bool:
+    """Whether the session was created by importing/uploading an existing table.
+
+    A creation-identity fact (kept as such through Phase B). Gates that are
+    genuinely about "this is an imported project" use this: the upload/rediscover
+    entrypoints and the pubmed cloud-dataset fallback. Note that an imported
+    session which has been promoted to a pipeline session is no longer
+    ``is_imported`` — matching the previous ``== UPLOAD`` behavior exactly.
+
+    A ``None`` session yields ``False`` so callers can drop separate null guards.
+    """
+    return bool(session) and session.type == SessionType.UPLOAD

--- a/backend/tests/test_session_capabilities.py
+++ b/backend/tests/test_session_capabilities.py
@@ -1,0 +1,46 @@
+"""Tests for the session capability predicates.
+
+Phase A is behavior-preserving: these assert the predicates return exactly the
+boolean the old ``session.type == ...`` comparisons produced, including the
+``None``-session case that call sites used to guard with ``not session or``.
+"""
+
+from __future__ import annotations
+
+from app.models.session import SessionMetadata, SessionType, VisualizationSession
+from app.services.session_capabilities import has_live_pipeline, is_imported
+
+
+def _session(session_type: SessionType) -> VisualizationSession:
+    return VisualizationSession(
+        id="s1",
+        type=session_type,
+        metadata=SessionMetadata(source="test"),
+    )
+
+
+def test_has_live_pipeline_true_only_for_schematiq():
+    assert has_live_pipeline(_session(SessionType.SCHEMATIQ)) is True
+    assert has_live_pipeline(_session(SessionType.UPLOAD)) is False
+
+
+def test_is_imported_true_only_for_upload():
+    assert is_imported(_session(SessionType.UPLOAD)) is True
+    assert is_imported(_session(SessionType.SCHEMATIQ)) is False
+
+
+def test_none_session_is_neither():
+    # Call sites previously wrote `not session or session.type != SCHEMATIQ`;
+    # folding the null check into the predicate must reproduce that.
+    assert has_live_pipeline(None) is False
+    assert is_imported(None) is False
+
+
+def test_predicates_are_exact_complements_on_real_sessions():
+    # Two enum values today, so on a real (non-None) session the predicates are
+    # complementary. They are deliberately defined independently (not one as the
+    # negation of the other) because Phase B will make has_live_pipeline
+    # state-based while is_imported stays a creation fact.
+    for t in (SessionType.SCHEMATIQ, SessionType.UPLOAD):
+        s = _session(t)
+        assert has_live_pipeline(s) != is_imported(s)


### PR DESCRIPTION
## Problem
Reads of `SessionType` are scattered across the backend (~15 gate comparisons in 4 files). Each one hardcodes the `load`/`schematiq` distinction, so changing or eventually removing that distinction means hunting across the codebase. The type is also increasingly a poor proxy for what the gates actually need (e.g. the promotion path already rewrites UPLOAD->SCHEMATIQ once an imported session behaves like a pipeline).

## Solution (Phase A — behavior-preserving containment)
Add `app/services/session_capabilities.py` with two predicates, and route every gate through them:
- `has_live_pipeline(session)` — replaces `session.type == SCHEMATIQ` gates (pipeline-only endpoints, `run_schematiq`, the `rediscover` reuse-vs-synthesize branch). Folds in the `not session` null check.
- `is_imported(session)` — replaces `session.type == UPLOAD` gates (upload/rediscover entrypoints, the pubmed cloud fallback, and the type atoms inside the document-precondition blocks).

The predicate bodies currently just wrap the type check, so behavior is identical; the status logic in the document-precondition blocks stays inline (only the type atoms are routed). After this, `SessionType` is read for GATING in exactly one module.

## Explicitly out of scope (unchanged)
- Session **creation** writes (`type=SessionType.UPLOAD/SCHEMATIQ`) and **serialization** (`session_type` in exports/archives) — they legitimately set/record the raw type.
- The **promotion** in `schematiq_runner.py` (a write site).
- `_handle_get_status` — that branches on the chat `session_mode` string, not `SessionType`; a separate axis.

## Verify
- `git apply --ignore-whitespace --check` on a fresh clone of current main: clean.
- `python -m py_compile` on all six files: clean. `SessionType` import dropped from the two files that no longer need it (tool_executor, pubmed), retained where creation/serialization still use it.
- No `session.type ==/!=` comparisons remain in the four routed files.
- Executed the real capability module: predicates correct incl. `None`, and proven boolean-equivalent to every old gate shape (`not session or != SCHEMATIQ`; `== UPLOAD`; `== SCHEMATIQ`; `!= UPLOAD`).
- New unit tests in `test_session_capabilities.py`.

## Next (not in this PR)
Phase B (on decision): flip `has_live_pipeline` to a state check (pipeline output presence) and drop the promotion special-case — a one-file change. Phase C: remove the enum once users have re-uploaded. See design-session-type-adapter.md.