### PR TITLE
feat(chat): really stop an in-flight chat turn

### DIFF
--- a/backend/app/api/routes/chat.py
+++ b/backend/app/api/routes/chat.py
@@ -153,3 +153,16 @@ async def cancel_chat_action(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/{session_id}/stop")
+async def stop_chat_turn(session_id: str) -> dict[str, bool]:
+    """Halt the in-flight chat turn for a session.
+
+    Fire-and-forget companion to the client aborting its request: the run loop
+    checks a cooperative flag at its next step boundary, then discards the turn
+    without persisting it. Returns ``stopped`` = whether a live turn existed.
+    """
+    _require_session(session_id)
+    stopped = chat_agent_service.request_stop(session_id)
+    return {"stopped": stopped}

--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -265,11 +265,15 @@ class ChatAgentService:
         if pinned_tool:
             user_text = f"[User suggested tool: {pinned_tool}]\n{message}"
 
+        # A fresh turn clears any stale Stop intent from a prior turn.
+        state.stop_requested = False
         try:
             await self._ensure_quota_available()
             result = await self._run_loop(state, user_text, outbound_messages)
             if result["status"] == "complete":
                 await self._persist_history(state)
+            elif result["status"] == "stopped":
+                self._discard_stopped_turn(state)
             return {
                 "chat_id": state.chat_id,
                 "status": result["status"],
@@ -295,9 +299,12 @@ class ChatAgentService:
                 state = await self._get_or_create_session(
                     session_id, session_mode, None, model
                 )
+                state.stop_requested = False
                 result = await self._run_loop(state, user_text, outbound_messages)
                 if result["status"] == "complete":
                     await self._persist_history(state)
+                elif result["status"] == "stopped":
+                    self._discard_stopped_turn(state)
                 return {
                     "chat_id": state.chat_id,
                     "status": result["status"],
@@ -335,6 +342,8 @@ class ChatAgentService:
 
         pending = state.pending
         state.pending = None
+        # A confirmation resumes the turn, so clear any stale Stop intent first.
+        state.stop_requested = False
         outbound_messages: list[dict[str, Any]] = []
         await self._emit(state, outbound_messages,
             self._tool_log(pending.tool_name, "running", f"...{tool_running_label(pending.tool_name).lower()}")
@@ -382,6 +391,8 @@ class ChatAgentService:
             loop_result = await self._continue_after_tool(state, response, outbound_messages)
             if loop_result["status"] == "complete":
                 await self._persist_history(state)
+            elif loop_result["status"] == "stopped":
+                self._discard_stopped_turn(state)
             return {
                 "chat_id": chat_id,
                 "status": loop_result["status"],
@@ -419,6 +430,32 @@ class ChatAgentService:
             "messages": outbound_messages,
             "pending_action": new_pending,
         }
+
+    def request_stop(self, session_id: str) -> bool:
+        """Ask the in-flight turn for a workspace session to halt.
+
+        Sets a cooperative flag the run loop checks at its next step boundary.
+        Fire-and-forget from the client's side: the HTTP turn is already being
+        abandoned, so this only tells the backend to stop working and discard
+        the turn. Returns whether a live chat existed to signal.
+        """
+        state = chat_session_store.get_by_workspace_session(session_id)
+        if state is None:
+            return False
+        state.stop_requested = True
+        return True
+
+    def _discard_stopped_turn(self, state: ChatSessionState) -> None:
+        """Drop the in-memory chat so a stopped turn leaves no trace.
+
+        The turn is not persisted, and the live SDK chat may hold a model
+        function call whose response was never sent (we bailed before running
+        the tool). Deleting the chat forces the next message to rebuild from the
+        last *completed* persisted history, so the discarded turn cannot corrupt
+        the balanced-history invariant the SDK requires.
+        """
+        if state.chat_id:
+            chat_session_store.delete(state.chat_id)
 
     async def _abort_pending(
         self,
@@ -834,6 +871,13 @@ class ChatAgentService:
         outbound_messages: list[dict[str, Any]],
     ) -> dict[str, Any]:
         for _ in range(MAX_TOOL_ITERATIONS):
+            # Bail at the step boundary if the user pressed Stop. This is a safe
+            # point: any tool batch from a previous iteration already sent its
+            # function responses, so the SDK chat is balanced. The turn is
+            # discarded by the caller (no persist), so an unanswered function
+            # call sitting in `response` here is dropped with it.
+            if state.stop_requested:
+                return {"status": "stopped"}
             function_calls = getattr(response, "function_calls", None) or []
             if function_calls:
                 # Execute every tool call the model issued this turn. The model often
@@ -921,6 +965,10 @@ class ChatAgentService:
 
             text = (getattr(response, "text", None) or "").strip()
             if text:
+                # A Stop that arrived while this reply was being generated drops
+                # the answer instead of emitting it.
+                if state.stop_requested:
+                    return {"status": "stopped"}
                 await self._emit(state, outbound_messages, self._text_message(text))
                 return {"status": "complete"}
 

--- a/backend/app/services/chat/session_store.py
+++ b/backend/app/services/chat/session_store.py
@@ -29,6 +29,10 @@ class ChatSessionState:
     # Gemini calls made since the last quota flush (chat bypasses the
     # schematiq LLM backends, so calls are counted here explicitly).
     pending_llm_calls: int = 0
+    # Set by a Stop request to cooperatively halt the running turn. The run loop
+    # checks it at step boundaries and bails without persisting, so the turn is
+    # discarded rather than half-committed. Reset at the start of every turn.
+    stop_requested: bool = False
 
 
 class ChatSessionStore:

--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -2,7 +2,7 @@
 // Parent: Workspace (index.tsx).
 
 import { type ChangeEvent, type DragEvent, useCallback, useEffect, useRef, useState } from 'react';
-import { ArrowUp, Bot, Check, FileText, Loader2, Paperclip, X } from 'lucide-react';
+import { ArrowUp, Bot, Check, FileText, Loader2, Paperclip, Square, X } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -29,6 +29,7 @@ import { formatToolsList, mapChatTurnMessage } from '../helpers';
 import type { PendingChatAction, PendingRerunKind, WorkspaceMessage, WorkspaceSessionMode } from '../types';
 import { ChatMessageBody } from './ChatMessageBody';
 import { ToolActivityGroup } from './ToolActivityGroup';
+import { useChatTurn } from './hooks/useChatTurn';
 
 // Fold a flat message list into render groups so that consecutive tool_log
 // messages collapse into a single expandable block, while text/user messages
@@ -84,7 +85,10 @@ export function ChatPanel({
     },
   ]);
   const [input, setInput] = useState('');
-  const [busy, setBusy] = useState(false);
+  // The chat turn lifecycle (busy flag + abort wiring) lives in its own hook so
+  // Stop can cancel the in-flight request and every handler shares one busy
+  // source instead of toggling it by hand.
+  const { busy, runTurn, stop } = useChatTurn();
   const [chatId, setChatId] = useState<string | null>(null);
   const [chatModel, setChatModel] = useState<string>(() => getDefaultModelForProvider('gemini'));
   const [pinnedTool, setPinnedTool] = useState<string | null>(null);
@@ -104,6 +108,10 @@ export function ChatPanel({
   // Flips true once the user drives the conversation, so a late-arriving history
   // load can't clobber messages they've already produced this session.
   const conversationStartedRef = useRef(false);
+  // Set when the user presses Stop: the backend may still emit a message or two
+  // from the step that was already running, so drop live chat_message events
+  // until the next turn starts rather than letting the stopped reply trickle in.
+  const suppressStreamRef = useRef(false);
 
   useEffect(() => {
     const container = messagesRef.current;
@@ -283,7 +291,9 @@ export function ChatPanel({
       if (message.type === 'chat_message' && message.data) {
         // Emitted by agent_service as each assistant/tool message is produced,
         // so the panel fills in while the turn is still running instead of
-        // staying empty until the HTTP response returns.
+        // staying empty until the HTTP response returns. After a Stop we ignore
+        // these so the halted turn's reply does not keep landing.
+        if (suppressStreamRef.current) return;
         appendMessages([mapChatTurnMessage(message.data as unknown as ChatTurnMessage)]);
       } else if (message.type === 'reference_fill_started') {
         const data = (message.data ?? {}) as unknown as { column?: string };
@@ -412,9 +422,9 @@ export function ChatPanel({
   }, [appendMessages, onEditFollowUp, onRefresh]);
 
   const showToolsList = useCallback(async () => {
-    setBusy(true);
     try {
-      const tools = await loadTools();
+      const tools = await runTurn(() => loadTools());
+      if (!tools) return; // stopped
       appendMessages([
         {
           id: `${Date.now()}-tools`,
@@ -430,10 +440,8 @@ export function ChatPanel({
           content: err?.response?.data?.detail || err?.message || 'Could not load tools.',
         },
       ]);
-    } finally {
-      setBusy(false);
     }
-  }, [appendMessages, loadTools]);
+  }, [appendMessages, loadTools, runTurn]);
 
   const ask = useCallback(async () => {
     const text = input.trim();
@@ -460,16 +468,24 @@ export function ChatPanel({
       return;
     }
 
-    setBusy(true);
+    // A new turn re-opens the live stream that a prior Stop had muted.
+    suppressStreamRef.current = false;
     try {
-      const response = await chatAPI.sendMessage(sessionId, {
-        message: text,
-        chat_id: chatId || undefined,
-        session_mode: sessionMode,
-        pinned_tool: pinnedTool || undefined,
-        model: chatModel || undefined,
-      });
-      applyChatResponse(response);
+      const response = await runTurn((signal) =>
+        chatAPI.sendMessage(
+          sessionId,
+          {
+            message: text,
+            chat_id: chatId || undefined,
+            session_mode: sessionMode,
+            pinned_tool: pinnedTool || undefined,
+            model: chatModel || undefined,
+          },
+          signal,
+        ),
+      );
+      // null means the user pressed Stop; leave the transcript as-is.
+      if (response) applyChatResponse(response);
     } catch (err: any) {
       appendMessages([
         {
@@ -478,16 +494,16 @@ export function ChatPanel({
           content: err?.response?.data?.detail || err?.message || 'That workspace action failed.',
         },
       ]);
-    } finally {
-      setBusy(false);
     }
   }, [
     appendMessages,
     applyChatResponse,
     busy,
     chatId,
+    chatModel,
     input,
     pinnedTool,
+    runTurn,
     sessionId,
     sessionMode,
     showToolsList,
@@ -495,10 +511,12 @@ export function ChatPanel({
 
   const confirmPendingAction = useCallback(async () => {
     if (!pendingAction || !sessionId) return;
-    setBusy(true);
+    suppressStreamRef.current = false;
     try {
-      const response = await chatAPI.confirmAction(sessionId, pendingAction.chatId);
-      applyChatResponse(response);
+      const response = await runTurn((signal) =>
+        chatAPI.confirmAction(sessionId, pendingAction.chatId, signal),
+      );
+      if (response) applyChatResponse(response); // null => stopped
     } catch (err: any) {
       appendMessages([
         {
@@ -507,16 +525,16 @@ export function ChatPanel({
           content: err?.response?.data?.detail || err?.message || 'The confirmed action failed.',
         },
       ]);
-    } finally {
-      setBusy(false);
     }
-  }, [appendMessages, applyChatResponse, pendingAction, sessionId]);
+  }, [appendMessages, applyChatResponse, pendingAction, runTurn, sessionId]);
 
   const cancelPendingAction = useCallback(async (): Promise<boolean> => {
     if (!pendingAction || !sessionId) return true;
-    setBusy(true);
     try {
-      const response = await chatAPI.cancelAction(sessionId, pendingAction.chatId);
+      const response = await runTurn(() =>
+        chatAPI.cancelAction(sessionId, pendingAction.chatId),
+      );
+      if (!response) return false; // stopped; the pending action still stands
       setPendingAction(null);
       applyChatResponse(response);
       return true;
@@ -532,10 +550,22 @@ export function ChatPanel({
         },
       ]);
       return false;
-    } finally {
-      setBusy(false);
     }
-  }, [appendMessages, applyChatResponse, pendingAction, sessionId]);
+  }, [appendMessages, applyChatResponse, pendingAction, runTurn, sessionId]);
+
+  // Stop the running turn: mute the live stream so the halted reply stops
+  // landing, abort the client's wait so the composer frees up immediately, and
+  // tell the backend to bail and discard the turn. The backend call is
+  // best-effort -- the UI is already unblocked regardless of its outcome.
+  const handleStop = useCallback(() => {
+    suppressStreamRef.current = true;
+    stop();
+    if (sessionId) {
+      chatAPI.stopChat(sessionId).catch(() => {
+        // Best-effort: the turn ends server-side on its own if this misses.
+      });
+    }
+  }, [sessionId, stop]);
 
   useEffect(() => {
     if (!onRegisterCancelPending) return;
@@ -749,21 +779,31 @@ export function ChatPanel({
             )}
             Attach reference
           </Button>
-          <Button
-            type="button"
-            size="icon"
-            onClick={ask}
-            disabled={busy || !input.trim()}
-            className="ml-auto h-8 w-8 rounded-lg"
-            aria-label="Send message"
-            title="Send message (Enter)"
-          >
-            {busy ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
+          {busy ? (
+            <Button
+              type="button"
+              size="icon"
+              variant="destructive"
+              onClick={handleStop}
+              className="ml-auto h-8 w-8 rounded-lg"
+              aria-label="Stop"
+              title="Stop"
+            >
+              <Square className="h-4 w-4" />
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              size="icon"
+              onClick={ask}
+              disabled={!input.trim()}
+              className="ml-auto h-8 w-8 rounded-lg"
+              aria-label="Send message"
+              title="Send message (Enter)"
+            >
               <ArrowUp className="h-4 w-4" />
-            )}
-          </Button>
+            </Button>
+          )}
         </div>
       </div>
     </aside>

--- a/frontend/src/pages/Workspace/chat/hooks/useChatTurn.ts
+++ b/frontend/src/pages/Workspace/chat/hooks/useChatTurn.ts
@@ -1,0 +1,57 @@
+// Owns the lifecycle of a single chat "turn" -- the window between the user
+// sending something and the agent's reply landing. Centralising it here keeps
+// the busy flag and the cancel wiring in one place (instead of duplicated in
+// every ChatPanel handler) and gives future turn-level features -- retry,
+// streaming, per-turn state -- a single seam to hang off.
+import { useCallback, useRef, useState } from 'react';
+
+export interface ChatTurnController {
+  // True while a turn is in flight. Drives the composer's disabled state and
+  // the Send/Stop button swap.
+  busy: boolean;
+  // Runs one turn. `work` receives an AbortSignal to thread into its request so
+  // Stop can abort the wait. Resolves to the work's value, or null when the
+  // user stopped the turn -- callers treat null as "stopped" and skip their
+  // success handling rather than surfacing it as an error.
+  runTurn: <T>(work: (signal: AbortSignal) => Promise<T>) => Promise<T | null>;
+  // Aborts the in-flight turn, if any. A no-op when idle.
+  stop: () => void;
+}
+
+export function useChatTurn(): ChatTurnController {
+  const [busy, setBusy] = useState(false);
+  // Only one turn runs at a time (the composer is disabled while busy), so a
+  // single controller ref is enough to route Stop to the active request.
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const stop = useCallback(() => {
+    controllerRef.current?.abort();
+  }, []);
+
+  const runTurn = useCallback(
+    async <T>(work: (signal: AbortSignal) => Promise<T>): Promise<T | null> => {
+      const controller = new AbortController();
+      controllerRef.current = controller;
+      setBusy(true);
+      try {
+        return await work(controller.signal);
+      } catch (error) {
+        // A user-initiated Stop surfaces as a rejected request; swallow it and
+        // report "stopped" via null so callers don't render it as a failure.
+        // Any other rejection is a real error and propagates to the caller.
+        if (controller.signal.aborted) return null;
+        throw error;
+      } finally {
+        // Guard against a fast re-send having already installed a newer
+        // controller: only the turn that owns the current ref clears state.
+        if (controllerRef.current === controller) {
+          controllerRef.current = null;
+          setBusy(false);
+        }
+      }
+    },
+    [],
+  );
+
+  return { busy, runTurn, stop };
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1127,16 +1127,18 @@ export const chatAPI = {
       pinned_tool?: string;
       model?: string;
     },
+    signal?: AbortSignal,
   ): Promise<ChatMessageResponse> => {
-    const response = await api.post(`/chat/${sessionId}/message`, payload, { timeout: CHAT_REQUEST_TIMEOUT_MS });
+    const response = await api.post(`/chat/${sessionId}/message`, payload, { timeout: CHAT_REQUEST_TIMEOUT_MS, signal });
     return response.data;
   },
 
   confirmAction: async (
     sessionId: string,
     chatId: string,
+    signal?: AbortSignal,
   ): Promise<ChatMessageResponse> => {
-    const response = await api.post(`/chat/${sessionId}/confirm`, { chat_id: chatId }, { timeout: CHAT_REQUEST_TIMEOUT_MS });
+    const response = await api.post(`/chat/${sessionId}/confirm`, { chat_id: chatId }, { timeout: CHAT_REQUEST_TIMEOUT_MS, signal });
     return response.data;
   },
 
@@ -1145,6 +1147,14 @@ export const chatAPI = {
     chatId: string,
   ): Promise<ChatMessageResponse> => {
     const response = await api.post(`/chat/${sessionId}/cancel`, { chat_id: chatId });
+    return response.data;
+  },
+
+  // Tells the backend to halt the in-flight turn and discard it. Fire-and-forget:
+  // the client aborts its own request separately, so a failure here only means
+  // the server keeps working until the turn ends on its own.
+  stopChat: async (sessionId: string): Promise<{ stopped: boolean }> => {
+    const response = await api.post(`/chat/${sessionId}/stop`);
     return response.data;
   },
 };


### PR DESCRIPTION
## Problem
The Stop button only aborted the client's HTTP wait. The backend kept running the turn to completion, its messages kept streaming over the WebSocket, and the turn was persisted, so the reply still appeared (and returned on refresh).

## Solution
Cooperative server-side cancellation. A `stop_requested` flag on the chat session is checked at run-loop step boundaries and before the final text emit, returning a `stopped` status. A stopped turn is discarded: the in-memory chat is deleted and not persisted, so the next message rebuilds from the last completed history and the SDK's function-call/response history stays balanced (no dangling tool call). `POST /chat/{session_id}/stop` sets the flag. On the client, the turn lifecycle (busy + AbortController) moves into a `useChatTurn` hook; Stop mutes the live WS stream, aborts the wait, and calls the stop endpoint.

Known limits: a Stop after the reply already emitted cannot un-send what is already on screen (only later messages are muted); a mutation tool that finished before Stop has already written to the DB.

## Verify
- `git apply --ignore-whitespace` on a clean clone of main
- `cd frontend && npx tsc --noEmit` passes; `python -m py_compile` on the three backend files passes
- Send a long message, press Stop mid-run: the red Stop reverts to Send, the input re-enables, no further assistant/tool messages land, and refreshing the project does not resurrect the stopped turn.