### PR TITLE
feat(extraction): per-unit column narrowing in extract_values_for_unit

### DIFF
--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -1610,6 +1610,8 @@ class PaperProcessor:
         max_new_tokens: int,
         paper_title: str,
         paper_text: Optional[str] = None,
+        target_columns: Optional[List[str]] = None,
+        already_extracted: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Extract values for a single observation unit using its relevant passages.
@@ -1623,12 +1625,43 @@ class PaperProcessor:
         Args:
             paper_text: Full document text, needed for fallback retrieval passes.
                 Falls back to the joined relevant_passages if not provided.
+            target_columns: When provided (only_empty re-extraction), restricts
+                extraction to exactly these column names for this unit — the
+                model is never asked for cells that are already filled. ``None``
+                keeps the previous behavior (extract every schema column). An
+                empty list means every target cell for this unit is already
+                filled, so the LLM is skipped entirely.
+            already_extracted: Flat ``{col_name: answer}`` of this unit's
+                already-filled columns, passed as context to the prompt to
+                prevent hallucinating dependent columns when the extracted set
+                is narrowed. Ignored when ``target_columns`` is ``None``.
         """
         from schematiq.value_extraction.utils.schema_builder import (
             _MAX_COLUMNS_FOR_CONTROLLED_GENERATION,
+            align_extraction_keys_to_schema,
         )
+        from dataclasses import replace as _dc_replace
 
         columns = list(schema.columns)
+        # Per-unit narrowing for only_empty: extract just this unit's empty
+        # columns and let passes 2-4 see the same narrowed schema, so the
+        # already-filled columns are never re-requested. The merge-time guard
+        # remains the correctness backstop: even a wrong target set can only
+        # under-extract, never overwrite a filled cell.
+        effective_schema = schema
+        if target_columns is not None:
+            wanted = set(target_columns)
+            columns = [c for c in schema.columns if c.name in wanted]
+            if not columns:
+                logger.info(
+                    "[extract_values_for_unit] unit %r: no empty target columns, "
+                    "skipping LLM",
+                    unit_name,
+                )
+                return align_extraction_keys_to_schema(
+                    {}, [c.name for c in schema.columns]
+                )
+            effective_schema = _dc_replace(schema, columns=columns)
         eff = "\n\n--- RELEVANT PASSAGE ---\n\n".join(relevant_passages)
         system_prompt = SYSTEM_PROMPT_VAL_WITH_UNIT.format(unit_name=unit_name)
 
@@ -1664,6 +1697,7 @@ class PaperProcessor:
                 [c.to_dict() for c in col_batch],
                 mode="all",
                 strict=False,
+                already_extracted=already_extracted,
                 reference_query=unit_name,
             )
             msgs[0]["content"] = system_prompt
@@ -1729,21 +1763,22 @@ class PaperProcessor:
                     raw,
                 )
 
-        # Passes 2-4: reordered → batch fallback → snippet fallback
+        # Passes 2-4: reordered → batch fallback → snippet fallback.
+        # Retry against the (possibly narrowed) effective_schema so already-filled
+        # columns excluded above are not re-requested as "missing".
         fallback_text = paper_text or eff
         self._retry_missing_columns(
             all_cleaned,
-            schema=schema,
+            schema=effective_schema,
             paper_title=f"{paper_title} - {unit_name}",
             paper_text=fallback_text,
             effective_text=eff,
             max_new_tokens=effective_max,
         )
 
-        from schematiq.value_extraction.utils.schema_builder import (
-            align_extraction_keys_to_schema,
-        )
-
+        # Align to the FULL schema so the row shape is unchanged; columns not
+        # extracted this run stay absent/empty and the merge guard leaves their
+        # existing table values untouched.
         return align_extraction_keys_to_schema(
             all_cleaned, [c.name for c in schema.columns]
         )

--- a/schematiq-lib/tests/test_extract_values_for_unit_narrowing.py
+++ b/schematiq-lib/tests/test_extract_values_for_unit_narrowing.py
@@ -1,0 +1,106 @@
+"""Per-unit column narrowing for only_empty re-extraction.
+
+extract_values_for_unit(target_columns=...) must extract exactly the listed
+columns for a unit (never the already-filled ones), narrow passes 2-4 to the
+same set, skip the LLM entirely when the target set is empty, and always return
+a row aligned to the FULL schema so the row shape is unchanged.
+
+Follows the repo pattern of driving the method unbound with a MagicMock ``self``
+(see test_controlled_generation.py), so no real LLM/retriever is needed.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from schematiq.core.schema import Schema, Column
+from schematiq.value_extraction.core.paper_processor import PaperProcessor
+
+
+def _make_self():
+    """A MagicMock self wired just enough for pass-1 + retry to run."""
+    s = MagicMock()
+    s._check_stop_requested.return_value = False
+    s._should_skip_truncation.return_value = True
+    s.llm.context_window_size = 8192
+    s.llm.max_tokens_for_task.return_value = 512
+    s._gemini_kwargs.return_value = {}
+    s.prompt_builder.build_val_messages.return_value = [{"content": ""}]
+    s._build_response_schema.return_value = (None, {})
+    s._generate.return_value = "{}"
+    s.json_parser.parse_response.return_value = {}
+    s._remap_response_keys.return_value = {}
+    s.json_parser.postprocess.return_value = ({}, {})
+    s._attach_source_to_excerpts.side_effect = lambda cleaned, _title: cleaned
+    return s
+
+
+def _schema():
+    return Schema(
+        query="q",
+        columns=[Column(name="A"), Column(name="B"), Column(name="C"), Column(name="D")],
+        observation_unit="row",
+    )
+
+
+def _requested_column_names(mock_self):
+    """Column names passed to build_val_messages across all pass-1 batches."""
+    names = []
+    for call in mock_self.prompt_builder.build_val_messages.call_args_list:
+        col_dicts = call.args[3]  # 4th positional arg: [c.to_dict() ...]
+        names.extend(cd["name"] for cd in col_dicts)
+    return names
+
+
+@patch("schematiq.value_extraction.core.paper_processor.utils.fit_prompt",
+       side_effect=lambda msgs, **kw: msgs)
+def test_target_columns_narrows_pass1_and_retry(_fit):
+    s = _make_self()
+    schema = _schema()
+
+    result = PaperProcessor.extract_values_for_unit(
+        s, unit_name="Unit 1", relevant_passages=["text"], schema=schema,
+        max_new_tokens=256, paper_title="doc1", target_columns=["B"],
+    )
+
+    # Pass 1 requested ONLY the empty target column, never A/C/D.
+    assert _requested_column_names(s) == ["B"]
+    # Passes 2-4 saw a schema narrowed to the same single column.
+    retry_schema = s._retry_missing_columns.call_args.kwargs["schema"]
+    assert [c.name for c in retry_schema.columns] == ["B"]
+    # Row is still aligned to the FULL schema (shape unchanged).
+    assert set(result.keys()) == {"A", "B", "C", "D"}
+
+
+@patch("schematiq.value_extraction.core.paper_processor.utils.fit_prompt",
+       side_effect=lambda msgs, **kw: msgs)
+def test_empty_target_skips_llm_entirely(_fit):
+    s = _make_self()
+    schema = _schema()
+
+    result = PaperProcessor.extract_values_for_unit(
+        s, unit_name="Unit 1", relevant_passages=["text"], schema=schema,
+        max_new_tokens=256, paper_title="doc1", target_columns=[],
+    )
+
+    # No LLM work at all — this is the cost saving.
+    s._generate.assert_not_called()
+    s.prompt_builder.build_val_messages.assert_not_called()
+    s._retry_missing_columns.assert_not_called()
+    # Still returns a full-schema-aligned (empty) row for the merge no-op.
+    assert set(result.keys()) == {"A", "B", "C", "D"}
+
+
+@patch("schematiq.value_extraction.core.paper_processor.utils.fit_prompt",
+       side_effect=lambda msgs, **kw: msgs)
+def test_none_target_is_unchanged_behavior(_fit):
+    s = _make_self()
+    schema = _schema()
+
+    PaperProcessor.extract_values_for_unit(
+        s, unit_name="Unit 1", relevant_passages=["text"], schema=schema,
+        max_new_tokens=256, paper_title="doc1", target_columns=None,
+    )
+
+    # Default path still requests every schema column, retry sees full schema.
+    assert set(_requested_column_names(s)) == {"A", "B", "C", "D"}
+    retry_schema = s._retry_missing_columns.call_args.kwargs["schema"]
+    assert [c.name for c in retry_schema.columns] == ["A", "B", "C", "D"]


### PR DESCRIPTION
## Problem
only_empty currently narrows at the column-set level and relies on the merge guard to discard values re-extracted for already-filled cells — so the model is still billed for filled cells. The engine had no way to extract only a specific unit's empty columns.

## Solution
extract_values_for_unit gains target_columns (restrict to a unit's empty columns; [] => skip the LLM) and already_extracted (filled columns as anti-hallucination context). Passes 2-4 run against the narrowed schema so filled columns are not re-requested; output is aligned to the full schema so row shape is unchanged. Default None = current behavior. This is the leaf capability; the backend map + threading through build_table_jsonl land in a follow-up PR.

## Verify
- ( cd schematiq-lib && python -m pytest tests/test_extract_values_for_unit_narrowing.py -q )
- target=[B] requests only B in pass 1 and retry; target=[] makes zero LLM calls; target=None is unchanged.