### PR TITLE
fix(workspace): tell the user which source documents were skipped on attach

### DIFF
--- a/frontend/src/components/DocumentViewer/DocumentViewer.tsx
+++ b/frontend/src/components/DocumentViewer/DocumentViewer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { FileText, Upload, Loader2 } from 'lucide-react';
 
-import { unitsAPI } from '../../services/api';
+import { unitsAPI, describeSkippedAttachments } from '../../services/api';
 import { DocumentSummary } from '../../types/unit';
 import { SkippedDocument } from '../../types';
 import DocumentPreview from './DocumentPreview';
@@ -20,6 +20,12 @@ interface DocumentViewerProps {
 const extractErrorMessage = (err: any): string => {
   const detail = err?.response?.data?.detail;
   if (typeof detail === 'string') return detail;
+  // The attach endpoint returns 400 with { skipped: [...] } when nothing could
+  // be stored (e.g. every file was over the size limit). Report the specific
+  // reasons instead of a generic "try again", which would be misleading.
+  if (detail && Array.isArray(detail.skipped) && detail.skipped.length > 0) {
+    return `No files were attached. Skipped: ${describeSkippedAttachments(detail.skipped)}`;
+  }
   if (detail && Array.isArray(detail.errors) && detail.errors.length > 0) {
     return detail.errors.join(' ');
   }
@@ -91,9 +97,17 @@ const DocumentViewer: React.FC<DocumentViewerProps> = ({ sessionId, refreshKey, 
       setUploading(true);
       setUploadError(null);
       try {
-        await unitsAPI.attachSourceDocuments(sessionId, files);
+        const res = await unitsAPI.attachSourceDocuments(sessionId, files);
         // Refetch the list and re-probe the preview against the newly stored files.
         setReloadToken((t) => t + 1);
+        // Partial success (200) can still carry skipped files; tell the user so
+        // they know why those specific previews won't resolve.
+        const skipped = res.skipped ?? [];
+        if (skipped.length > 0) {
+          setUploadError(
+            `${skipped.length} file${skipped.length === 1 ? '' : 's'} skipped: ${describeSkippedAttachments(skipped)}`,
+          );
+        }
       } catch (err: any) {
         setUploadError(extractErrorMessage(err));
       } finally {

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -45,7 +45,7 @@ import SkippedDocumentsBanner from '@/components/DataTable/SkippedDocumentsBanne
 import { ViewModeToggle } from '@/components/ViewMode/ViewModeToggle';
 import MissingDocumentsSection from '@/components/SchemaEditor/MissingDocumentsSection';
 import TableFeedbackWidget from '@/components/TableFeedbackWidget/TableFeedbackWidget';
-import api, { configAPI, loadAPI, schematiqAPI, unitsAPI } from '@/services/api';
+import api, { configAPI, loadAPI, schematiqAPI, unitsAPI, describeSkippedAttachments } from '@/services/api';
 import { rememberProject } from '@/utils/recentProjects';
 import type {
   CostEstimate,
@@ -1186,8 +1186,19 @@ function Workspace() {
       if (!sessionId || files.length === 0) return;
       setAttachingSourceDocs(true);
       try {
-        await unitsAPI.attachSourceDocuments(sessionId, files);
+        const res = await unitsAPI.attachSourceDocuments(sessionId, files);
         setSourceDocReloadToken((t) => t + 1);
+        // Some files can be attached while others are skipped (e.g. over the
+        // size limit). The backend still returns 200 in that case, so without
+        // this the user is never told those specific previews won't resolve.
+        const skipped = res.skipped ?? [];
+        if (skipped.length > 0) {
+          toast({
+            title: `${skipped.length} file${skipped.length === 1 ? '' : 's'} skipped`,
+            description: `${describeSkippedAttachments(skipped)}. The other files were attached.`,
+            variant: 'destructive',
+          });
+        }
       } catch (err) {
         toast({
           title: 'Upload failed',

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -931,6 +931,28 @@ export const observationUnitAPI = {
   },
 };
 
+/** A source file the attach endpoint declined to store, with a human-readable reason. */
+export interface SkippedAttachment {
+  name: string;
+  reason: string;
+}
+
+/**
+ * Build a concise, human-readable summary of files the attach endpoint skipped
+ * (e.g. over the size limit), for a toast or inline notice. Returns '' when
+ * nothing was skipped. Caps the list so a large batch doesn't overflow the UI.
+ */
+export const describeSkippedAttachments = (skipped: SkippedAttachment[]): string => {
+  if (!skipped || skipped.length === 0) return '';
+  const MAX_SHOWN = 5;
+  const shown = skipped
+    .slice(0, MAX_SHOWN)
+    .map((s) => `${s.name} (${s.reason})`)
+    .join(', ');
+  const extra = skipped.length > MAX_SHOWN ? `, and ${skipped.length - MAX_SHOWN} more` : '';
+  return shown + extra;
+};
+
 // Units API (Observation Unit View and Merge)
 export const unitsAPI = {
   /**
@@ -1014,7 +1036,7 @@ export const unitsAPI = {
   attachSourceDocuments: async (
     sessionId: string,
     files: File[],
-  ): Promise<{ status: string; attached: string[]; skipped: { name: string; reason: string }[] }> => {
+  ): Promise<{ status: string; attached: string[]; skipped: SkippedAttachment[] }> => {
     const formData = new FormData();
     files.forEach((file) => formData.append('files', file));
     const response = await api.post(


### PR DESCRIPTION
## Problem
The source-document attach endpoint returns { attached, skipped }. When some files attach and others are skipped (e.g. over the 25MB limit) it still returns 200 with a non-empty `skipped`, but the frontend ignored it entirely — so the user is never told those specific previews won't resolve, reproducing the same "is this broken?" confusion. When *every* file is skipped the endpoint returns 400 with { detail: { skipped: [...] } }, which the Documents tab's `extractErrorMessage` didn't recognize, showing a misleading generic "try again".

## Solution
Add a shared `describeSkippedAttachments` formatter (and `SkippedAttachment` type) in api.ts. In the Workspace source panel, show a toast listing skipped files and reasons on partial success. In the Documents tab, show the same summary via the existing upload-notice line, and teach `extractErrorMessage` to report `detail.skipped` reasons for the all-skipped 400. Frontend only; no backend change.

## Verify
- `git apply --ignore-whitespace --check` clean on a fresh clone.
- `( cd frontend && npx tsc --noEmit )` passes.
- Manually: attach a batch where one file exceeds 25MB — the rest attach and a toast/notice names the skipped file and why.