### PR TITLE
Load the embedding model lazily instead of at import time

### DIFF
--- a/schematiq-lib/schematiq/core/schema.py
+++ b/schematiq-lib/schematiq/core/schema.py
@@ -10,14 +10,30 @@ from schematiq.core.embedding_model import load_sentence_transformer
 # -------------------------------------------------------------------- #
 # Globals                                                              #
 # -------------------------------------------------------------------- #
-EMB_MODEL = load_sentence_transformer("all-MiniLM-L6-v2")
+EMB_MODEL_NAME = "all-MiniLM-L6-v2"
 SIM_THRESHOLD = 0.9            # paraphrase deduplication
 MAX_KEYS_DEFAULT = None         # unlimited unless specified
+
+# The SentenceTransformer is loaded lazily on first embedding use rather than at
+# import time. Importing this module (directly or transitively) no longer pulls
+# in torch/transformers or downloads model weights, which keeps unrelated imports
+# — tests, CLI tools, the FastAPI app startup — fast and dependency-light.
+_EMB_MODEL = None
+
+
+def _get_emb_model():
+    """Return the shared SentenceTransformer, loading it once on first use."""
+    global _EMB_MODEL
+    if _EMB_MODEL is None:
+        _EMB_MODEL = load_sentence_transformer(EMB_MODEL_NAME)
+    return _EMB_MODEL
 
 
 def _embed(text: str):
     """Small helper – add caching in production."""
-    return EMB_MODEL.encode(text, normalize_embeddings=True, show_progress_bar=False)
+    return _get_emb_model().encode(
+        text, normalize_embeddings=True, show_progress_bar=False
+    )
 
 
 # -------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem
schematiq/core/schema.py loads a SentenceTransformer at module import (EMB_MODEL = load_sentence_transformer(...)). Any import of schematiq — tests, CLI tools, FastAPI startup — therefore pulls in torch/transformers and downloads/initializes model weights, even when no embedding is ever computed. This slows every import and forces heavy ML deps into environments (like CI) that only run unrelated code.

## Solution
Replace the module-level load with a cached lazy getter (_get_emb_model), loaded on first embedding use and memoized thereafter. _embed() calls the getter. EMB_MODEL is only used via _embed and is not imported elsewhere, so behavior at runtime is unchanged; only the load timing moves from import to first use.

## Verify
- Proven lazy in isolation: after importing schema, the module-level model handle is still None; it loads only on the first _embed() call, returns a 384-dim vector, and is reused (cached) on subsequent calls.
- backend: python -m pytest — 223 passed, and faster (no per-import model load).
- schematiq-lib: same pass/fail set before and after this change (pre-existing failures unrelated to embeddings).
- git apply --ignore-whitespace --check on a fresh clone; py_compile clean.