### PR TITLE
fix(workspace): show upload/processing spinner in the source-document preview

### DIFF
--- a/frontend/src/components/DocumentViewer/DocumentPreview.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentPreview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { FileText, ExternalLink, Download, FileX, Upload } from 'lucide-react';
+import { FileText, ExternalLink, Download, FileX, Upload, Loader2 } from 'lucide-react';
 
 import { unitsAPI } from '../../services/api';
 import { findHighlightRanges } from './highlightUtils';
@@ -51,6 +51,13 @@ interface DocumentPreviewProps {
    */
   onRequestUpload?: () => void;
   /**
+   * True while re-attached source files are being uploaded and processed on the
+   * server. Converting several documents can take a while, so the "not
+   * available" state shows a spinner instead of a static message — otherwise the
+   * panel looks frozen and the user assumes the upload silently failed.
+   */
+  uploading?: boolean;
+  /**
    * Grounding excerpts to highlight in the document. Passing this prop at all
    * (even `null`/`[]`) enables the highlight-capable inline text renderer for
    * text-based formats; the Documents tab omits it and keeps the plain iframe.
@@ -89,6 +96,7 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
   emptyHint,
   reloadToken,
   onRequestUpload,
+  uploading,
   highlightTexts,
   scrollNonce,
 }) => {
@@ -243,6 +251,19 @@ const DocumentPreview: React.FC<DocumentPreviewProps> = ({
       );
     }
     if (availability === 'unavailable') {
+      // Uploading/converting the re-attached files can take a while. Show a
+      // spinner instead of the static prompt so the panel doesn't look frozen
+      // (the button is hidden while uploading, so without this it appears as if
+      // nothing happened and the upload silently failed).
+      if (uploading) {
+        return (
+          <div className="h-full flex flex-col items-center justify-center gap-2 text-sm text-muted-foreground text-center px-6">
+            <Loader2 className="h-8 w-8 opacity-60 animate-spin" />
+            <span>Uploading and processing documents&hellip;</span>
+            <span className="text-xs">This can take a moment for large files.</span>
+          </div>
+        );
+      }
       return (
         <div className="h-full flex flex-col items-center justify-center gap-2 text-sm text-muted-foreground text-center px-6">
           <FileX className="h-8 w-8 opacity-40" />

--- a/frontend/src/components/DocumentViewer/DocumentViewer.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentViewer.tsx
@@ -212,6 +212,7 @@ const DocumentViewer: React.FC<DocumentViewerProps> = ({ sessionId, refreshKey, 
         sessionId={sessionId}
         documentName={selected}
         reloadToken={reloadToken}
+        uploading={uploading}
         onRequestUpload={openFilePicker}
       />
     </div>

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -1447,6 +1447,7 @@ function Workspace() {
                     reloadToken={sourceDocReloadToken}
                     highlightTexts={groundingHighlights}
                     scrollNonce={groundingScrollNonce}
+                    uploading={attachingSourceDocs}
                     onRequestUpload={attachingSourceDocs ? undefined : () => sourceDocInputRef.current?.click()}
                   />
                 </div>


### PR DESCRIPTION
## Problem
Re-attaching source documents to an imported project works, but uploading and server-side conversion can take a while. During that window the source panel keeps showing the static "This document isn't available to preview" message. The busy flag (`attachingSourceDocs`) was only used to *hide* the upload button, and `DocumentPreview` renders that button only when `onRequestUpload` is defined — so while uploading the user sees no button and no spinner. The panel looks frozen and the upload appears to have silently failed, when in fact the files become available shortly after.

## Solution
Add an `uploading` prop to `DocumentPreview`; when true, the "unavailable" state renders a spinner and "Uploading and processing documents…" instead of the static prompt. Wire `uploading={attachingSourceDocs}` into the Workspace source panel, and `uploading={uploading}` into the Documents-tab viewer (same component, existing state). Feedback is now continuous: click → spinner → "Loading…" (HEAD probe) → content.

## Verify
- `git apply --ignore-whitespace --check` clean on a fresh clone.
- `( cd frontend && npx tsc --noEmit )` passes.
- Manually: open an imported project, select a row whose source doc is unavailable, click "Upload source documents", pick several files — a spinner shows immediately and stays until the preview resolves.