### PR TITLE
feat(chat): GET /{session_id}/messages for transcript reload (PR2)

### DIFF
--- a/backend/app/api/routes/chat.py
+++ b/backend/app/api/routes/chat.py
@@ -8,6 +8,7 @@ from app.models.chat import (
     ChatConfirmRequest,
     ChatMessageRequest,
     ChatMessageResponse,
+    ChatMessagesResponse,
     ChatToolsResponse,
     ChatToolInfo,
     ChatTurnMessage,
@@ -51,6 +52,28 @@ async def list_chat_tools(
         _require_session(session_id)
     tools = await chat_agent_service.list_tools(session_id, session_mode)
     return ChatToolsResponse(tools=[ChatToolInfo(**tool) for tool in tools])
+
+
+@router.get("/{session_id}/messages", response_model=ChatMessagesResponse)
+async def get_chat_messages(session_id: str) -> ChatMessagesResponse:
+    """Return the reconstructed transcript so a reloaded client can repaint it.
+
+    Read-only: no Gemini work happens here. Guarded like the other routes so an
+    unknown session is a 404 before the agent service is touched. When there is
+    no persisted history (or the session opted out), ``messages`` is empty and
+    the client keeps its local seed.
+    """
+    _require_session(session_id)
+    try:
+        result = await chat_agent_service.get_transcript(session_id)
+        return ChatMessagesResponse(
+            chat_id=result["chat_id"],
+            messages=[ChatTurnMessage(**msg) for msg in result["messages"]],
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @router.post("/{session_id}/message", response_model=ChatMessageResponse)

--- a/backend/app/models/chat.py
+++ b/backend/app/models/chat.py
@@ -43,6 +43,18 @@ class ChatMessageResponse(BaseModel):
     pending_action: Optional[PendingChatAction] = None
 
 
+class ChatMessagesResponse(BaseModel):
+    """The reconstructed transcript for a session's chat, for repaint on load.
+
+    ``chat_id`` is the conversation to resume with when it is already live in
+    memory; it is ``None`` when nothing is loaded yet, in which case the next
+    send restores the persisted history and mints a fresh id.
+    """
+
+    chat_id: Optional[str] = None
+    messages: list[ChatTurnMessage]
+
+
 class ChatToolInfo(BaseModel):
     name: str
     description: str

--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -654,6 +654,64 @@ class ChatAgentService:
                 "could not persist chat history for session %s: %s", session_id, exc
             )
 
+    async def get_transcript(self, session_id: str) -> dict[str, Any]:
+        """Reconstruct the UI transcript for a session's persisted chat.
+
+        Reads the same persisted model history that restore uses — honoring
+        opt-out and returning empty when the transcript is absent or unreadable —
+        and maps it to the display messages the client repaints on load. Also
+        returns the ``chat_id`` to resume with when the conversation is already
+        live in memory; otherwise ``None``, and the next send restores it and
+        mints a fresh id.
+        """
+        restored = await self._load_history(session_id)
+        messages = self._reconstruct_transcript(restored)
+        existing = chat_session_store.get_by_workspace_session(session_id)
+        return {
+            "chat_id": existing.chat_id if existing else None,
+            "messages": messages,
+        }
+
+    @staticmethod
+    def _reconstruct_transcript(history: list[Any]) -> list[dict[str, Any]]:
+        """Map persisted model-history turns to display messages.
+
+        The persisted history is model context, not a display list, so it is
+        translated the same way the live UI groups a turn: user and model text
+        parts become chat bubbles, and a model ``function_call`` becomes a compact
+        ``tool_log`` line. ``function_response`` parts are the raw tool output fed
+        back to the model and are never surfaced. Fresh message ids are minted;
+        they are display-only and need not match the ephemeral live-stream ids.
+        """
+        messages: list[dict[str, Any]] = []
+        for content in history or []:
+            role = getattr(content, "role", None)
+            for part in getattr(content, "parts", None) or []:
+                text = getattr(part, "text", None)
+                function_call = getattr(part, "function_call", None)
+                if text and role in ("model", "user"):
+                    messages.append(
+                        {
+                            "id": str(uuid.uuid4()),
+                            "role": "assistant" if role == "model" else "user",
+                            "kind": "text",
+                            "content": text,
+                        }
+                    )
+                elif function_call is not None and role == "model":
+                    name = getattr(function_call, "name", None) or "tool"
+                    messages.append(
+                        {
+                            "id": str(uuid.uuid4()),
+                            "role": "tool",
+                            "kind": "tool_log",
+                            "tool_name": name,
+                            "tool_status": "done",
+                            "content": f"...{tool_running_label(name).lower()}",
+                        }
+                    )
+        return messages
+
     async def _emit(
         self,
         state: ChatSessionState,

--- a/backend/tests/test_chat_messages_endpoint.py
+++ b/backend/tests/test_chat_messages_endpoint.py
@@ -1,0 +1,180 @@
+"""Tests for GET /{session_id}/messages and transcript reconstruction (PR2).
+
+The endpoint is read-only: it reconstructs a display transcript from the
+persisted model history so a reloaded client can repaint the conversation, and
+returns the chat_id to resume with when one is live. Like the other chat routes
+it 404s an unknown session before touching the agent service, and it never runs
+Gemini.
+
+Route handlers are called directly with the agent service faked, matching
+test_chat_session_validation.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from google.genai import types
+
+from app.api.routes import chat as chat_routes
+from app.models.chat import ChatMessagesResponse, ChatTurnMessage
+from app.services.chat.agent_service import ChatAgentService
+
+
+class _Session:
+    id = "real-session"
+
+
+@pytest.fixture
+def known_session(monkeypatch):
+    """Only 'real-session' resolves; everything else is unknown."""
+
+    def _get_session(session_id: str):
+        return _Session() if session_id == "real-session" else None
+
+    monkeypatch.setattr(
+        chat_routes.session_manager, "get_session", _get_session, raising=True
+    )
+
+
+# --- the route: guard + shape --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_session_is_rejected_without_calling_agent(
+    known_session, monkeypatch
+):
+    async def _boom(*args, **kwargs):
+        raise AssertionError("agent service must not be reached for a bad session")
+
+    monkeypatch.setattr(
+        chat_routes.chat_agent_service, "get_transcript", _boom, raising=True
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await chat_routes.get_chat_messages("does-not-exist")
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_empty_when_no_history(known_session, monkeypatch):
+    async def _empty(session_id):
+        return {"chat_id": None, "messages": []}
+
+    monkeypatch.setattr(
+        chat_routes.chat_agent_service, "get_transcript", _empty, raising=True
+    )
+
+    result = await chat_routes.get_chat_messages("real-session")
+    assert isinstance(result, ChatMessagesResponse)
+    assert result.chat_id is None
+    assert result.messages == []
+
+
+@pytest.mark.asyncio
+async def test_returns_turns_and_chat_id_when_history_exists(known_session, monkeypatch):
+    async def _transcript(session_id):
+        return {
+            "chat_id": "chat-abc",
+            "messages": [
+                {"id": "1", "role": "user", "kind": "text", "content": "hi"},
+                {
+                    "id": "2",
+                    "role": "tool",
+                    "kind": "tool_log",
+                    "tool_name": "add_column",
+                    "tool_status": "done",
+                    "content": "...adding column",
+                },
+                {"id": "3", "role": "assistant", "kind": "text", "content": "done"},
+            ],
+        }
+
+    monkeypatch.setattr(
+        chat_routes.chat_agent_service, "get_transcript", _transcript, raising=True
+    )
+
+    result = await chat_routes.get_chat_messages("real-session")
+    assert result.chat_id == "chat-abc"
+    assert [m.role for m in result.messages] == ["user", "tool", "assistant"]
+    assert result.messages[1].tool_name == "add_column"
+    assert result.messages[1].tool_status == "done"
+
+
+# --- reconstruction from model history ------------------------------------
+
+
+def _history():
+    """A realistic persisted conversation: user text, a tool call, its response,
+    and the model's reply."""
+    return [
+        types.Content(role="user", parts=[types.Part(text="add a column X")]),
+        types.Content(
+            role="model",
+            parts=[
+                types.Part(
+                    function_call=types.FunctionCall(
+                        name="add_column", args={"name": "X"}
+                    )
+                )
+            ],
+        ),
+        types.Content(
+            role="user",
+            parts=[
+                types.Part.from_function_response(
+                    name="add_column", response={"result": {"message": "ok"}}
+                )
+            ],
+        ),
+        types.Content(role="model", parts=[types.Part(text="Added column X.")]),
+    ]
+
+
+def test_reconstruct_maps_bubbles_and_hides_function_response():
+    messages = ChatAgentService._reconstruct_transcript(_history())
+
+    kinds = [(m["role"], m.get("kind")) for m in messages]
+    assert kinds == [
+        ("user", "text"),
+        ("tool", "tool_log"),
+        ("assistant", "text"),
+    ], "function_response turn must be hidden; text turns become bubbles"
+
+    user_bubble, tool_log, assistant_bubble = messages
+    assert user_bubble["content"] == "add a column X"
+    assert tool_log["tool_name"] == "add_column"
+    assert tool_log["tool_status"] == "done"
+    assert assistant_bubble["content"] == "Added column X."
+
+
+def test_reconstruct_ids_are_unique():
+    messages = ChatAgentService._reconstruct_transcript(_history())
+    assert len({m["id"] for m in messages}) == len(messages)
+
+
+def test_reconstructed_messages_validate_as_chat_turn_messages():
+    """What the reconstruction emits must satisfy the response model unchanged."""
+    for msg in ChatAgentService._reconstruct_transcript(_history()):
+        ChatTurnMessage(**msg)  # raises if a field is missing or mistyped
+
+
+def test_reconstruct_empty_history_is_empty():
+    assert ChatAgentService._reconstruct_transcript([]) == []
+
+
+def test_reconstruct_unknown_tool_falls_back_to_generic_label():
+    history = [
+        types.Content(
+            role="model",
+            parts=[
+                types.Part(
+                    function_call=types.FunctionCall(name="mystery_tool", args={})
+                )
+            ],
+        )
+    ]
+    (tool_log,) = ChatAgentService._reconstruct_transcript(history)
+    assert tool_log["tool_name"] == "mystery_tool"
+    # tool_running_label has a generic fallback, so the content is non-empty.
+    assert tool_log["content"].strip(". ")


### PR DESCRIPTION
## Problem
PR1 persists and restores chat history server-side, but there is no way for a reloaded client to read an existing conversation back. A page refresh therefore repaints an empty transcript even though the model context survives.

## Solution
Add a read-only `GET /{session_id}/messages`:
- `agent_service.get_transcript()` loads the persisted history (reusing PR1's opt-out/absent/error handling, so an opted-out or missing transcript returns empty) and reconstructs display messages; it also returns the `chat_id` to resume with when the chat is live in memory, else `null` (the next send restores and mints one).
- `_reconstruct_transcript()` maps model history to the UI's grouping: user/model text -> chat bubbles; a model `function_call` -> a compact `tool_log`; `function_response` parts (raw tool output) are hidden. Fresh, display-only message ids are minted.
- The route is guarded by `_require_session` (404 before any agent work) and runs no Gemini.
- `ChatMessagesResponse` reuses `ChatTurnMessage`.

Reads only; independently mergeable. Depends on PR1's persisted format.

## Verify
- `git apply --ignore-whitespace --check` on a fresh clone; `py_compile` on all four files.
- `pytest tests/test_chat_messages_endpoint.py` (404 before agent; empty when no history; turns + chat_id when present; reconstruction maps bubbles, hides function_response, validates against the response model, and falls back for unknown tools) and `tests/test_chat_session_validation.py` (no regression).
- Manual smoke: send messages -> GET the endpoint -> the reconstructed transcript matches.

Follow-up (not stacked): PR3 frontend load-on-mount calls this endpoint, delivered after this merges.