### PR TITLE
feat(chat): add Stop button to cancel an in-flight chat turn

### DIFF
--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -2,7 +2,7 @@
 // Parent: Workspace (index.tsx).
 
 import { type ChangeEvent, type DragEvent, useCallback, useEffect, useRef, useState } from 'react';
-import { ArrowUp, Bot, Check, FileText, Loader2, Paperclip, X } from 'lucide-react';
+import { ArrowUp, Bot, Check, FileText, Loader2, Paperclip, Square, X } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -29,6 +29,7 @@ import { formatToolsList, mapChatTurnMessage } from '../helpers';
 import type { PendingChatAction, PendingRerunKind, WorkspaceMessage, WorkspaceSessionMode } from '../types';
 import { ChatMessageBody } from './ChatMessageBody';
 import { ToolActivityGroup } from './ToolActivityGroup';
+import { useChatTurn } from './hooks/useChatTurn';
 
 // Fold a flat message list into render groups so that consecutive tool_log
 // messages collapse into a single expandable block, while text/user messages
@@ -84,7 +85,10 @@ export function ChatPanel({
     },
   ]);
   const [input, setInput] = useState('');
-  const [busy, setBusy] = useState(false);
+  // The chat turn lifecycle (busy flag + abort wiring) lives in its own hook so
+  // Stop can cancel the in-flight request and every handler shares one busy
+  // source instead of toggling it by hand.
+  const { busy, runTurn, stop } = useChatTurn();
   const [chatId, setChatId] = useState<string | null>(null);
   const [chatModel, setChatModel] = useState<string>(() => getDefaultModelForProvider('gemini'));
   const [pinnedTool, setPinnedTool] = useState<string | null>(null);
@@ -412,9 +416,9 @@ export function ChatPanel({
   }, [appendMessages, onEditFollowUp, onRefresh]);
 
   const showToolsList = useCallback(async () => {
-    setBusy(true);
     try {
-      const tools = await loadTools();
+      const tools = await runTurn(() => loadTools());
+      if (!tools) return; // stopped
       appendMessages([
         {
           id: `${Date.now()}-tools`,
@@ -430,10 +434,8 @@ export function ChatPanel({
           content: err?.response?.data?.detail || err?.message || 'Could not load tools.',
         },
       ]);
-    } finally {
-      setBusy(false);
     }
-  }, [appendMessages, loadTools]);
+  }, [appendMessages, loadTools, runTurn]);
 
   const ask = useCallback(async () => {
     const text = input.trim();
@@ -460,16 +462,22 @@ export function ChatPanel({
       return;
     }
 
-    setBusy(true);
     try {
-      const response = await chatAPI.sendMessage(sessionId, {
-        message: text,
-        chat_id: chatId || undefined,
-        session_mode: sessionMode,
-        pinned_tool: pinnedTool || undefined,
-        model: chatModel || undefined,
-      });
-      applyChatResponse(response);
+      const response = await runTurn((signal) =>
+        chatAPI.sendMessage(
+          sessionId,
+          {
+            message: text,
+            chat_id: chatId || undefined,
+            session_mode: sessionMode,
+            pinned_tool: pinnedTool || undefined,
+            model: chatModel || undefined,
+          },
+          signal,
+        ),
+      );
+      // null means the user pressed Stop; leave the transcript as-is.
+      if (response) applyChatResponse(response);
     } catch (err: any) {
       appendMessages([
         {
@@ -478,16 +486,16 @@ export function ChatPanel({
           content: err?.response?.data?.detail || err?.message || 'That workspace action failed.',
         },
       ]);
-    } finally {
-      setBusy(false);
     }
   }, [
     appendMessages,
     applyChatResponse,
     busy,
     chatId,
+    chatModel,
     input,
     pinnedTool,
+    runTurn,
     sessionId,
     sessionMode,
     showToolsList,
@@ -495,10 +503,11 @@ export function ChatPanel({
 
   const confirmPendingAction = useCallback(async () => {
     if (!pendingAction || !sessionId) return;
-    setBusy(true);
     try {
-      const response = await chatAPI.confirmAction(sessionId, pendingAction.chatId);
-      applyChatResponse(response);
+      const response = await runTurn((signal) =>
+        chatAPI.confirmAction(sessionId, pendingAction.chatId, signal),
+      );
+      if (response) applyChatResponse(response); // null => stopped
     } catch (err: any) {
       appendMessages([
         {
@@ -507,16 +516,16 @@ export function ChatPanel({
           content: err?.response?.data?.detail || err?.message || 'The confirmed action failed.',
         },
       ]);
-    } finally {
-      setBusy(false);
     }
-  }, [appendMessages, applyChatResponse, pendingAction, sessionId]);
+  }, [appendMessages, applyChatResponse, pendingAction, runTurn, sessionId]);
 
   const cancelPendingAction = useCallback(async (): Promise<boolean> => {
     if (!pendingAction || !sessionId) return true;
-    setBusy(true);
     try {
-      const response = await chatAPI.cancelAction(sessionId, pendingAction.chatId);
+      const response = await runTurn(() =>
+        chatAPI.cancelAction(sessionId, pendingAction.chatId),
+      );
+      if (!response) return false; // stopped; the pending action still stands
       setPendingAction(null);
       applyChatResponse(response);
       return true;
@@ -532,10 +541,8 @@ export function ChatPanel({
         },
       ]);
       return false;
-    } finally {
-      setBusy(false);
     }
-  }, [appendMessages, applyChatResponse, pendingAction, sessionId]);
+  }, [appendMessages, applyChatResponse, pendingAction, runTurn, sessionId]);
 
   useEffect(() => {
     if (!onRegisterCancelPending) return;
@@ -749,21 +756,31 @@ export function ChatPanel({
             )}
             Attach reference
           </Button>
-          <Button
-            type="button"
-            size="icon"
-            onClick={ask}
-            disabled={busy || !input.trim()}
-            className="ml-auto h-8 w-8 rounded-lg"
-            aria-label="Send message"
-            title="Send message (Enter)"
-          >
-            {busy ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
+          {busy ? (
+            <Button
+              type="button"
+              size="icon"
+              variant="destructive"
+              onClick={stop}
+              className="ml-auto h-8 w-8 rounded-lg"
+              aria-label="Stop"
+              title="Stop"
+            >
+              <Square className="h-4 w-4" />
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              size="icon"
+              onClick={ask}
+              disabled={!input.trim()}
+              className="ml-auto h-8 w-8 rounded-lg"
+              aria-label="Send message"
+              title="Send message (Enter)"
+            >
               <ArrowUp className="h-4 w-4" />
-            )}
-          </Button>
+            </Button>
+          )}
         </div>
       </div>
     </aside>

--- a/frontend/src/pages/Workspace/chat/hooks/useChatTurn.ts
+++ b/frontend/src/pages/Workspace/chat/hooks/useChatTurn.ts
@@ -1,0 +1,57 @@
+// Owns the lifecycle of a single chat "turn" -- the window between the user
+// sending something and the agent's reply landing. Centralising it here keeps
+// the busy flag and the cancel wiring in one place (instead of duplicated in
+// every ChatPanel handler) and gives future turn-level features -- retry,
+// streaming, per-turn state -- a single seam to hang off.
+import { useCallback, useRef, useState } from 'react';
+
+export interface ChatTurnController {
+  // True while a turn is in flight. Drives the composer's disabled state and
+  // the Send/Stop button swap.
+  busy: boolean;
+  // Runs one turn. `work` receives an AbortSignal to thread into its request so
+  // Stop can abort the wait. Resolves to the work's value, or null when the
+  // user stopped the turn -- callers treat null as "stopped" and skip their
+  // success handling rather than surfacing it as an error.
+  runTurn: <T>(work: (signal: AbortSignal) => Promise<T>) => Promise<T | null>;
+  // Aborts the in-flight turn, if any. A no-op when idle.
+  stop: () => void;
+}
+
+export function useChatTurn(): ChatTurnController {
+  const [busy, setBusy] = useState(false);
+  // Only one turn runs at a time (the composer is disabled while busy), so a
+  // single controller ref is enough to route Stop to the active request.
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const stop = useCallback(() => {
+    controllerRef.current?.abort();
+  }, []);
+
+  const runTurn = useCallback(
+    async <T>(work: (signal: AbortSignal) => Promise<T>): Promise<T | null> => {
+      const controller = new AbortController();
+      controllerRef.current = controller;
+      setBusy(true);
+      try {
+        return await work(controller.signal);
+      } catch (error) {
+        // A user-initiated Stop surfaces as a rejected request; swallow it and
+        // report "stopped" via null so callers don't render it as a failure.
+        // Any other rejection is a real error and propagates to the caller.
+        if (controller.signal.aborted) return null;
+        throw error;
+      } finally {
+        // Guard against a fast re-send having already installed a newer
+        // controller: only the turn that owns the current ref clears state.
+        if (controllerRef.current === controller) {
+          controllerRef.current = null;
+          setBusy(false);
+        }
+      }
+    },
+    [],
+  );
+
+  return { busy, runTurn, stop };
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1127,16 +1127,18 @@ export const chatAPI = {
       pinned_tool?: string;
       model?: string;
     },
+    signal?: AbortSignal,
   ): Promise<ChatMessageResponse> => {
-    const response = await api.post(`/chat/${sessionId}/message`, payload, { timeout: CHAT_REQUEST_TIMEOUT_MS });
+    const response = await api.post(`/chat/${sessionId}/message`, payload, { timeout: CHAT_REQUEST_TIMEOUT_MS, signal });
     return response.data;
   },
 
   confirmAction: async (
     sessionId: string,
     chatId: string,
+    signal?: AbortSignal,
   ): Promise<ChatMessageResponse> => {
-    const response = await api.post(`/chat/${sessionId}/confirm`, { chat_id: chatId }, { timeout: CHAT_REQUEST_TIMEOUT_MS });
+    const response = await api.post(`/chat/${sessionId}/confirm`, { chat_id: chatId }, { timeout: CHAT_REQUEST_TIMEOUT_MS, signal });
     return response.data;
   },
 


### PR DESCRIPTION
## Problem
While the chat is processing a turn the composer is disabled, so the user is stuck waiting with no way to bail out and ask something else.

## Solution
Introduce a `useChatTurn` hook (`chat/hooks/`) that owns the `busy` flag and an `AbortController`, giving the chat turn lifecycle its own home and removing the busy-toggling duplicated across four handlers. While a turn is in flight the Send button is replaced by a Stop button that aborts the in-flight request; the composer re-enables immediately so a new message can be sent. An optional `AbortSignal` is threaded through `sendMessage` and `confirmAction`.

Note: this is a client-side stop. There is no backend endpoint to abort a running agent turn today, so the server may finish the turn and partial messages already streamed over the WebSocket can still land. A true server-side cancel is a separate follow-up.

## Verify
- `git apply --ignore-whitespace` on a clean clone of main
- `cd frontend && npx tsc --noEmit` passes
- Send a message, confirm the Send button turns into a red Stop button and the input is disabled; click Stop and confirm the input re-enables and a new message can be sent.