### PR TITLE
Add CI: backend pytest + frontend typecheck and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  backend:
+    name: Backend (pytest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.txt
+            schematiq-lib/pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+          pip install -e ./schematiq-lib
+          pip install pytest pytest-asyncio
+
+      - name: Run backend tests
+        working-directory: backend
+        run: python -m pytest
+
+  frontend:
+    name: Frontend (typecheck + tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Type check
+        working-directory: frontend
+        run: npx tsc --noEmit
+
+      - name: Run frontend tests
+        working-directory: frontend
+        env:
+          CI: "true"
+        run: npm test -- --watchAll=false --passWithNoTests


### PR DESCRIPTION
## Problem
The repo has 30+ backend test files and a frontend test setup, but no CI. Nothing runs the suite automatically on a PR, so regressions land on main unnoticed — as happened recently with several failing chat/import tests. There is no .github/workflows directory at all.

## Solution
Add a GitHub Actions workflow that runs on every pull_request and push to main:
- Backend job (Python 3.11): pip install -r backend/requirements.txt, pip install -e ./schematiq-lib, then python -m pytest, with pip caching.
- Frontend job (Node 20): npm ci, npx tsc --noEmit, then craco test with CI=true (single run, no watch).
Install steps mirror the README. No product code is touched.

## Verify
- git apply --ignore-whitespace --check on a fresh clone of main
- YAML validated; frontend package-lock.json present for npm ci
- main is currently green (223 backend tests pass), so the first CI run will pass.

Note: schematiq/core/schema.py loads an embedding model at import time, so the backend job installs torch/transformers/sentence-transformers; pip caching keeps later runs fast. A future lazy-load refactor of that module would let CI skip the heavy ML deps and cut runtime substantially.