### PR TITLE
fix(workspace): hide Thinking indicator once assistant reply is on screen

### DIFF
--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -577,6 +577,15 @@ export function ChatPanel({
     return () => onRegisterCancelPending(null);
   }, [cancelPendingAction, onRegisterCancelPending, pendingAction]);
 
+  // The assistant reply streams in over the WebSocket before the HTTP turn
+  // resolves and clears `busy`, so gating the "Thinking…" indicator on `busy`
+  // alone leaves it rendered below the reply until the response returns. Once a
+  // non-tool assistant message is the latest entry the reply is already on
+  // screen, so hide the indicator immediately instead of waiting for `busy`.
+  const lastMessage = messages[messages.length - 1];
+  const assistantHasReplied =
+    lastMessage?.role === 'assistant' && lastMessage.kind !== 'tool_log';
+
   return (
     <aside
       className="workspace-chat"
@@ -646,7 +655,7 @@ export function ChatPanel({
           ),
         )}
 
-        {busy && (
+        {busy && !assistantHasReplied && (
           <div className="workspace-chat-message" data-role="assistant">
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <img


### PR DESCRIPTION
Problem: The chat 'Thinking…' indicator is gated on `busy` alone. The assistant reply streams in over the WebSocket before the HTTP turn resolves and clears `busy`, so the indicator stays rendered below the completed reply until the response returns (confirmed on a screen recording: reply fully shown with 'Thinking…' still beneath it and the send button still spinning).

Solution: Track whether the latest message is a non-tool assistant reply (`assistantHasReplied`) and gate the indicator on `busy && !assistantHasReplied`. It still shows while tools run (latest message is a `tool_log`) and while waiting on the user turn.

Verify: `git apply --ignore-whitespace` check passes on clean main; `cd frontend && npx tsc --noEmit` clean. Manually: send a chat message, confirm 'Thinking…' disappears as the reply appears rather than lingering below it.