### PR TITLE
fix(reextraction): un-skip documents that yield rows after re-extraction

### DIFF
--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -2398,6 +2398,12 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     col_stat.non_null_count = sum(
                         1 for row in all_rows if self._cell_value_present(row, col_stat.name)
                     )
+            # A document skipped at discovery time can start yielding rows once
+            # re-extraction runs (e.g. a newly added column finally matches the
+            # observation unit). Such a document is no longer "skipped", so drop
+            # it from the skipped list here to keep the statistics — and the
+            # skipped-documents banner that reads them — consistent with the data.
+            self._reconcile_skipped_documents(session, all_rows)
         for col in session.columns:
             if col.name in columns:
                 col.non_null_count = sum(
@@ -2412,6 +2418,48 @@ class ReextractionService(WebSocketBroadcasterMixin):
             len(all_rows),
             columns[:5],
         )
+
+    @staticmethod
+    def _reconcile_skipped_documents(
+        session: "VisualizationSession",
+        all_rows: List[Dict[str, Any]],
+    ) -> None:
+        """Un-skip any document that now has at least one row.
+
+        ``skipped_documents`` is captured once at discovery time and is never
+        rewritten by re-extraction, so a document skipped then — but which
+        produces observation units on a later re-extraction — would otherwise
+        stay listed as skipped even though it now contributes rows. Match rows to
+        skipped entries by document stem (the same normalization used elsewhere
+        for document scope) and remove the reconciled entries. Guards against an
+        empty row set so a merge that produced no rows never clears the list.
+        """
+        if not (session.statistics and session.statistics.skipped_documents):
+            return
+
+        from app.services.data_utils import _resolve_source_document
+
+        present_stems = {
+            Path(src).stem.lower()
+            for row in all_rows
+            if (src := _resolve_source_document(row))
+        }
+        if not present_stems:
+            return
+
+        remaining = [
+            skipped
+            for skipped in session.statistics.skipped_documents
+            if Path(skipped.document).stem.lower() not in present_stems
+        ]
+        removed = len(session.statistics.skipped_documents) - len(remaining)
+        if removed:
+            session.statistics.skipped_documents = remaining
+            logger.info(
+                "Un-skipped %d document(s) in session %s that now yield rows",
+                removed,
+                session.id,
+            )
 
     def _get_llm_from_session(self, session_id: str):
         """Get LLM configuration from session, including API key."""


### PR DESCRIPTION
## Problem
`skipped_documents` is captured once at discovery and never rewritten by re-extraction. When a document skipped at discovery (e.g. "no matching Judge found") later matches — after adding a column like `ruling_date` and running reextract — it gets a new row in the table but stays in the skipped list. The banner shows "2 of 6 skipped" for a document that now has a row: inconsistent state.

## Solution
Reconcile `skipped_documents` inside `_update_session_stats_after_merge` (the single choke point both reextract paths funnel through, after the merge populates all rows). Any skipped entry whose source document now has at least one row is removed, matched by `Path(...).stem.lower()` — the same normalization used for document scope in `_project_document_stems`. Guarded against an empty row set so a no-row merge never clears the list. Backend-only: the frontend already issues a full refresh on `reextraction_completed` and reads `statistics.skipped_documents` directly, and the banner denominator (`total + skipped.length`) keeps "of 6" stable while count drops 2→1.

## Verify
1. Open a session with skipped documents (banner shows e.g. "2 of 6 skipped").
2. Add a column that matches a skipped document's observation unit; run `reextract`.
3. The previously skipped document appears as a row, and the banner updates to "1 of 6" (or disappears at 0) — no stale skipped entry remains.
- `git apply --ignore-whitespace --check` clean on fresh main (#464); `py_compile` passes.
- Logic verified in isolation (AST-extracted method) against the reported case + empty-merge / stem+case / no-op / papers-fallback edge cases.