### PR TITLE
feat(reextract): wire per-unit only_empty targets into extraction

### DIFF
--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -86,6 +86,7 @@ class ReextractionOperation:
         documents: Optional[List[str]] = None,
         rows: Optional[List[str]] = None,
         only_empty: bool = False,
+        only_empty_targets: Optional[Dict[str, Dict[str, Dict[str, Any]]]] = None,
     ):
         self.operation_id = operation_id
         self.session_id = session_id
@@ -105,6 +106,11 @@ class ReextractionOperation:
         self.documents: Optional[List[str]] = documents
         self.rows: Optional[List[str]] = rows
         self.only_empty: bool = only_empty
+        # Per-unit only_empty plan: {paper_stem -> {unit_name -> {targets, filled}}}.
+        # Lets the extractor ask the model for only each unit's empty columns.
+        self.only_empty_targets: Optional[Dict[str, Dict[str, Dict[str, Any]]]] = (
+            only_empty_targets
+        )
         # composite keys already merged incrementally during extraction
         self.incrementally_merged_keys: Set[tuple] = set()
         # paper discovery snapshot for this operation (avoids redundant rescans)
@@ -1055,6 +1061,80 @@ class ReextractionService(WebSocketBroadcasterMixin):
             return None, None
         return empty_columns, docs_with_empties
 
+    def _build_only_empty_targets(
+        self,
+        session_id: str,
+        columns: List[str],
+        documents: Optional[List[str]],
+        rows: Optional[List[str]] = None,
+    ) -> Optional[Dict[str, Dict[str, Dict[str, Any]]]]:
+        """Per-unit column plan for only_empty, keyed exactly like known_units.
+
+        Returns ``{paper_stem -> {unit_name -> {"targets": [...], "filled": {...}}}}``
+        over the same in-scope rows the extraction will process. ``targets`` are
+        the unit's fillable-gap columns (respecting ``_is_fillable_gap``, so
+        confirmed-empty cells are treated as resolved); ``filled`` are the
+        remaining in-scope columns' current values, handed to the model as
+        context. A unit whose targets list is empty is still included so the
+        extractor skips the LLM for it rather than re-extracting every column.
+
+        Keys mirror ``_build_known_units_for_reextraction`` (``Path(paper).stem``
+        and ``row_name_of``) so the lib can look the plan up by the same
+        ``paper_title``/``unit_name`` it already uses for known_units. Returns
+        ``None`` when no data files are readable — the caller then extracts
+        normally and the merge guard stays the only gate.
+        """
+        from app.services.data_utils import get_extraction_column_value, extract_papers
+
+        data_files = self._resolve_reextraction_data_files(session_id)
+        if not data_files:
+            return None
+        doc_filter = set(documents) if documents else None
+        row_filter = set(rows) if rows else None
+        plan: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        seen_any = False
+        for df in data_files:
+            try:
+                with open(df, "r") as handle:
+                    for line in handle:
+                        if not line.strip():
+                            continue
+                        try:
+                            row = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        seen_any = True
+                        unit_name = row_name_of(row)
+                        if not unit_name:
+                            continue
+                        if row_filter is not None and unit_name not in row_filter:
+                            continue
+                        paper_stems = {Path(p).stem for p in (extract_papers(row) or [])}
+                        if doc_filter is not None and not (paper_stems & doc_filter):
+                            continue
+                        scope_stems = (
+                            paper_stems & doc_filter if doc_filter is not None else paper_stems
+                        )
+                        targets: List[str] = []
+                        filled: Dict[str, Any] = {}
+                        for col in columns:
+                            value = get_extraction_column_value(row, col)
+                            if _is_fillable_gap(value):
+                                targets.append(col)
+                            elif value is not None:
+                                filled[col] = value
+                        for stem in scope_stems:
+                            plan.setdefault(stem, {})[unit_name] = {
+                                "targets": targets,
+                                "filled": filled,
+                            }
+            except Exception as e:  # unreadable file -> no narrowing
+                logger.warning("only_empty target scan failed for %s: %s", df, e)
+                return None
+        if not seen_any:
+            return None
+        return plan
+
     def _scoped_documents_availability(
         self,
         session_id: str,
@@ -1164,6 +1244,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
             }
             skipped_scope = {d for d in scoped_documents if d in all_skipped}
 
+        only_empty_targets: Optional[Dict[str, Dict[str, Dict[str, Any]]]] = None
         if only_empty:
             empty_columns, docs_with_empties = self._find_empty_target_cells(
                 session_id, resolved, scoped_documents, scoped_rows
@@ -1186,6 +1267,14 @@ class ReextractionService(WebSocketBroadcasterMixin):
                         d for d in scoped_documents
                         if d in docs_with_empties or d in skipped_scope
                     ]
+                # Per-unit plan so the extractor asks the model only for each
+                # unit's empty columns (a unit with none is skipped entirely),
+                # rather than re-extracting filled columns and discarding them at
+                # merge. Keyed like known_units; unmatched units (e.g. under unit
+                # rediscovery) fall back to full extraction in the lib.
+                only_empty_targets = self._build_only_empty_targets(
+                    session_id, resolved, scoped_documents, scoped_rows
+                )
 
         availability = await self.precheck_document_availability(
             session_id,
@@ -1229,6 +1318,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
             documents=scoped_documents,
             rows=scoped_rows,
             only_empty=only_empty,
+            only_empty_targets=only_empty_targets,
         )
 
     async def start_reextraction(
@@ -1240,6 +1330,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
         documents: Optional[List[str]] = None,
         rows: Optional[List[str]] = None,
         only_empty: bool = False,
+        only_empty_targets: Optional[Dict[str, Dict[str, Dict[str, Any]]]] = None,
     ) -> Dict[str, Any]:
         """
         Start a re-extraction operation for selected columns.
@@ -1343,6 +1434,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
             rows=rows,
             only_empty=only_empty,
         )
+        operation.only_empty_targets = only_empty_targets
         operation.total_documents = doc_count
         operation.paper_discovery = paper_discovery
         with self._state_lock:
@@ -1750,6 +1842,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                         on_document_started=on_document_started,
                         should_stop=should_stop,  # Allow graceful stop
                         known_units=known_units if known_units else None,
+                        unit_targets_by_paper=operation.only_empty_targets,
                         write_skip_rationale_artifact=session.write_artifacts,
                         reference_context=reference_context,
                     )

--- a/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
+++ b/schematiq-lib/schematiq/value_extraction/core/paper_processor.py
@@ -1793,6 +1793,7 @@ class PaperProcessor:
         retrieval_k: int = 8,
         on_unit_extracted: Optional[Callable[[str, Dict[str, Any]], None]] = None,
         known_units: Optional[List[str]] = None,
+        unit_targets: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> ExtractionResult:
         """
         Extract values from a paper, potentially producing multiple rows
@@ -1897,6 +1898,12 @@ class PaperProcessor:
                 )
                 unit_start = time_module.time()
 
+                # Per-unit only_empty plan (keyed by unit name). Absent unit ->
+                # target_columns=None -> full extraction (unchanged behavior).
+                unit_plan = unit_targets.get(unit_name) if unit_targets else None
+                unit_target_columns = unit_plan.get("targets") if unit_plan else None
+                unit_already_extracted = unit_plan.get("filled") if unit_plan else None
+
                 # Extract values for this specific unit
                 unit_values = self.extract_values_for_unit(
                     unit_name=unit_name,
@@ -1905,6 +1912,8 @@ class PaperProcessor:
                     max_new_tokens=max_new_tokens,
                     paper_title=paper_title,
                     paper_text=paper_text,
+                    target_columns=unit_target_columns,
+                    already_extracted=unit_already_extracted,
                 )
 
                 unit_elapsed = time_module.time() - unit_start

--- a/schematiq-lib/schematiq/value_extraction/core/table_builder.py
+++ b/schematiq-lib/schematiq/value_extraction/core/table_builder.py
@@ -258,7 +258,8 @@ class TableBuilder:
                                     mode: str = "all",
                                     retrieval_k: int = 8,
                                     max_workers: int = DEFAULT_MAX_WORKERS,
-                                    known_units: Optional[Dict[str, List[str]]] = None) -> None:
+                                    known_units: Optional[Dict[str, List[str]]] = None,
+                                    unit_targets_by_paper: Optional[Dict[str, Dict[str, Any]]] = None) -> None:
         """
         Extract values from papers across multiple directories and write to JSONL.
         """
@@ -280,7 +281,8 @@ class TableBuilder:
             schema_path, all_docs_with_source, output_path,
             max_new_tokens=max_new_tokens, resume=resume, mode=mode,
             retrieval_k=retrieval_k, max_workers=max_workers,
-            known_units=known_units
+            known_units=known_units,
+            unit_targets_by_paper=unit_targets_by_paper
         )
     
     def _build_table_multi_dirs_impl(self,
@@ -293,7 +295,8 @@ class TableBuilder:
                                     mode: str,
                                     retrieval_k: int,
                                     max_workers: int,
-                                    known_units: Optional[Dict[str, List[str]]] = None) -> None:
+                                    known_units: Optional[Dict[str, List[str]]] = None,
+                                    unit_targets_by_paper: Optional[Dict[str, Dict[str, Any]]] = None) -> None:
         """Implementation for multi-directory process
         ing."""
         schema = self._load_schema(schema_path)
@@ -342,7 +345,8 @@ class TableBuilder:
                 row_name, papers, doc_to_source, schema, mode, retrieval_k,
                 max_new_tokens, max_workers, existing_rows, processed_papers,
                 written_rows, completed_rows, output_path,
-                known_units=known_units
+                known_units=known_units,
+                unit_targets_by_paper=unit_targets_by_paper
             )
 
         print(f"\n✅ Processing complete! Wrote {len(written_rows)} rows to {output_path}")
@@ -364,7 +368,8 @@ class TableBuilder:
                                written_rows: set,
                                completed_rows: set,
                                output_path: Path,
-                               known_units: Optional[Dict[str, List[str]]] = None) -> None:
+                               known_units: Optional[Dict[str, List[str]]] = None,
+                               unit_targets_by_paper: Optional[Dict[str, Dict[str, Any]]] = None) -> None:
         """Process a single row across multiple directories.
 
         Uses observation unit extraction - each document may produce multiple rows
@@ -383,7 +388,8 @@ class TableBuilder:
             row_name, papers, doc_to_source, schema, retrieval_k,
             max_new_tokens, existing_rows, processed_papers,
             written_rows, output_path,
-            known_units=known_units
+            known_units=known_units,
+            unit_targets_by_paper=unit_targets_by_paper
         )
 
     def _process_papers_with_observation_units(
@@ -399,6 +405,7 @@ class TableBuilder:
         written_rows: set,
         output_path: Path,
         known_units: Optional[Dict[str, List[str]]] = None,
+        unit_targets_by_paper: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> None:
         """
         Process papers using observation unit extraction, potentially producing
@@ -443,6 +450,7 @@ class TableBuilder:
 
                 # Extract values with observation units (may return multiple rows)
                 paper_known_units = known_units.get(paper_title) if known_units else None
+                paper_unit_targets = unit_targets_by_paper.get(paper_title) if unit_targets_by_paper else None
                 extraction_result = self.paper_processor.extract_values_for_paper_with_units(
                     paper_title=paper_title,
                     paper_text=paper_text,
@@ -451,6 +459,7 @@ class TableBuilder:
                     mode="all",
                     retrieval_k=retrieval_k,
                     known_units=paper_known_units,
+                    unit_targets=paper_unit_targets,
                 )
                 unit_rows = extraction_result.rows
                 skip_reason = extraction_result.skip_reason

--- a/schematiq-lib/schematiq/value_extraction/main.py
+++ b/schematiq-lib/schematiq/value_extraction/main.py
@@ -37,6 +37,7 @@ def build_table_jsonl(
     should_stop: Optional[ShouldStopCallback] = None,
     on_warning: Optional[OnWarningCallback] = None,
     known_units: Optional[Dict[str, List[str]]] = None,
+    unit_targets_by_paper: Optional[Dict[str, Dict[str, Any]]] = None,
     on_document_started: Optional[Callable[[str], None]] = None,
     write_skip_rationale_artifact: Optional[bool] = None,
     reference_context: Optional[str] = None,
@@ -92,6 +93,7 @@ def build_table_jsonl(
         retrieval_k=retrieval_k,
         max_workers=max_workers,
         known_units=known_units,
+        unit_targets_by_paper=unit_targets_by_paper,
     )
     # Return extraction results including suggested values and skipped documents
     return {


### PR DESCRIPTION
## Problem
#464 gave extract_values_for_unit the ability to extract only a unit's empty columns, but nothing built or passed the per-unit plan — so only_empty still re-extracted filled cells and relied on the merge guard to discard them.

## Solution
- Backend: _build_only_empty_targets scans current data (same files/scope as the empty-cell narrowing) into {paper_stem -> {unit_name -> {targets, filled}}}, respecting _is_fillable_gap (confirmed-empty = resolved). Stored on the operation and passed to build_table_jsonl.
- Lib: thread unit_targets_by_paper through build_table_jsonl -> build_table_jsonl_multi_dirs -> _process_row_multi_dirs -> _process_row_with_units (split per paper exactly like known_units) -> extract_values_for_paper_with_units, which passes each unit's target_columns/already_extracted to extract_values_for_unit.
- Keys mirror known_units (paper stem + unit name); a unit absent from the plan (e.g. under observation-unit rediscovery) falls back to full extraction. The merge guard stays as the correctness backstop. Default None everywhere = no behavior change.

## Verify
- ( cd schematiq-lib && python -m pytest -q ) and ( cd backend && python -m pytest -q )
- only_empty re-extraction: a unit whose target cells are all filled makes zero LLM calls; a unit with gaps is asked only for its empty columns; filled cells are unchanged.