### PR TITLE
feat(chat): resume persisted chat transcript on mount (PR3)

### DIFF
--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -98,6 +98,12 @@ export function ChatPanel({
   const [reextractionRunning, setReextractionRunning] = useState<{ columns: string[] } | null>(null);
   const messagesRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // Which session's persisted transcript we've already tried to load, so a model
+  // switch (which resets chatId) or a re-render doesn't refetch and repaint.
+  const historyLoadedForRef = useRef<string | null>(null);
+  // Flips true once the user drives the conversation, so a late-arriving history
+  // load can't clobber messages they've already produced this session.
+  const conversationStartedRef = useRef(false);
 
   useEffect(() => {
     const container = messagesRef.current;
@@ -108,6 +114,32 @@ export function ChatPanel({
       behavior: 'smooth',
     });
   }, [messages, pendingAction, busy]);
+
+  // On entering a project, repaint any persisted conversation so a refresh or a
+  // backend redeploy resumes where the user left off instead of showing only the
+  // seed. Runs once per session id; keeps the seed when there is no history, and
+  // never overwrites a conversation the user has already started this session.
+  useEffect(() => {
+    if (!sessionId) return;
+    if (historyLoadedForRef.current === sessionId) return;
+    historyLoadedForRef.current = sessionId;
+    let cancelled = false;
+    (async () => {
+      try {
+        const history = await chatAPI.getMessages(sessionId);
+        if (cancelled || conversationStartedRef.current) return;
+        if (history.messages.length === 0) return;
+        setMessages(history.messages.map(mapChatTurnMessage));
+        // Adopt the resumable chat id so the next send continues this thread.
+        if (history.chat_id) setChatId(history.chat_id);
+      } catch {
+        // Best-effort: on any failure keep the local seed, exactly as before.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
 
   const loadTools = useCallback(async () => {
     const tools = await chatAPI.getTools(sessionId, sessionMode);
@@ -406,6 +438,9 @@ export function ChatPanel({
   const ask = useCallback(async () => {
     const text = input.trim();
     if (!text || busy) return;
+    // The user is now driving this conversation; block any in-flight history
+    // restore from overwriting what they produce.
+    conversationStartedRef.current = true;
     setInput('');
     appendMessages([{ id: `${Date.now()}-user`, role: 'user', content: text }]);
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -34,6 +34,7 @@ import {
   CostEstimate,
   ChatToolInfo,
   ChatMessageResponse,
+  ChatMessagesResponse,
 } from '../types';
 import {
   UnitListResponse,
@@ -1109,6 +1110,12 @@ export const chatAPI = {
     }
     const response = await api.get(`/chat/tools?${params.toString()}`);
     return response.data.tools;
+  },
+
+  getMessages: async (sessionId: string): Promise<ChatMessagesResponse> => {
+    // Read-only transcript for repainting the chat after a refresh/redeploy.
+    const response = await api.get(`/chat/${sessionId}/messages`);
+    return response.data;
   },
 
   sendMessage: async (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1017,6 +1017,13 @@ export interface ChatMessageResponse {
   pending_action?: PendingChatToolAction;
 }
 
+export interface ChatMessagesResponse {
+  // The conversation to resume with when it is already live in memory; null
+  // when nothing is loaded yet, in which case the next send restores it.
+  chat_id: string | null;
+  messages: ChatTurnMessage[];
+}
+
 export interface CostEstimate {
   /** Estimate for schema discovery phase */
   schema_discovery: PhaseEstimate;


### PR DESCRIPTION
## Problem
PR1 persists chat history and PR2 exposes it via GET /{session_id}/messages, but the workspace client still initializes ChatPanel with a single hard-coded seed and never reloads. A page refresh or a return to a project therefore shows an empty conversation even though the model context survives on the server.

## Solution
- `chatAPI.getMessages(sessionId)` calls the PR2 endpoint.
- `ChatMessagesResponse` type mirrors the backend (`chat_id: string | null`, `messages`).
- `ChatPanel` gains a load-on-mount effect: once per session id it fetches the transcript, and if any turns exist it replaces the seed with the reconstructed messages and adopts the returned `chat_id` so the next send resumes the same conversation. When there is no history it keeps the seed, unchanged from today.

Robustness: the effect is keyed on `sessionId` (not `chatId`), so a model switch — which resets `chatId` — does not refetch or repaint. A `conversationStartedRef` guard prevents a late-arriving load from clobbering messages the user has already produced, and a `cancelled` flag avoids setState after unmount. Any load failure falls back to the seed.

## Verify
- `git apply --ignore-whitespace --check` on a fresh clone.
- `( cd frontend && npx tsc --noEmit )` — clean, exit 0.
- Manual smoke: send messages -> refresh the page -> the transcript repaints and the next message continues the same thread; redeploy the backend -> same.