### PR TITLE
feat(chat): clear spinner on reextraction_stopped

### DIFF
--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -309,6 +309,25 @@ export function ChatPanel({
             content: `Re-extraction failed: ${data.error ?? 'unknown error'}.`,
           },
         ]);
+      } else if (message.type === 'reextraction_stopped') {
+        // A user-halted run still merges whatever it processed before stopping,
+        // so report partial progress rather than treating it as a failure. This
+        // is the third and final terminal event that must clear the spinner.
+        const data = (message.data ?? {}) as unknown as {
+          processed_documents?: number; total_documents?: number; message?: string;
+        };
+        setReextractionRunning(null);
+        const progress =
+          data.processed_documents != null && data.total_documents != null
+            ? ` Kept results from ${data.processed_documents} of ${data.total_documents} documents processed so far.`
+            : '';
+        appendMessages([
+          {
+            id: `${Date.now()}-reextract-stopped`,
+            role: 'assistant',
+            content: `${data.message ?? 'Re-extraction stopped'}.${progress}`,
+          },
+        ]);
       }
     };
     webSocketService.addMessageHandler(handler);


### PR DESCRIPTION
## Problem
The re-extraction summary feature (#471) added a background spinner in the chat panel that clears on `reextraction_completed` and `reextraction_failed`. It does not handle `reextraction_stopped`, which the backend broadcasts when a user halts a run — so a stopped re-extraction leaves the spinner running forever.

## Solution
Add a `reextraction_stopped` handler as the third and final terminal event that clears the spinner. A stopped run still merges whatever it processed before halting, so the message reports partial progress (`processed_documents` of `total_documents`) rather than treating the stop as a failure.

## Verify
Validated on current main:
- `git apply --ignore-whitespace --check` — clean
- `( cd frontend && npx tsc --noEmit )` — exit 0, no new errors

Manual: start a chat-triggered `reextract`, then stop it mid-run. The spinner clears and the chat reports how many documents were kept.