### PR TITLE
Sync stale test mocks with current signatures

### DIFF
--- a/backend/tests/test_chat_executor.py
+++ b/backend/tests/test_chat_executor.py
@@ -70,7 +70,15 @@ def patched_reextraction(monkeypatch):
 
     captured: dict[str, list] = {}
 
-    async def fake_start(session_id, columns, renamed_from=None, paper_discovery=None):
+    async def fake_start(
+        session_id,
+        columns,
+        renamed_from=None,
+        paper_discovery=None,
+        documents=None,
+        rows=None,
+        only_empty=False,
+    ):
         captured["columns"] = list(columns)
         return {"status": "started", "columns": list(columns)}
 
@@ -190,7 +198,7 @@ async def test_fill_tool_delegates_to_background_service(executor, sample_sessio
 
     captured: dict = {}
 
-    async def fake_start(session_id, column, reference_id):
+    async def fake_start(session_id, column, reference_id, rows=None):
         captured.update(
             {"session_id": session_id, "column": column, "reference_id": reference_id}
         )

--- a/backend/tests/test_reextraction_renamed_from.py
+++ b/backend/tests/test_reextraction_renamed_from.py
@@ -80,6 +80,9 @@ async def test_gated_reextraction_collects_renamed_from_before_baseline_recaptur
         ["judge_name"],
         renamed_from={"judge_name": "appointing_president"},
         paper_discovery=discovery,
+        documents=None,
+        rows=None,
+        only_empty=False,
     )
     service.capture_and_save_baseline.assert_awaited_once_with("sess-1")
     assert service.start_reextraction.await_args.kwargs["renamed_from"] == {


### PR DESCRIPTION
## Problem
Seven backend tests fail on main. The fakes in test_chat_executor, test_reextraction_renamed_from, and test_chat_rediscover were not updated when signatures changed: start_reextraction gained documents/rows/only_empty, reference_fill_service.start_fill gained rows, and rediscover moved to a fire-and-forget asyncio.create_task so the awaited-once assertion raced the scheduled task.

## Solution
Extend fake_start signatures to match start_reextraction and start_fill; add the new kwargs to the renamed_from assert_awaited_once_with; yield to the loop (await asyncio.sleep(0)) in the rediscover test before asserting the spawned task ran.

## Verify
- python -m pytest (backend) green
- No product code touched