### PR TITLE
feat(llm): default schema creation + chat to Gemini 3.7 Flash

### DIFF
--- a/backend/app/services/chat/deps.py
+++ b/backend/app/services/chat/deps.py
@@ -58,7 +58,7 @@ reference_fill_service = ReferenceFillService(
     schematiq_runner=schematiq_runner,
 )
 
-CHAT_MODEL = ModelNames.GEMINI_36_FLASH
+CHAT_MODEL = ModelNames.GEMINI_37_FLASH
 WORK_DIR = Path(DEFAULT_SCHEMATIQ_WORK_DIR)
 
 

--- a/frontend/src/constants/llmModels.ts
+++ b/frontend/src/constants/llmModels.ts
@@ -103,7 +103,16 @@ export const LLM_MODELS: LLMModelDefinition[] = [
     id: 'gemini-3.6-flash',
     provider: 'gemini',
     label: 'Gemini 3.6 Flash',
-    description: 'Latest Flash: better token efficiency and agentic planning at lower cost than 3.5 Flash',
+    description: 'Better token efficiency and agentic planning at lower cost than 3.5 Flash',
+    cost: 'medium',
+    speed: 'fast',
+    contextWindow: 1000000,
+  },
+  {
+    id: 'gemini-3.7-flash',
+    provider: 'gemini',
+    label: 'Gemini 3.7 Flash',
+    description: 'Latest Flash: improved agentic planning and instruction-following over 3.6 Flash',
     cost: 'medium',
     speed: 'fast',
     isDefault: true,
@@ -132,7 +141,7 @@ export const LLM_MODELS: LLMModelDefinition[] = [
 ];
 
 // ── Default model constants ─────────────────────────────────────────
-export const DEFAULT_SCHEMA_MODEL = 'gemini-3.6-flash';
+export const DEFAULT_SCHEMA_MODEL = 'gemini-3.7-flash';
 export const DEFAULT_EXTRACTION_MODEL = 'gemini-3.5-flash-lite';
 export const DEFAULT_RELEASE_EXTRACTION_MODEL = 'gemini-3.5-flash-lite';
 

--- a/schematiq-lib/schematiq/core/model_specs.py
+++ b/schematiq-lib/schematiq/core/model_specs.py
@@ -55,6 +55,7 @@ class ModelNames:
     GEMINI_35_FLASH = "gemini-3.5-flash"
     GEMINI_35_FLASH_LITE = "gemini-3.5-flash-lite"
     GEMINI_36_FLASH = "gemini-3.6-flash"
+    GEMINI_37_FLASH = "gemini-3.7-flash"
     GEMINI_31_PRO_PREVIEW = "gemini-3.1-pro-preview"
     GEMINI_15_FLASH = "gemini-1.5-flash"
 
@@ -77,7 +78,7 @@ class ModelNames:
     TIKTOKEN_ENCODING_MODEL = "gpt-4o"
 
     # Role-based defaults
-    DEFAULT_SCHEMA_CREATION = GEMINI_36_FLASH
+    DEFAULT_SCHEMA_CREATION = GEMINI_37_FLASH
     DEFAULT_VALUE_EXTRACTION = GEMINI_35_FLASH_LITE
     DEFAULT_RELEASE_EXTRACTION = GEMINI_35_FLASH_LITE
     DEFAULT_EVALUATION = GEMINI_15_FLASH
@@ -107,6 +108,12 @@ MODEL_SPECS: Dict[str, Dict[str, ModelSpec]] = {
             fallback_thinking_level="medium",
         ),
         ModelNames.GEMINI_36_FLASH: ModelSpec(
+            1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True,
+            supports_sampling_params=False,
+            allowed_thinking_levels=("low", "medium", "high"),
+            fallback_thinking_level="medium",
+        ),
+        ModelNames.GEMINI_37_FLASH: ModelSpec(
             1_048_576, 65_536, supports_thinking=True, uses_thinking_level=True,
             supports_sampling_params=False,
             allowed_thinking_levels=("low", "medium", "high"),

--- a/schematiq-lib/schematiq/core/pricing_config.json
+++ b/schematiq-lib/schematiq/core/pricing_config.json
@@ -65,6 +65,11 @@
           "output": 9.00,
           "context_window": 1048576
         },
+        "gemini-3.7-flash": {
+          "input": 1.50,
+          "output": 9.00,
+          "context_window": 1048576
+        },
         "gemini-3.1-pro-preview": {
           "input": 2.00,
           "output": 12.00,


### PR DESCRIPTION
## Problem
Gemini 3.7 Flash was released but the app still defaults schema creation and chat to 3.6.

## Solution
- Add `gemini-3.7-flash` to `ModelNames`, `MODEL_SPECS`, `pricing_config.json`, and the frontend model catalog (same spec/pricing as 3.6 as a starting point — adjust if Google publishes different numbers).
- Switch `DEFAULT_SCHEMA_CREATION` and `CHAT_MODEL` to 3.7.
- Value extraction (`DEFAULT_VALUE_EXTRACTION` / `DEFAULT_RELEASE_EXTRACTION`) is untouched — still 3.5-flash-lite.
- 3.6 stays in the catalog and specs, just no longer the default, so existing saved configs keep working.

## Verify
- `git apply --ignore-whitespace --check` on clean main
- `( cd frontend && npx tsc --noEmit )` — 0 errors
- `python -m py_compile` on touched backend/lib files
- Manually confirmed `ModelNames.DEFAULT_SCHEMA_CREATION == 'gemini-3.7-flash'` and value-extraction defaults unchanged