### PR TITLE
feat(chat): persist WS-only summaries and anchor them in the restored transcript

### DIFF
--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -676,7 +676,17 @@ class ChatAgentService:
         mints a fresh id.
         """
         restored = await self._load_history(session_id)
-        messages = self._reconstruct_transcript(restored)
+        # WS-only summaries (re-extraction / reference-fill recaps) live outside
+        # the model history; load them so reconstruction can splice each one back
+        # in at the position of the tool call that produced it.
+        summaries: dict[str, str] = {}
+        try:
+            from app.services.chat.chat_summary_store import load_summaries
+
+            summaries = await load_summaries(session_id)
+        except Exception:
+            summaries = {}
+        messages = self._reconstruct_transcript(restored, summaries)
         existing = chat_session_store.get_by_workspace_session(session_id)
         return {
             "chat_id": existing.chat_id if existing else None,
@@ -684,17 +694,62 @@ class ChatAgentService:
         }
 
     @staticmethod
-    def _reconstruct_transcript(history: list[Any]) -> list[dict[str, Any]]:
+    def _summary_id_from_function_response(part: Any) -> Optional[str]:
+        """Return the operation id embedded in a ``function_response`` part, if any.
+
+        Tool results are stored as ``response={"result": <tool_result>}`` (see
+        ``_function_response_part``). Asynchronous starts carry the id under
+        ``operation_id`` (re-extraction) or ``fill_id`` (reference fill); either
+        is the key a persisted summary is stored under. Returns ``None`` for any
+        other tool result, which simply means "no summary to anchor here".
+        """
+        function_response = getattr(part, "function_response", None)
+        if function_response is None:
+            return None
+        response = getattr(function_response, "response", None)
+        if not isinstance(response, dict):
+            return None
+        result = response.get("result")
+        if not isinstance(result, dict):
+            return None
+        op_id = result.get("operation_id") or result.get("fill_id")
+        return str(op_id) if op_id else None
+
+    @staticmethod
+    def _reconstruct_transcript(
+        history: list[Any], summaries: Optional[dict[str, str]] = None
+    ) -> list[dict[str, Any]]:
         """Map persisted model-history turns to display messages.
 
         The persisted history is model context, not a display list, so it is
         translated the same way the live UI groups a turn: user and model text
         parts become chat bubbles, and a model ``function_call`` becomes a compact
         ``tool_log`` line. ``function_response`` parts are the raw tool output fed
-        back to the model and are never surfaced. Fresh message ids are minted;
-        they are display-only and need not match the ephemeral live-stream ids.
+        back to the model and are never surfaced as bubbles -- but when one starts
+        an asynchronous operation whose recap was persisted out of band, that
+        recap is spliced in right here, so a re-extraction / reference-fill
+        summary lands in the same chronological spot the user saw it live. Fresh
+        message ids are minted; they are display-only and need not match the
+        ephemeral live-stream ids.
         """
+        summaries = summaries or {}
         messages: list[dict[str, Any]] = []
+        # Summaries whose tool call we have passed but whose model acknowledgement
+        # ("Re-extraction started…") we have not yet emitted. Deferring injection
+        # until just after that ack reproduces the live order the user saw:
+        # tool_log -> started -> (async, later) summary. Each is a (id, text) pair.
+        pending_summaries: list[str] = []
+
+        def _emit_summary(content: str) -> None:
+            messages.append(
+                {
+                    "id": str(uuid.uuid4()),
+                    "role": "assistant",
+                    "kind": "text",
+                    "content": content,
+                }
+            )
+
         for content in history or []:
             role = getattr(content, "role", None)
             for part in getattr(content, "parts", None) or []:
@@ -709,6 +764,12 @@ class ChatAgentService:
                             "content": text,
                         }
                     )
+                    # The model's post-tool acknowledgement is the anchor point:
+                    # flush any summaries whose tool call preceded this reply.
+                    if role == "model" and pending_summaries:
+                        for summary in pending_summaries:
+                            _emit_summary(summary)
+                        pending_summaries = []
                 elif function_call is not None and role == "model":
                     name = getattr(function_call, "name", None) or "tool"
                     messages.append(
@@ -721,6 +782,15 @@ class ChatAgentService:
                             "content": f"...{tool_running_label(name).lower()}",
                         }
                     )
+                else:
+                    op_id = ChatAgentService._summary_id_from_function_response(part)
+                    summary = summaries.get(op_id) if op_id else None
+                    if summary:
+                        pending_summaries.append(summary)
+        # A summary whose tool call had no following model text still belongs in
+        # the transcript; emit any leftovers at the end rather than dropping them.
+        for summary in pending_summaries:
+            _emit_summary(summary)
         return messages
 
     async def _emit(

--- a/backend/app/services/chat/chat_summary_store.py
+++ b/backend/app/services/chat/chat_summary_store.py
@@ -1,0 +1,134 @@
+"""Persistence for chat summaries that never pass through the chat agent.
+
+Some conversation messages are produced by background operations rather than by
+the chat agent's own turns: the re-extraction recap and the reference-fill recap
+are computed inside their services and pushed to the client over the WebSocket.
+They are never part of the Gemini SDK history, so the transcript reconstruction
+in ``agent_service`` (which reads only the persisted model history) cannot see
+them, and they vanish on reload.
+
+This module gives those messages a home. Each summary is written as its own
+small file keyed by the originating operation id -- the same id that already
+appears, at the correct chronological position, inside the ``function_response``
+of the tool call that started the operation in the persisted model history. On
+reload, ``get_transcript`` loads this map once and splices each summary in right
+after its tool call, so the restored order matches what the user saw live.
+
+Design notes:
+- One file per summary (``{session_id}/chat_summaries/{op_id}.json``) so two
+  concurrent operations can never race on a shared file (no read-modify-write).
+- Gated by the same ``opt_out_data_collection`` flag as the model-history
+  persistence, and strictly best-effort: a storage failure logs and continues,
+  never breaking an operation or a transcript load.
+- No dependency on ``agent_service``; the services and the agent both import
+  this module, keeping the dependency graph acyclic.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Reuse the bucket the model-history persistence already writes to, so a
+# session's chat artifacts live together and are cleaned up together.
+CHAT_SUMMARY_BUCKET = "data"
+CHAT_SUMMARY_VERSION = 1
+
+
+def _chat_summaries_prefix(session_id: str) -> str:
+    return f"{session_id}/chat_summaries/"
+
+
+def _chat_summary_path(session_id: str, op_id: str) -> str:
+    return f"{_chat_summaries_prefix(session_id)}{op_id}.json"
+
+
+def _get_storage() -> Any:
+    from app.storage import get_storage
+
+    return get_storage()
+
+
+def _opted_out(session_id: str) -> bool:
+    """Mirror ``agent_service._history_opted_out`` without importing it.
+
+    Persisting a summary is the same kind of retention as persisting the model
+    history, so it is governed by the same flag. If opt-out cannot be read, we
+    treat the session as opted out -- the privacy-conservative default, matching
+    the model-history path.
+    """
+    try:
+        from app.services.chat.deps import session_manager
+
+        session = session_manager.get_session(session_id)
+        return bool(session and session.opt_out_data_collection)
+    except Exception:
+        logger.debug(
+            "could not read opt-out for session %s; skipping summary persistence",
+            session_id,
+            exc_info=True,
+        )
+        return True
+
+
+async def save_summary(session_id: str, op_id: str, content: str) -> None:
+    """Persist one WS-only summary message, keyed by its operation id.
+
+    Best-effort and opt-out gated. ``op_id`` is the re-extraction ``operation_id``
+    or the reference-fill ``fill_id`` -- the value that also appears in the tool
+    call's persisted ``function_response``, which is how the summary is later
+    anchored back into the transcript at the right position.
+    """
+    if not op_id or not content:
+        return
+    try:
+        if _opted_out(session_id):
+            return
+        payload = {
+            "version": CHAT_SUMMARY_VERSION,
+            "op_id": op_id,
+            "content": content,
+        }
+        await _get_storage().upload_json(
+            CHAT_SUMMARY_BUCKET, _chat_summary_path(session_id, op_id), payload
+        )
+    except Exception as exc:
+        logger.warning(
+            "could not persist chat summary for session %s op %s: %s",
+            session_id,
+            op_id,
+            exc,
+        )
+
+
+async def load_summaries(session_id: str) -> Dict[str, str]:
+    """Return ``{op_id: content}`` for a session, or ``{}`` when absent/opted-out.
+
+    Best-effort: any listing or read failure yields an empty map so a transcript
+    load degrades to model-history-only (today's behavior) rather than failing.
+    """
+    try:
+        if _opted_out(session_id):
+            return {}
+        storage = _get_storage()
+        prefix = _chat_summaries_prefix(session_id)
+        paths = await storage.list_files(CHAT_SUMMARY_BUCKET, prefix)
+        summaries: Dict[str, str] = {}
+        for path in paths or []:
+            payload: Optional[Dict[str, Any]] = await storage.download_json(
+                CHAT_SUMMARY_BUCKET, path
+            )
+            if not isinstance(payload, dict):
+                continue
+            op_id = payload.get("op_id")
+            content = payload.get("content")
+            if op_id and content:
+                summaries[str(op_id)] = str(content)
+        return summaries
+    except Exception as exc:
+        logger.warning(
+            "could not load chat summaries for session %s: %s", session_id, exc
+        )
+        return {}

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -1905,6 +1905,18 @@ class ReextractionService(WebSocketBroadcasterMixin):
             except Exception as exc:
                 logger.debug("Re-extraction summary skipped: %s", exc)
 
+            # Persist the recap keyed by operation_id so it survives a reload.
+            # The same operation_id is already in the persisted model history
+            # (inside this tool call's function_response), which is how the
+            # transcript reconstruction re-anchors this message at the right spot.
+            if summary_text:
+                try:
+                    from app.services.chat.chat_summary_store import save_summary
+
+                    await save_summary(operation.session_id, operation_id, summary_text)
+                except Exception as exc:
+                    logger.debug("Re-extraction summary persist skipped: %s", exc)
+
             await self.broadcast_event(
                 operation.session_id,
                 "reextraction_completed",

--- a/backend/app/services/reference_fill_service.py
+++ b/backend/app/services/reference_fill_service.py
@@ -633,6 +633,18 @@ class ReferenceFillService:
             pass
 
     async def _broadcast_complete(self, op: FillOperation) -> None:
+        # Persist the recap keyed by fill_id so it survives a reload. The same
+        # fill_id is already in the persisted model history (inside this tool
+        # call's function_response), which is how transcript reconstruction
+        # re-anchors this message at the right position. Best-effort and separate
+        # from the broadcast so a persist failure never suppresses the live event.
+        if op.message:
+            try:
+                from app.services.chat.chat_summary_store import save_summary
+
+                await save_summary(op.session_id, op.fill_id, op.message)
+            except Exception:
+                pass
         try:
             await self._ws.broadcast_to_session(
                 op.session_id,

--- a/backend/tests/test_chat_summary_anchoring.py
+++ b/backend/tests/test_chat_summary_anchoring.py
@@ -1,0 +1,172 @@
+"""Tests for anchoring WS-only summaries back into the restored transcript.
+
+Re-extraction and reference-fill recaps are produced by background operations and
+pushed to the client over the WebSocket; they never enter the Gemini model
+history. They are persisted separately (``chat_summary_store``) keyed by the
+operation id, and on reload ``_reconstruct_transcript`` splices each one back in
+right after the model's acknowledgement of the tool call that started it — the
+same chronological spot the user saw it live.
+
+The anchor is exact rather than heuristic: the operation id already lives in the
+persisted history, inside the ``function_response`` of the starting tool call.
+These tests build realistic histories (round-tripped through the same serialize/
+deserialize the persistence uses) and assert placement, including the awkward
+cases: no following model text, two operations on the same column, and an empty
+summary map.
+"""
+
+from __future__ import annotations
+
+from google.genai import types
+
+from app.services.chat.agent_service import ChatAgentService
+from app.models.chat import ChatTurnMessage
+
+
+def _roundtrip(contents: list) -> list:
+    """Serialize + deserialize like the persistence layer, so tests exercise the
+    same shape restore produces rather than in-memory objects."""
+    return [
+        types.Content.model_validate(c.model_dump(mode="json", exclude_none=True))
+        for c in contents
+    ]
+
+
+def _reextract_call(op_id: str, ack: str | None = "Re-extraction started.") -> list:
+    """A tool call + its function_response (carrying ``op_id``) + optional ack."""
+    turns = [
+        types.Content(
+            role="model",
+            parts=[
+                types.Part(
+                    function_call=types.FunctionCall(name="reextract", args={})
+                )
+            ],
+        ),
+        types.Content(
+            role="user",
+            parts=[
+                types.Part.from_function_response(
+                    name="reextract",
+                    response={"result": {"status": "started", "operation_id": op_id}},
+                )
+            ],
+        ),
+    ]
+    if ack is not None:
+        turns.append(types.Content(role="model", parts=[types.Part(text=ack)]))
+    return turns
+
+
+def test_summary_anchored_after_ack_before_later_message():
+    history = _roundtrip(
+        [
+            types.Content(role="user", parts=[types.Part(text="add column ruling_date")]),
+            *_reextract_call("71cbbc6d"),
+            types.Content(role="user", parts=[types.Part(text="now add another column")]),
+            types.Content(role="model", parts=[types.Part(text="Sure, which column?")]),
+        ]
+    )
+    summaries = {"71cbbc6d": "Re-extraction finished. 37 of 40 rows filled."}
+    messages = ChatAgentService._reconstruct_transcript(history, summaries)
+
+    contents = [m.get("content", "") for m in messages]
+    i_ack = contents.index("Re-extraction started.")
+    i_sum = next(i for i, c in enumerate(contents) if "37 of 40" in c)
+    i_later = contents.index("now add another column")
+    assert i_ack < i_sum < i_later
+
+
+def test_summary_without_following_model_text_is_still_emitted():
+    history = _roundtrip(_reextract_call("z9", ack=None))
+    messages = ChatAgentService._reconstruct_transcript(history, {"z9": "LEFTOVER"})
+    assert any("LEFTOVER" in (m.get("content") or "") for m in messages)
+
+
+def test_two_operations_same_column_anchor_distinctly_by_id():
+    history = _roundtrip(
+        [
+            *_reextract_call("aaa", ack="Started A."),
+            *_reextract_call("bbb", ack="Started B."),
+        ]
+    )
+    messages = ChatAgentService._reconstruct_transcript(
+        history, {"aaa": "SUM_A", "bbb": "SUM_B"}
+    )
+    contents = [m.get("content", "") for m in messages]
+    assert contents.index("Started A.") < contents.index("SUM_A")
+    assert contents.index("SUM_A") < contents.index("Started B.")
+    assert contents.index("Started B.") < contents.index("SUM_B")
+
+
+def test_empty_summary_map_injects_nothing():
+    history = _roundtrip(_reextract_call("op1"))
+    with_summary = ChatAgentService._reconstruct_transcript(history, {"op1": "S"})
+    without = ChatAgentService._reconstruct_transcript(history, {})
+    assert len(with_summary) == len(without) + 1
+    assert not any("S" == (m.get("content") or "") for m in without)
+
+
+def test_reference_fill_anchored_by_fill_id():
+    history = _roundtrip(
+        [
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part.from_function_response(
+                        name="fill_column_from_reference",
+                        response={"result": {"status": "started", "fill_id": "f1"}},
+                    )
+                ],
+            ),
+            types.Content(role="model", parts=[types.Part(text="Filling started.")]),
+        ]
+    )
+    messages = ChatAgentService._reconstruct_transcript(history, {"f1": "FILL_SUM"})
+    contents = [m.get("content", "") for m in messages]
+    assert contents.index("Filling started.") < contents.index("FILL_SUM")
+
+
+def test_no_summary_for_unrelated_tool_result():
+    """A tool result without operation_id/fill_id must not pull in any summary."""
+    history = _roundtrip(
+        [
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part.from_function_response(
+                        name="add_column", response={"result": {"message": "ok"}}
+                    )
+                ],
+            ),
+        ]
+    )
+    messages = ChatAgentService._reconstruct_transcript(history, {"x": "should-not-appear"})
+    assert not any("should-not-appear" in (m.get("content") or "") for m in messages)
+
+
+def test_injected_summaries_validate_as_chat_turn_messages():
+    history = _roundtrip(_reextract_call("op1"))
+    for msg in ChatAgentService._reconstruct_transcript(history, {"op1": "recap text"}):
+        ChatTurnMessage(**msg)  # raises if a field is missing or mistyped
+
+
+def test_summary_id_extraction_handles_missing_and_malformed():
+    extract = ChatAgentService._summary_id_from_function_response
+    # A plain text part has no function_response.
+    assert extract(types.Part(text="hi")) is None
+    # A function_response with operation_id.
+    op_part = types.Part.from_function_response(
+        name="reextract", response={"result": {"operation_id": "op7"}}
+    )
+    assert extract(op_part) == "op7"
+    # A function_response with fill_id.
+    fill_part = types.Part.from_function_response(
+        name="fill_column_from_reference", response={"result": {"fill_id": "f7"}}
+    )
+    assert extract(fill_part) == "f7"
+    # A function_response with neither id.
+    plain = types.Part.from_function_response(
+        name="add_column", response={"result": {"message": "ok"}}
+    )
+    assert extract(plain) is None


### PR DESCRIPTION
## Problem
Re-extraction and reference-fill recaps are produced by background operations and pushed to the client over the WebSocket. They never enter the Gemini model history, so the transcript reconstruction added in #476/#478 (which reads only the persisted model history) cannot restore them — after a reload, these summaries vanish, even though the surrounding conversation is restored.

## Solution
Persist each recap in a small per-session store (`chat_summary_store`), one file per summary, keyed by its operation id (`operation_id` for re-extraction, `fill_id` for reference fill). That id **already exists** in the persisted model history — inside the `function_response` of the tool call that started the operation — so no new ordering metadata is needed. On reload, `_reconstruct_transcript` reads the summary map and splices each summary in right after the model's acknowledgement of its originating tool call, reproducing the exact chronological order the user saw live. The anchor is exact (unique id), not heuristic, so it is correct even when the user keeps chatting afterward or re-extracts the same column twice.

- New `chat_summary_store.py`: separate file per summary (no read-modify-write race), same opt-out gate as model-history persistence, strictly best-effort.
- `reextraction_service` / `reference_fill_service`: persist the recap at completion, alongside the existing broadcast.
- `agent_service`: load summaries in `get_transcript`; anchor them in `_reconstruct_transcript`.
- **No format change** to the existing `chat_history.json`; **no frontend change** (#478 already repaints whatever the endpoint returns).

## Verify
- `git apply --ignore-whitespace --check` — clean on current main
- `python -m py_compile` on all five files — OK
- `pytest tests/test_chat_summary_anchoring.py` — 8 cases: exact placement, no-following-text, two ops on same column, empty map, fill_id, unrelated tool result, model validation, id extraction
- Existing `tests/test_chat_messages_endpoint.py` still passes (reconstruction's new `summaries` arg is optional)

Manual: from chat, add a column and run `reextract`; wait for the summary; send another message; reload. The summary reappears in its original position.