### PR TITLE
Fix import selecting a generated artifact instead of the export

### DIFF
--- a/backend/app/services/file_parser.py
+++ b/backend/app/services/file_parser.py
@@ -367,12 +367,27 @@ class FileParser:
         """Parse file and extract data."""
         session_dir = self.data_dir / session_id
         
-        # Find the uploaded file
+        # Find the uploaded file. Skip pipeline-generated artifacts: on a
+        # re-import the session dir can already hold files this parser (or the
+        # pipeline) writes, e.g. schematiq_config.json. Selecting one of those
+        # instead of the actual export makes the import parse the wrong file
+        # and silently skip the config restore below.
+        _GENERATED_ARTIFACTS = frozenset({
+            "schematiq_config.json", "config.json", "user_llm_config.json",
+            "data.json", "schema.json", "parsed_schema.json",
+            "discovered_schema.json", "extracted_schema.json",
+            "processing_schema.json", "value_extraction_schema.json",
+            "comprehensive_schema_context.json", "schema_discovery_skips.json",
+            "global_llm_usage.json", "llm_call_stats.json",
+        })
         file_path = None
         for f in session_dir.glob("*"):
-            if f.is_file() and not f.name.startswith('.'):
-                file_path = f
-                break
+            if not f.is_file() or f.name.startswith('.'):
+                continue
+            if f.name in _GENERATED_ARTIFACTS:
+                continue
+            file_path = f
+            break
         
         if not file_path:
             raise FileNotFoundError("No uploaded file found")


### PR DESCRIPTION
## Problem
parse_file picks the uploaded file via glob('*') and takes the first hit. On a re-import the session dir can already hold schematiq_config.json, which sorts before project.json, so the parser reads the config file instead of the export and silently skips the config restore. Verified in isolation: with an existing schematiq_config.json present, glob returns it first and documents_batch_size/backends/query are never restored.

## Solution
Skip a defined set of pipeline-generated artifacts (schematiq_config.json, config.json, schema/data files, usage stats, etc.) when selecting the uploaded file, so the actual export is parsed. CRLF-safe edit.

## Verify
- python -m pytest (backend) green, incl. test_config_merge_preserves_unrelated_existing_keys
- git apply --ignore-whitespace --check on a fresh clone
- python -m py_compile backend/app/services/file_parser.py