### PR TITLE
fix(dev): honor STORAGE_BACKEND from .env in dev.sh

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -13,9 +13,27 @@ set -euo pipefail
 #    ./dev.sh 1      -> instance 1: backend 8001, frontend 3001
 #    ./dev.sh 2      -> instance 2: backend 8002, frontend 3002
 #  Ctrl+C stops both processes for that instance.
+#
+#  Storage backend:
+#    By default the backend honors STORAGE_BACKEND from backend/.env, so if
+#    that file selects Supabase you get the shared cloud datasets. Pass --local
+#    (or LOCAL=1) to force local, isolated per-instance storage instead — use
+#    that when running several instances at once so they don't share state.
+#    ./dev.sh --local     -> instance 0, forced local storage
+#    ./dev.sh 1 --local   -> instance 1, forced local storage
 # ============================================================
 
-N="${1:-0}"
+# Parse args: an optional instance number (positional) and an optional --local
+# flag, in any order. LOCAL=1 in the environment is equivalent to --local.
+N=0
+FORCE_LOCAL="${LOCAL:-0}"
+for arg in "$@"; do
+  case "$arg" in
+    --local) FORCE_LOCAL=1 ;;
+    *[!0-9]*) echo "error: unknown argument '$arg'" >&2; exit 1 ;;
+    *) N="$arg" ;;
+  esac
+done
 BACK_PORT="${BACK_PORT:-$((8000 + N))}"
 FRONT_PORT="${FRONT_PORT:-$((3000 + N))}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -65,16 +83,29 @@ echo "=================================================="
 echo " instance $N   (branch: $BRANCH)"
 echo "   backend  -> http://localhost:$BACK_PORT"
 echo "   frontend -> http://localhost:$FRONT_PORT"
-echo "   storage  -> local (isolated): $DATA_DIR"
+if [[ "$FORCE_LOCAL" == "1" ]]; then
+  echo "   storage  -> local (isolated, forced): $DATA_DIR"
+else
+  echo "   storage  -> from backend/.env (Supabase datasets if configured)"
+fi
 echo "=================================================="
 
 # Backend: run from isolated DATA_DIR; .env still loads from backend/ via __file__ in main.py.
-# STORAGE_BACKEND=local overrides supabase in backend/.env for per-instance isolation.
+# By default we leave STORAGE_BACKEND unset here so backend/.env decides (Supabase
+# gives shared cloud datasets). With --local we export STORAGE_BACKEND=local to
+# override .env and keep per-instance isolation.
+#
+# NOTE ON ISOLATION: --local isolates the writable state (sessions/data/exports)
+# per instance. Honoring a Supabase .env means multiple instances share one
+# cloud backend and therefore share that state; run --local when you need
+# several isolated instances at once.
 (
   cd "$DATA_DIR"
+  if [[ "$FORCE_LOCAL" == "1" ]]; then
+    export STORAGE_BACKEND="local"
+  fi
   PATH="$VENV/bin:$PATH" \
   PYTHONPATH="$ROOT/backend" \
-  STORAGE_BACKEND="local" \
   ALLOWED_ORIGINS="http://localhost:$FRONT_PORT,http://127.0.0.1:$FRONT_PORT" \
   "$VENV/bin/python" -m uvicorn app.main:app --reload --reload-dir "$ROOT/backend/app" --port "$BACK_PORT"
 ) &


### PR DESCRIPTION
## Problem
`dev.sh` hard-coded `STORAGE_BACKEND=local` on the backend launch line, which overrides whatever `backend/.env` sets (dotenv does not override existing env vars). Running `./dev.sh` therefore always started local storage, so the Supabase cloud datasets never appeared in the picker — even with SUPABASE_URL/SUPABASE_KEY correctly set in .env.

## Solution
Make local an opt-in override rather than the default:
- `./dev.sh` now leaves STORAGE_BACKEND unset so `backend/.env` decides (Supabase datasets show up).
- `./dev.sh --local` / `LOCAL=1 ./dev.sh` forces local, isolated per-instance storage — the previous behavior, for running multiple instances at once.
- Instance-number arg still works in any position (`./dev.sh 1 --local`).
- Startup banner reflects the active storage mode.

Only `dev.sh` changes; no backend/frontend code touched.

## Verify
- `bash -n dev.sh` passes
- Arg parsing tested for: no args, instance number, --local, combined, LOCAL=1 env, and invalid arg
- `git apply --ignore-whitespace --check` passes on a fresh clone at current main tip