### PR TITLE
refactor(reextraction): unify concurrency-slot guard around gated re-extraction

### DIFF
--- a/backend/app/api/routes/schema.py
+++ b/backend/app/api/routes/schema.py
@@ -492,23 +492,17 @@ async def reprocess_documents(
             if not any(col.name == col_name for col in session.columns):
                 raise HTTPException(status_code=404, detail=f"Column '{col_name}' not found")
 
-        # Reserve a concurrency slot
-        await concurrency_limiter.acquire(session_id, "reextraction")
-
-        try:
-            # Shared gated entry point (same as POST /reextract): the legacy
-            # reprocess_documents path silently no-ops on the Supabase backend,
-            # so route through the gated path, which materializes documents first.
-            scope = "explicit" if reprocess_request.columns else "all"
-            result = await reextraction_service.start_gated_reextraction(
-                session_id,
-                columns=reprocess_request.columns,
-                scope=scope,
-            )
-        except Exception:
-            # Release slot if the gated start fails before creating its task
-            await concurrency_limiter.release(session_id)
-            raise
+        # Shared gated entry point (same as POST /reextract): the legacy
+        # reprocess_documents path silently no-ops on the Supabase backend,
+        # so route through the gated path, which materializes documents first.
+        # start_gated_reextraction_guarded reserves the concurrency slot and
+        # releases it if the gated start fails before spawning its task.
+        scope = "explicit" if reprocess_request.columns else "all"
+        result = await reextraction_service.start_gated_reextraction_guarded(
+            session_id,
+            columns=reprocess_request.columns,
+            scope=scope,
+        )
 
         return result
 
@@ -1031,21 +1025,15 @@ async def start_reextraction(
             has_api_key = 'api_key' in request.llm_config and request.llm_config['api_key']
             logger.debug(f"Saved user LLM config for re-extraction: {config_for_log}, api_key={'present' if has_api_key else 'MISSING'}")
 
-        # Reserve a concurrency slot
-        await concurrency_limiter.acquire(session_id, "reextraction")
-
-        try:
-            # Shared gated entry point (also used by the chat reextract tool):
-            # scope resolution + baseline capture + document precheck + start.
-            result = await reextraction_service.start_gated_reextraction(
-                session_id,
-                columns=request.columns,
-                scope="explicit",
-            )
-        except Exception:
-            # Release slot if the gated start fails before creating its task
-            await concurrency_limiter.release(session_id)
-            raise
+        # Shared gated entry point (also used by the chat reextract tool):
+        # scope resolution + baseline capture + document precheck + start.
+        # start_gated_reextraction_guarded reserves the concurrency slot and
+        # releases it if the gated start fails before spawning its task.
+        result = await reextraction_service.start_gated_reextraction_guarded(
+            session_id,
+            columns=request.columns,
+            scope="explicit",
+        )
 
         return ReextractionResponse(**result)
 

--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -1046,17 +1046,11 @@ class ToolExecutor:
       # Funnel through the same gated entry point as the manual workspace
       # button: scope resolution (explicit / all / edited_only), baseline
       # capture, document precheck, then start. Keeps both routes identical.
-      await concurrency_limiter.acquire(session_id, "reextraction")
-      try:
-          result = await reextraction_service.start_gated_reextraction(
-              session_id,
-              columns=args.get("columns"),
-              scope=args.get("scope", "edited_only"),
-          )
-      except Exception:
-          await concurrency_limiter.release(session_id)
-          raise
-      return result
+      return await reextraction_service.start_gated_reextraction_guarded(
+          session_id,
+          columns=args.get("columns"),
+          scope=args.get("scope", "edited_only"),
+      )
 
   async def _handle_extract_cells(
       self, session_id: str, session_mode: str, args: dict[str, Any]
@@ -1067,21 +1061,14 @@ class ToolExecutor:
       # only_empty / the document+row scope narrow the actual work.
       columns = args.get("columns")
       scope = "explicit" if columns else "all"
-      only_empty = args.get("only_empty", True)
-      await concurrency_limiter.acquire(session_id, "reextraction")
-      try:
-          result = await reextraction_service.start_gated_reextraction(
-              session_id,
-              columns=columns,
-              scope=scope,
-              documents=args.get("documents"),
-              rows=args.get("rows"),
-              only_empty=only_empty,
-          )
-      except Exception:
-          await concurrency_limiter.release(session_id)
-          raise
-      return result
+      return await reextraction_service.start_gated_reextraction_guarded(
+          session_id,
+          columns=columns,
+          scope=scope,
+          documents=args.get("documents"),
+          rows=args.get("rows"),
+          only_empty=args.get("only_empty", True),
+      )
 
   async def _handle_continue_discovery(
       self, session_id: str, session_mode: str, args: dict[str, Any]
@@ -1115,17 +1102,12 @@ class ToolExecutor:
       # from storage and fails clearly when none are available.
       columns = args.get("columns")
       scope = args.get("scope", "all" if not columns else "edited_only")
-      await concurrency_limiter.acquire(session_id, "reprocess")
-      try:
-          result = await reextraction_service.start_gated_reextraction(
-              session_id,
-              columns=columns,
-              scope=scope,
-          )
-      except Exception:
-          await concurrency_limiter.release(session_id)
-          raise
-      return result
+      return await reextraction_service.start_gated_reextraction_guarded(
+          session_id,
+          operation_label="reprocess",
+          columns=columns,
+          scope=scope,
+      )
 
   async def _handle_rediscover(
       self, session_id: str, session_mode: str, args: dict[str, Any]

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -1182,6 +1182,34 @@ class ReextractionService(WebSocketBroadcasterMixin):
         missing = sorted(s for s in wanted if s not in reachable)
         return {"available": available, "missing": missing}
 
+    async def start_gated_reextraction_guarded(
+        self,
+        session_id: str,
+        *,
+        operation_label: str = "reextraction",
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Reserve a concurrency slot, then start a gated re-extraction.
+
+        Wraps :meth:`start_gated_reextraction` with the slot bookkeeping that
+        every caller (the chat reextract / reprocess / extract_cells tools and
+        the ``POST /schema/reprocess`` and ``POST /schema/reextract`` routes)
+        previously duplicated: acquire the slot up front and release it *only*
+        if the gated start raises before it spawns its background task. On
+        success the slot stays held and is released later by the running
+        operation, exactly as the inline callers did.
+
+        ``operation_label`` is the tag recorded on the slot for logging /
+        capacity messages (defaults to ``"reextraction"``); all other keyword
+        arguments are forwarded verbatim to :meth:`start_gated_reextraction`.
+        """
+        await concurrency_limiter.acquire(session_id, operation_label)
+        try:
+            return await self.start_gated_reextraction(session_id, **kwargs)
+        except Exception:
+            await concurrency_limiter.release(session_id)
+            raise
+
     async def start_gated_reextraction(
         self,
         session_id: str,


### PR DESCRIPTION
## Problem
The acquire-slot / try / start_gated_reextraction / except: release-slot pattern was duplicated across five call sites: the chat reextract, reprocess, and extract_cells handlers, plus the POST /schema/reprocess and POST /schema/reextract routes. Same lock dance, copy-pasted, with the release-only-on-error contract re-implemented each time — easy to drift and a latent slot-leak risk if one copy forgets the release.

## Solution
Add ReextractionService.start_gated_reextraction_guarded(session_id, *, operation_label='reextraction', **kwargs): it acquires the slot, forwards all kwargs to start_gated_reextraction, and releases the slot only if the gated start raises before spawning its task. On success the slot stays held and is released later by the running operation — identical to the previous inline behavior. All five call sites now delegate to it. Site-specific scope computation stays at the call site (it legitimately differs); only the identical lock bookkeeping is unified. The reprocess handler passes operation_label='reprocess' to preserve its slot tag.

## Verify
- git apply --ignore-whitespace --check clean on a fresh clone of main
- python -m py_compile on all three touched files
- schema.py CRLF line endings preserved
- No behavior change: release-on-error-only semantics and per-site scope/label preserved; existing tests call the untouched raw start_gated_reextraction