### PR TITLE
feat(chat): post re-extraction summary + spinner in chat panel

### DIFF
--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -4,6 +4,7 @@ Handles schema change detection, paper discovery, and selective re-extraction.
 """
 
 import json
+import os
 import asyncio
 import hashlib
 import threading
@@ -1883,13 +1884,37 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
             logger.info(f"Re-extraction completed successfully for operation {operation_id}")
 
+            # Post-run recap for the chat panel. Mirrors the reference-fill flow:
+            # compute per-column coverage from the merged data, then make one model
+            # call to phrase it in plain language. Best-effort throughout — a failure
+            # here must never change the run's own "completed" status, so the whole
+            # block is guarded and the broadcast falls back to counts-only.
+            summary_text = ""
+            coverage: List[Dict[str, Any]] = []
+            total_rows = 0
+            try:
+                coverage, total_rows = await self._compute_column_coverage(
+                    operation.session_id, operation.columns
+                )
+            except Exception as exc:
+                logger.debug("Re-extraction coverage computation skipped: %s", exc)
+            try:
+                summary_text = await self._summarize_reextraction(
+                    operation.columns, coverage, total_rows
+                )
+            except Exception as exc:
+                logger.debug("Re-extraction summary skipped: %s", exc)
+
             await self.broadcast_event(
                 operation.session_id,
                 "reextraction_completed",
                 {
                     "operation_id": operation_id,
                     "columns": operation.columns,
-                    "status": "success"
+                    "status": "success",
+                    "coverage": coverage,
+                    "total_rows": total_rows,
+                    "summary": summary_text,
                 }
             )
 
@@ -2494,6 +2519,103 @@ class ReextractionService(WebSocketBroadcasterMixin):
         # Fallback: Use default GeminiLLM (will use GEMINI_API_KEY env var)
         logger.debug("Using default GeminiLLM - this will use GEMINI_API_KEY env var")
         return GeminiLLM(model=ModelNames.DEFAULT_VALUE_EXTRACTION, temperature=0)
+
+    async def _compute_column_coverage(
+        self, session_id: str, columns: List[str]
+    ) -> tuple[List[Dict[str, Any]], int]:
+        """Filled / empty counts per re-extracted column, from the merged data.
+
+        Uses the same canonical row source and emptiness test as the chat
+        data-summary tool, so the recap agrees with what the user sees. Returns
+        (per-column stats, total_rows). Columns absent from the data are reported
+        with zero fills rather than dropped, so the recap can still mention them.
+        """
+        from app.services.pipeline.data_query import get_data as query_get_data
+        from app.services.chat.deps import WORK_DIR
+
+        rows: List[Dict[str, Any]] = []
+        page = 0
+        page_size = 200
+        while page < 500:  # hard cap: 100k rows, matches the chat tool
+            data = await query_get_data(session_id, WORK_DIR, page=page, page_size=page_size)
+            batch = [r.model_dump() for r in data.rows]
+            rows.extend(batch)
+            if len(batch) < page_size:
+                break
+            page += 1
+
+        total = len(rows)
+        stats: List[Dict[str, Any]] = []
+        for col in columns:
+            filled = 0
+            empty = 0
+            confirmed_empty = 0
+            for row in rows:
+                value = (row.get("data") or {}).get(col)
+                if _is_empty_cell_value(value):
+                    empty += 1
+                    if isinstance(value, dict) and value.get("_confirmed_empty"):
+                        confirmed_empty += 1
+                else:
+                    filled += 1
+            stats.append({
+                "column": col,
+                "filled": filled,
+                "empty": empty,
+                "confirmed_empty": confirmed_empty,
+                "coverage_pct": round(100 * filled / total) if total else 0,
+            })
+        return stats, total
+
+    def _get_summary_client(self) -> Any:
+        """Lazily build a genai client for the recap call (mirrors reference-fill)."""
+        from google import genai
+        from app.services.chat.deps import get_gemini_api_key
+
+        return genai.Client(api_key=get_gemini_api_key())
+
+    async def _summarize_reextraction(
+        self, columns: List[str], coverage: List[Dict[str, Any]], total_rows: int
+    ) -> str:
+        """One model call that recaps the re-extraction for the user in plain text.
+
+        Grounded entirely in the coverage counts (never the documents), so it is a
+        single cheap call. Returns "" on any failure so the caller can fall back to
+        a deterministic message on the frontend.
+        """
+        from google.genai import types
+
+        if not columns:
+            return ""
+
+        lines = []
+        for c in coverage:
+            lines.append(
+                f"- {c['column']}: {c['filled']} of {total_rows} rows filled, "
+                f"{c['empty']} empty"
+                + (f" ({c['confirmed_empty']} confirmed not present in the source)"
+                   if c.get("confirmed_empty") else "")
+            )
+        coverage_block = "\n".join(lines) or "(no per-column counts available)"
+        column_label = ", ".join(f"'{c}'" for c in columns)
+
+        prompt = (
+            f"A background re-extraction just finished, re-reading the source "
+            f"documents to populate the column(s) {column_label}. The table has "
+            f"{total_rows} rows. Per-column results:\n\n{coverage_block}\n\n"
+            "Write a plain-language recap for the user (2-4 sentences, no markdown "
+            "headers, no preamble). State how many rows were filled vs left empty "
+            "for each column. If some cells are confirmed not present in the source, "
+            "explain briefly that those rows have no value to extract rather than a "
+            "failure. Keep it concise and factual; do not invent numbers."
+        )
+        client = self._get_summary_client()
+        response = await client.aio.models.generate_content(
+            model=os.getenv("REFERENCE_SUMMARY_MODEL", ModelNames.GEMINI_35_FLASH),
+            contents=prompt,
+            config=types.GenerateContentConfig(temperature=0),
+        )
+        return (getattr(response, "text", None) or "").strip()
 
     async def broadcast_event(self, session_id: str, event_type: str, data: Dict[str, Any]):
         """Broadcast an event via WebSocket."""

--- a/backend/tests/test_resolve_docs_paths.py
+++ b/backend/tests/test_resolve_docs_paths.py
@@ -1,0 +1,93 @@
+"""Tests for resolve_docs_paths — the pipeline's source-document resolution.
+
+This is the glue that decides whether a run actually finds a session's source
+documents. For imported sessions it is the difference between re-extracting a
+re-attached document and silently running in schema-only mode (the failure the
+availability work set out to fix). It must return BOTH pending_documents/ and
+documents/ when populated, so freshly re-attached files and previously-committed
+originals are both fed to the pipeline.
+
+These are pure filesystem tests: no LLM, no pipeline run, no network. The cloud
+branch (download_supabase_dataset) is only reached when there are no local docs
+and is covered separately by leaving both dirs empty with no docs_path.
+"""
+
+import pytest
+
+from app.models.schematiq import LLMConfig, ScheMatiQConfig
+from app.services.pipeline.config_handler import resolve_docs_paths
+
+
+def _config(docs_path=None) -> ScheMatiQConfig:
+    backend = LLMConfig(provider="openai")
+    return ScheMatiQConfig(
+        query="q",
+        docs_path=docs_path,
+        schema_creation_backend=backend,
+        value_extraction_backend=backend,
+        output_path="outputs/out.json",
+    )
+
+
+def _write(dir_path, name):
+    dir_path.mkdir(parents=True, exist_ok=True)
+    (dir_path / name).write_text("content", encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_resolves_documents_dir_for_imported_session(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    session_id = "sess-docs"
+    work_dir = tmp_path / "schematiq_work"
+    _write(tmp_path / "data" / session_id / "documents", "CASA2025-06-27SCt.txt")
+
+    resolved = await resolve_docs_paths(_config(), session_id, work_dir)
+
+    assert len(resolved) == 1
+    assert resolved[0].endswith(f"data/{session_id}/documents")
+
+
+@pytest.mark.asyncio
+async def test_returns_both_pending_and_documents_when_populated(tmp_path, monkeypatch):
+    """The key guarantee: a re-attached file in pending_documents/ AND the
+    committed originals in documents/ are BOTH resolved, so no document is
+    silently missed (which would drop the run to schema-only mode)."""
+    monkeypatch.chdir(tmp_path)
+    session_id = "sess-both"
+    work_dir = tmp_path / "schematiq_work"
+    _write(tmp_path / "data" / session_id / "documents", "already_committed.txt")
+    _write(tmp_path / "data" / session_id / "pending_documents", "reattached.txt")
+
+    resolved = await resolve_docs_paths(_config(), session_id, work_dir)
+
+    assert len(resolved) == 2
+    # pending_documents/ is returned first (it takes precedence on de-dup).
+    assert resolved[0].endswith("pending_documents")
+    assert resolved[1].endswith("documents")
+
+
+@pytest.mark.asyncio
+async def test_dotfiles_do_not_count_as_documents(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    session_id = "sess-dot"
+    work_dir = tmp_path / "schematiq_work"
+    docs = tmp_path / "data" / session_id / "documents"
+    docs.mkdir(parents=True)
+    (docs / ".DS_Store").write_text("", encoding="utf-8")  # only a dotfile
+
+    resolved = await resolve_docs_paths(_config(docs_path=[]), session_id, work_dir)
+
+    # No real local documents and no configured docs_path -> nothing resolved
+    # (crucially, the dir with only a dotfile is not treated as populated).
+    assert resolved == []
+
+
+@pytest.mark.asyncio
+async def test_no_local_docs_and_no_config_path_resolves_empty(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    session_id = "sess-empty"
+    work_dir = tmp_path / "schematiq_work"
+
+    resolved = await resolve_docs_paths(_config(docs_path=[]), session_id, work_dir)
+
+    assert resolved == []

--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -95,6 +95,7 @@ export function ChatPanel({
   const [referenceError, setReferenceError] = useState<string | null>(null);
   const [dragActive, setDragActive] = useState(false);
   const [fillRunning, setFillRunning] = useState<{ column: string } | null>(null);
+  const [reextractionRunning, setReextractionRunning] = useState<{ columns: string[] } | null>(null);
   const messagesRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -267,6 +268,45 @@ export function ChatPanel({
             content:
               data.message
               || `Finished filling '${data.column ?? ''}' (${data.filled ?? 0} of ${data.total ?? 0} rows).`,
+          },
+        ]);
+      } else if (message.type === 'reextraction_started') {
+        // A chat-triggered reextract runs in the background after the turn ends;
+        // show a spinner until the completion event posts the model's recap.
+        const data = (message.data ?? {}) as unknown as { columns?: string[] };
+        setReextractionRunning({ columns: data.columns ?? [] });
+      } else if (message.type === 'reextraction_completed') {
+        const data = (message.data ?? {}) as unknown as {
+          columns?: string[]; summary?: string;
+          coverage?: { column: string; filled: number; empty: number }[];
+          total_rows?: number;
+        };
+        setReextractionRunning(null);
+        const fallback = () => {
+          const cols = data.coverage ?? [];
+          if (cols.length) {
+            return `Re-extraction finished. ${cols
+              .map((c) => `'${c.column}': ${c.filled} of ${data.total_rows ?? c.filled + c.empty} rows filled`)
+              .join('; ')}.`;
+          }
+          const names = data.columns?.length ? ` for ${data.columns.map((c) => `'${c}'`).join(', ')}` : '';
+          return `Re-extraction finished${names}.`;
+        };
+        appendMessages([
+          {
+            id: `${Date.now()}-reextract-summary`,
+            role: 'assistant',
+            content: data.summary || fallback(),
+          },
+        ]);
+      } else if (message.type === 'reextraction_failed') {
+        const data = (message.data ?? {}) as unknown as { error?: string };
+        setReextractionRunning(null);
+        appendMessages([
+          {
+            id: `${Date.now()}-reextract-failed`,
+            role: 'assistant',
+            content: `Re-extraction failed: ${data.error ?? 'unknown error'}.`,
           },
         ]);
       }
@@ -544,6 +584,21 @@ export function ChatPanel({
                 {fillRunning.column
                   ? `Filling '${fillRunning.column}' in the background…`
                   : 'Filling column in the background…'}
+              </span>
+            </div>
+          </div>
+        )}
+
+        {reextractionRunning && (
+          <div className="workspace-chat-message" data-role="assistant">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>
+                {reextractionRunning.columns.length
+                  ? `Re-extracting ${reextractionRunning.columns
+                      .map((c) => `'${c}'`)
+                      .join(', ')} in the background…`
+                  : 'Re-extracting in the background…'}
               </span>
             </div>
           </div>


### PR DESCRIPTION
## Problem
Re-extractions triggered from chat (e.g. `reextract` after adding a column) run in the background after the chat turn ends. On completion the app only fired a generic toast; nothing appeared in the chat and there was no in-progress indicator. Users had no in-conversation confirmation of what the run actually did (how many rows filled vs left empty).

## Solution
Mirror the existing `fill_column_from_reference` flow for re-extraction:
- **Backend** (`reextraction_service.py`): before broadcasting `reextraction_completed`, compute per-column coverage from the merged data (same canonical rows + `_is_empty_cell_value` test as the chat data-summary tool), then make one best-effort LLM call (`_summarize_reextraction`) to phrase a plain-language recap. The whole step is guarded — a coverage or summary failure never changes the run's `completed` status. The `reextraction_completed` payload gains `summary`, `coverage`, and `total_rows` **additively**; existing consumers (Monitor, Visualize, useWorkspaceSocket) are untouched.
- **Frontend** (`ChatPanel.tsx`): handlers for `reextraction_started` (spinner), `reextraction_completed` (clear spinner + post the summary as an assistant message, with a deterministic fallback if the summary is empty), and `reextraction_failed`. The existing workspace toast is left in place.

## Verify
Validated on a fresh clone of current main:
- `git apply --ignore-whitespace --check reextract-chat-summary.patch` — clean
- `python -m py_compile backend/app/services/reextraction_service.py` — OK
- `( cd frontend && npx tsc --noEmit )` — exit 0, no new errors

Manual: in the workspace chat, add a column and run `reextract`. A spinner shows while the background run works; on completion the chat posts a recap like "Re-extraction finished. 'ruling_date': 37 of 40 rows filled…".