### PR TITLE
feat(chat): persist and restore workspace chat history (PR1)

### DIFF
--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -74,6 +74,18 @@ MESSAGE_CAP_CHAT_MESSAGE = (
     "raised."
 )
 
+# The durable source of truth for a conversation is a persisted turn log; the
+# Gemini chat object is a transient cache rebuilt from it after a restart. The
+# transcript lives in its own per-session file (not the session blob, which is
+# rewritten whole on every unrelated edit), matching the existing data.jsonl
+# convention: the `data` bucket keyed by session id.
+CHAT_HISTORY_BUCKET = "data"
+CHAT_HISTORY_VERSION = 1
+
+
+def _chat_history_path(session_id: str) -> str:
+    return f"{session_id}/chat_history.json"
+
 
 class ChatAgentService:
     def __init__(self) -> None:
@@ -214,7 +226,9 @@ class ChatAgentService:
         pinned_tool: Optional[str] = None,
         model: Optional[str] = None,
     ) -> dict[str, Any]:
-        state = self._get_or_create_session(session_id, session_mode, chat_id, model)
+        state = await self._get_or_create_session(
+            session_id, session_mode, chat_id, model
+        )
         outbound_messages: list[dict[str, Any]] = []
         # Enforced before the pending-action handling and the quota check, so a
         # capped session does no Gemini work at all. Creating the chat session
@@ -254,6 +268,8 @@ class ChatAgentService:
         try:
             await self._ensure_quota_available()
             result = await self._run_loop(state, user_text, outbound_messages)
+            if result["status"] == "complete":
+                await self._persist_history(state)
             return {
                 "chat_id": state.chat_id,
                 "status": result["status"],
@@ -276,8 +292,12 @@ class ChatAgentService:
             if self._is_stale_chat_error(exc) and chat_id:
                 logger.warning("Stale chat session %s, starting fresh: %s", chat_id, exc)
                 chat_session_store.delete(chat_id)
-                state = self._get_or_create_session(session_id, session_mode, None, model)
+                state = await self._get_or_create_session(
+                    session_id, session_mode, None, model
+                )
                 result = await self._run_loop(state, user_text, outbound_messages)
+                if result["status"] == "complete":
+                    await self._persist_history(state)
                 return {
                     "chat_id": state.chat_id,
                     "status": result["status"],
@@ -360,6 +380,8 @@ class ChatAgentService:
 
             response = await self._send_function_response(state, pending, tool_result)
             loop_result = await self._continue_after_tool(state, response, outbound_messages)
+            if loop_result["status"] == "complete":
+                await self._persist_history(state)
             return {
                 "chat_id": chat_id,
                 "status": loop_result["status"],
@@ -388,6 +410,8 @@ class ChatAgentService:
             state,
             reason="User declined confirmation.",
         )
+        if not new_pending:
+            await self._persist_history(state)
         await self._flush_llm_usage(state)
         return {
             "chat_id": chat_id,
@@ -430,7 +454,7 @@ class ChatAgentService:
             )
         return outbound_messages, None
 
-    def _get_or_create_session(
+    async def _get_or_create_session(
         self,
         session_id: str,
         session_mode: str,
@@ -442,7 +466,25 @@ class ChatAgentService:
             if existing and existing.workspace_session_id == session_id:
                 return existing
 
-        client, chat = self._create_gemini_chat(session_id, session_mode, model)
+        # Cache miss. Before building a brand-new empty chat, reattach to the one
+        # live chat for this workspace session if it is still in memory — a client
+        # that refreshed (dropping its chat_id) or sent a stale id must not silently
+        # start a second conversation for the same project.
+        existing = chat_session_store.get_by_workspace_session(session_id)
+        if existing:
+            return existing
+
+        # Nothing in memory (first turn, or the store was emptied by a redeploy):
+        # restore the persisted transcript so the model continues with full context
+        # instead of starting from zero. Restore is best-effort and only ever adds
+        # context — a missing/opted-out/unreadable transcript falls back to empty.
+        restored = await self._load_history(session_id)
+        if restored:
+            client, chat = self._create_gemini_chat(
+                session_id, session_mode, model, history=restored
+            )
+        else:
+            client, chat = self._create_gemini_chat(session_id, session_mode, model)
         state = ChatSessionState(
             client=client,
             chat=chat,
@@ -469,7 +511,11 @@ class ChatAgentService:
         return self._genai_client
 
     def _create_gemini_chat(
-        self, session_id: str, session_mode: str, model: Optional[str] = None
+        self,
+        session_id: str,
+        session_mode: str,
+        model: Optional[str] = None,
+        history: Optional[list[Any]] = None,
     ) -> tuple[Any, Any]:
         from google.genai import types
 
@@ -491,8 +537,122 @@ class ChatAgentService:
         client = self._get_genai_client()
         resolved_model = model or CHAT_MODEL
         logger.info("Chat session using model: %s", resolved_model)
-        chat = client.aio.chats.create(model=resolved_model, config=config)
+        chat = client.aio.chats.create(
+            model=resolved_model, config=config, history=history or None
+        )
         return client, chat
+
+    @staticmethod
+    def _get_storage() -> Any:
+        """Return the process-wide storage backend (local or Supabase)."""
+        from app.storage import get_storage
+
+        return get_storage()
+
+    @staticmethod
+    def _history_opted_out(session_id: str) -> bool:
+        """Whether persisting this session's transcript is disallowed.
+
+        Persisting a transcript is a new form of retention, so it is gated by the
+        same ``opt_out_data_collection`` flag that already governs research
+        archival. If opt-out cannot be determined, we treat the session as opted
+        out — the privacy-conservative choice, and consistent with persistence
+        being strictly best-effort.
+        """
+        try:
+            session = session_manager.get_session(session_id)
+            return bool(session and session.opt_out_data_collection)
+        except Exception:
+            logger.debug(
+                "could not read opt-out for session %s; skipping chat persistence",
+                session_id,
+                exc_info=True,
+            )
+            return True
+
+    @staticmethod
+    def _serialize_history(history: list[Any]) -> list[dict[str, Any]]:
+        """Serialize the SDK's live history (``list[types.Content]``) to dicts.
+
+        A turn that cannot be serialized is dropped rather than failing the whole
+        write; restore can only ever add context, never remove function.
+        """
+        turns: list[dict[str, Any]] = []
+        for content in history or []:
+            try:
+                turns.append(content.model_dump(mode="json", exclude_none=True))
+            except Exception:
+                logger.debug(
+                    "skipping non-serializable chat history turn", exc_info=True
+                )
+        return turns
+
+    @staticmethod
+    def _deserialize_history(turns: list[dict[str, Any]]) -> list[Any]:
+        """Rebuild ``list[types.Content]`` from persisted dicts.
+
+        Each turn is validated independently so one malformed entry (e.g. written
+        by a different ``google-genai`` version) is skipped instead of discarding
+        the whole restored conversation.
+        """
+        from google.genai import types
+
+        restored: list[Any] = []
+        for turn in turns or []:
+            try:
+                restored.append(types.Content.model_validate(turn))
+            except Exception:
+                logger.debug("skipping malformed persisted chat turn", exc_info=True)
+        return restored
+
+    async def _load_history(self, session_id: str) -> list[Any]:
+        """Restore a session's SDK history, or ``[]`` when absent/opted-out.
+
+        Best-effort: any read or parse failure falls back to an empty history
+        (today's behavior), so a restore can only add context, never break chat.
+        """
+        try:
+            if self._history_opted_out(session_id):
+                return []
+            payload = await self._get_storage().download_json(
+                CHAT_HISTORY_BUCKET, _chat_history_path(session_id)
+            )
+            if not isinstance(payload, dict):
+                return []
+            turns = payload.get("turns")
+            if not turns:
+                return []
+            return self._deserialize_history(turns)
+        except Exception as exc:
+            logger.warning(
+                "could not restore chat history for session %s: %s", session_id, exc
+            )
+            return []
+
+    async def _persist_history(self, state: ChatSessionState) -> None:
+        """Write the chat's current history to storage (best-effort, gated).
+
+        Mirrors ``_record_message_used``: a failed write logs and continues so a
+        storage hiccup never breaks the user's turn. Gated on opt-out. Callers
+        invoke this only after a turn has settled (no dangling function call), so
+        a restored history never ends on an unanswered tool request.
+        """
+        session_id = state.workspace_session_id
+        try:
+            if self._history_opted_out(session_id):
+                return
+            history = state.chat.get_history()
+            payload = {
+                "version": CHAT_HISTORY_VERSION,
+                "turns": self._serialize_history(history),
+            }
+            await self._get_storage().upload_json(
+                CHAT_HISTORY_BUCKET, _chat_history_path(session_id), payload
+            )
+        except Exception as exc:
+            logger.warning(
+                "could not persist chat history for session %s: %s", session_id, exc
+            )
 
     async def _emit(
         self,

--- a/backend/app/services/chat/session_store.py
+++ b/backend/app/services/chat/session_store.py
@@ -39,6 +39,22 @@ class ChatSessionStore:
     def get(self, chat_id: str) -> Optional[ChatSessionState]:
         return self._sessions.get(chat_id)
 
+    def get_by_workspace_session(
+        self, workspace_session_id: str
+    ) -> Optional[ChatSessionState]:
+        """Return the live chat for a workspace session, if one is in memory.
+
+        One chat per project: a client that lost its ``chat_id`` (page refresh)
+        or holds a stale id (after a redeploy repopulated the store) reattaches
+        to the existing conversation instead of starting a new empty one. At
+        most one state exists per workspace session under the current flow, so
+        the first match is authoritative.
+        """
+        for state in self._sessions.values():
+            if state.workspace_session_id == workspace_session_id:
+                return state
+        return None
+
     def delete(self, chat_id: str) -> None:
         self._sessions.pop(chat_id, None)
 

--- a/backend/tests/test_chat_history_persistence.py
+++ b/backend/tests/test_chat_history_persistence.py
@@ -1,0 +1,331 @@
+"""Tests for workspace chat-history persistence and restore (PR1).
+
+The contract: a conversation is durably backed by a per-session transcript so it
+survives a backend restart/redeploy. The Gemini chat object is a transient cache
+rebuilt from that transcript. Persistence is best-effort (never breaks a turn),
+gated on ``opt_out_data_collection``, and a missing/unreadable transcript falls
+back to an empty chat — restore can only ever add context, never remove function.
+
+Uses a fake Gemini chat and a fake storage backend, so no real LLM, network, or
+disk is touched.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from google.genai import types
+
+from app.services.chat import agent_service as agent_module
+from app.services.chat.agent_service import (
+    CHAT_HISTORY_BUCKET,
+    ChatAgentService,
+    _chat_history_path,
+)
+from app.services.chat.session_store import chat_session_store
+
+
+class _FakeResponse:
+    function_calls: list = []
+    text = "done"
+
+
+class _FakeChat:
+    """Stand-in for the SDK async chat.
+
+    Seeds itself from a restored ``history`` (list of ``types.Content``) and grows
+    it by one user + one model turn per ``send_message``, so ``get_history`` returns
+    a realistic transcript the service can serialize and persist.
+    """
+
+    def __init__(self, history=None) -> None:
+        self._history: list = list(history or [])
+        self.seeded = list(history or [])
+
+    async def send_message(self, content):
+        text = content if isinstance(content, str) else "tool-response"
+        self._history.append(
+            types.Content(role="user", parts=[types.Part(text=str(text))])
+        )
+        self._history.append(
+            types.Content(role="model", parts=[types.Part(text="done")])
+        )
+        return _FakeResponse()
+
+    def get_history(self):
+        return list(self._history)
+
+
+class _FakeSession:
+    def __init__(self, session_id: str, opt_out: bool = False) -> None:
+        self.id = session_id
+        self.chat_messages_used = 0
+        self.opt_out_data_collection = opt_out
+
+
+class _FakeStorage:
+    """Minimal StorageInterface stand-in backed by an in-memory dict."""
+
+    def __init__(self, fail_write: bool = False) -> None:
+        self.blobs: dict[tuple[str, str], dict] = {}
+        self.writes: list[tuple[str, str]] = []
+        self.fail_write = fail_write
+
+    async def upload_json(self, bucket: str, path: str, data: dict) -> str:
+        if self.fail_write:
+            raise IOError("simulated storage failure")
+        # Round-trip through JSON exactly like the real helper, to catch any
+        # non-serializable turn slipping through.
+        self.blobs[(bucket, path)] = json.loads(json.dumps(data, default=str))
+        self.writes.append((bucket, path))
+        return path
+
+    async def download_json(self, bucket: str, path: str):
+        return self.blobs.get((bucket, path))
+
+
+@pytest.fixture(autouse=True)
+def _clean_chat_store():
+    """The chat session store is a process-wide singleton; isolate each test so a
+    leftover in-memory chat can't skew reattach/create assertions."""
+    chat_session_store._sessions.clear()
+    yield
+    chat_session_store._sessions.clear()
+
+
+@pytest.fixture
+def sessions(monkeypatch):
+    """Patch the session lookup and disable the message cap for these tests."""
+    registry: dict[str, _FakeSession] = {}
+
+    def _get_session(session_id: str):
+        return registry.setdefault(session_id, _FakeSession(session_id))
+
+    monkeypatch.setattr(
+        agent_module.session_manager, "get_session", _get_session, raising=True
+    )
+    # Cap disabled so _record_message_used / _message_cap_reached stay out of the
+    # way; this suite is about persistence, not the cap.
+    monkeypatch.setattr(
+        agent_module, "CHAT_MAX_MESSAGES_PER_SESSION", 0, raising=True
+    )
+    monkeypatch.setattr(agent_module, "DEVELOPER_MODE", False, raising=True)
+    return registry
+
+
+def _make_service(monkeypatch, storage: _FakeStorage) -> ChatAgentService:
+    """A service whose chats are fakes, quota is a no-op, and storage is faked."""
+    svc = ChatAgentService()
+
+    def _fake_create(session_id, session_mode, model=None, history=None):
+        return object(), _FakeChat(history=history)
+
+    async def _no_quota():
+        return None
+
+    async def _no_flush(state):
+        return None
+
+    monkeypatch.setattr(svc, "_create_gemini_chat", _fake_create, raising=True)
+    monkeypatch.setattr(svc, "_ensure_quota_available", _no_quota, raising=True)
+    monkeypatch.setattr(svc, "_flush_llm_usage", _no_flush, raising=True)
+    monkeypatch.setattr(svc, "_get_storage", lambda: storage, raising=True)
+    return svc
+
+
+# --- serialization --------------------------------------------------------
+
+
+def test_serialize_deserialize_round_trip():
+    """User text, a function call, its response, and model text all survive a
+    JSON round trip and rebuild into equivalent Content turns."""
+    history = [
+        types.Content(role="user", parts=[types.Part(text="add column X")]),
+        types.Content(
+            role="model",
+            parts=[
+                types.Part(
+                    function_call=types.FunctionCall(
+                        name="add_column", args={"name": "X"}
+                    )
+                )
+            ],
+        ),
+        types.Content(
+            role="user",
+            parts=[
+                types.Part.from_function_response(
+                    name="add_column", response={"result": {"message": "ok"}}
+                )
+            ],
+        ),
+        types.Content(role="model", parts=[types.Part(text="Added column X.")]),
+    ]
+
+    dumped = ChatAgentService._serialize_history(history)
+    dumped = json.loads(json.dumps(dumped))  # storage does the same
+    restored = ChatAgentService._deserialize_history(dumped)
+
+    assert [c.role for c in restored] == ["user", "model", "user", "model"]
+    assert restored[1].parts[0].function_call.name == "add_column"
+    assert restored[2].parts[0].function_response.name == "add_column"
+    assert restored[0].parts[0].text == "add column X"
+
+
+def test_deserialize_skips_malformed_turns():
+    """One bad turn is dropped, not fatal to the whole restore."""
+    good = types.Content(role="user", parts=[types.Part(text="hi")]).model_dump(
+        mode="json", exclude_none=True
+    )
+    restored = ChatAgentService._deserialize_history([good, {"role": 123}, "junk"])
+    assert len(restored) == 1
+    assert restored[0].parts[0].text == "hi"
+
+
+# --- persistence ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completed_turn_persists_history(sessions, monkeypatch):
+    storage = _FakeStorage()
+    svc = _make_service(monkeypatch, storage)
+
+    await svc.send_message("sess-1", "hello", "schematiq")
+
+    path = _chat_history_path("sess-1")
+    assert (CHAT_HISTORY_BUCKET, path) == ("data", "sess-1/chat_history.json")
+    assert storage.writes == [(CHAT_HISTORY_BUCKET, path)]
+    payload = storage.blobs[(CHAT_HISTORY_BUCKET, path)]
+    assert payload["version"] == 1
+    assert len(payload["turns"]) >= 2  # at least the user + model turn
+
+
+@pytest.mark.asyncio
+async def test_opt_out_skips_writing(sessions, monkeypatch):
+    sessions["sess-opt"] = _FakeSession("sess-opt", opt_out=True)
+    storage = _FakeStorage()
+    svc = _make_service(monkeypatch, storage)
+
+    result = await svc.send_message("sess-opt", "hello", "schematiq")
+
+    assert result["status"] == "complete"  # chat still works within the run
+    assert storage.writes == []  # but nothing is retained
+
+
+@pytest.mark.asyncio
+async def test_write_failure_does_not_raise(sessions, monkeypatch):
+    storage = _FakeStorage(fail_write=True)
+    svc = _make_service(monkeypatch, storage)
+
+    result = await svc.send_message("sess-1", "hello", "schematiq")
+
+    # The turn still completes even though persistence blew up.
+    assert result["status"] == "complete"
+    assert any(m.get("kind") == "text" for m in result["messages"])
+
+
+# --- restore --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restore_after_restart_rehydrates_the_model(sessions, monkeypatch):
+    """A fresh service (simulating a redeploy that emptied the in-memory store)
+    restores the persisted transcript and seeds the new chat with it."""
+    storage = _FakeStorage()
+
+    first = _make_service(monkeypatch, storage)
+    await first.send_message("sess-1", "remember apples", "schematiq")
+    persisted_turns = storage.blobs[
+        (CHAT_HISTORY_BUCKET, _chat_history_path("sess-1"))
+    ]["turns"]
+    assert persisted_turns
+
+    # Wipe the in-memory store the way a process restart would.
+    for state in list(chat_session_store._sessions.values()):
+        if state.workspace_session_id == "sess-1":
+            chat_session_store.delete(state.chat_id)
+
+    captured: dict = {}
+
+    def _capturing_create(session_id, session_mode, model=None, history=None):
+        chat = _FakeChat(history=history)
+        captured["seeded"] = chat.seeded
+        return object(), chat
+
+    restarted = _make_service(monkeypatch, storage)
+    monkeypatch.setattr(restarted, "_create_gemini_chat", _capturing_create)
+
+    await restarted.send_message("sess-1", "and pears", "schematiq", chat_id=None)
+
+    # The rebuilt chat was seeded from the persisted transcript, so the model
+    # continues with context instead of starting from zero.
+    assert captured["seeded"], "restarted chat should be seeded with restored history"
+    assert len(captured["seeded"]) == len(persisted_turns)
+
+
+@pytest.mark.asyncio
+async def test_missing_file_restores_empty(sessions, monkeypatch):
+    """No persisted transcript → a fresh empty chat, identical to today."""
+    storage = _FakeStorage()  # nothing stored
+    svc = _make_service(monkeypatch, storage)
+
+    captured: dict = {}
+
+    def _capturing_create(session_id, session_mode, model=None, history=None):
+        captured["history"] = history
+        return object(), _FakeChat(history=history)
+
+    monkeypatch.setattr(svc, "_create_gemini_chat", _capturing_create)
+
+    await svc.send_message("ghost", "hello", "schematiq")
+
+    assert not captured["history"]  # None or empty — no history to restore
+
+
+@pytest.mark.asyncio
+async def test_read_failure_restores_empty(sessions, monkeypatch):
+    class _BoomStorage(_FakeStorage):
+        async def download_json(self, bucket, path):
+            raise IOError("simulated read failure")
+
+    svc = _make_service(monkeypatch, _BoomStorage())
+
+    captured: dict = {}
+
+    def _capturing_create(session_id, session_mode, model=None, history=None):
+        captured["history"] = history
+        return object(), _FakeChat(history=history)
+
+    monkeypatch.setattr(svc, "_create_gemini_chat", _capturing_create)
+
+    result = await svc.send_message("sess-1", "hello", "schematiq")
+
+    assert result["status"] == "complete"
+    assert not captured["history"]
+
+
+# --- one chat per project -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_second_message_without_chat_id_reattaches(sessions, monkeypatch):
+    """A client that lost its chat_id (page refresh) reattaches to the one live
+    chat for the session rather than starting a second conversation."""
+    storage = _FakeStorage()
+    svc = _make_service(monkeypatch, storage)
+
+    creates = {"n": 0}
+    original_create = svc._create_gemini_chat
+
+    def _counting_create(session_id, session_mode, model=None, history=None):
+        creates["n"] += 1
+        return original_create(session_id, session_mode, model, history)
+
+    monkeypatch.setattr(svc, "_create_gemini_chat", _counting_create)
+
+    first = await svc.send_message("sess-1", "one", "schematiq")
+    second = await svc.send_message("sess-1", "two", "schematiq", chat_id=None)
+
+    assert creates["n"] == 1, "the second turn must reuse the existing chat"
+    assert first["chat_id"] == second["chat_id"]

--- a/backend/tests/test_chat_message_cap.py
+++ b/backend/tests/test_chat_message_cap.py
@@ -20,6 +20,20 @@ from app.services.chat.agent_service import (
 from app.services.chat.session_store import chat_session_store
 
 
+@pytest.fixture(autouse=True)
+def _isolate_chat_store():
+    """Reset the process-wide chat store between tests.
+
+    send_message now reattaches to the one live chat for a workspace session
+    (ChatSessionStore.get_by_workspace_session), so a chat left in the singleton
+    by an earlier test would otherwise be reused here — routing this test's turns
+    to a chat the local fake never recorded. Clearing keeps each test isolated.
+    """
+    chat_session_store._sessions.clear()
+    yield
+    chat_session_store._sessions.clear()
+
+
 class _FakeResponse:
     function_calls: list = []
     text = "done"


### PR DESCRIPTION
## Problem
The workspace chat agent is a stateful Gemini conversation only within a single server run. `ChatSessionStore` is an in-memory dict keyed by a random `chat_id`; any Railway restart/redeploy empties it, and `_get_or_create_session` then silently builds a fresh empty chat. The model "starts from zero" on every redeploy.

## Solution
Make the Gemini chat object a transient cache over a durable per-session transcript.
- `session_store.py`: `get_by_workspace_session()` reverse-lookup so a lost/stale `chat_id` reattaches to the one chat per project instead of starting a new one.
- `agent_service.py`: on a cache miss, restore `{session_id}/chat_history.json` from the `data` bucket and rebuild the chat via `chats.create(history=...)`; after each *settled* turn, persist the SDK history (best-effort). Persistence is gated on `opt_out_data_collection`, mirrors `_record_message_used`'s swallow-and-continue, and is never written on `pending_confirmation` (avoids a dangling function-call on restore). A missing/opted-out/unreadable transcript falls back to an empty chat — restore only ever adds context.
- Stored form is the SDK-visible history (`Content.model_dump(mode="json", exclude_none=True)`), rebuilt via `Content.model_validate`, so function calls/responses survive.

No API or frontend change; safe in isolation. Backward compatible: sessions with no `chat_history.json` restore empty.

## Verify
- `git apply --ignore-whitespace --check` on a fresh clone; `py_compile` on all four files.
- `pytest tests/test_chat_history_persistence.py` (round-trip; restore-after-restart rehydrates; opt-out skips writing; missing/read-failure restore empty; write-failure never raises; reattach without chat_id) and `tests/test_chat_message_cap.py` (no regression; adds store isolation now that send_message reattaches per session).
- Manual smoke: send a few messages -> restart backend -> the model still references earlier turns.

Follow-ups (not stacked): PR2 `GET /{session_id}/messages` after this merges; PR3 frontend load-on-mount after PR2.