### PR TITLE
fix(workspace): show a loading overlay while importing a project

### DIFF
--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -1238,11 +1238,18 @@ function Workspace() {
         layoutRevision={gridLayoutRevision}
         dataView={dataView}
       />
-      {(loading || importingProject) && sessionId && (
+      {/*
+        Show the blocking overlay while a project is loading or importing.
+        `loading` only makes sense once a session exists (we're fetching its
+        data), but an import happens BEFORE the route has a session id — so it
+        must not be gated on `sessionId`, otherwise the slow upload+parse shows
+        no feedback at all until navigation completes.
+      */}
+      {(importingProject || (loading && sessionId)) && (
         <div className="workspace-loading-overlay" role="status" aria-live="polite">
           <div className="workspace-loading-card">
             <Loader2 className="h-5 w-5 animate-spin" />
-            <span>Loading project…</span>
+            <span>{importingProject ? 'Importing project…' : 'Loading project…'}</span>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Problem
The workspace loading overlay was gated on `(loading || importingProject) && sessionId`. A project import happens *before* the route has a session id, so during the slow upload+parse `importingProject` is true but `sessionId` is still null — the `&& sessionId` guard suppressed the overlay entirely, leaving the user with no feedback until navigation completed. (Opening a recent project, loading rows, and the recents list already show their own indicators.)

## Solution
Split the condition so `importingProject` shows the overlay regardless of `sessionId` (loading data still requires a session), and label it "Importing project…" vs "Loading project…" so the user knows which is happening. The overlay lives in `dataGridNode`, which is mounted at the landing (default sheet is 'data'), so it renders during an import-from-landing.

## Verify
- `git apply --ignore-whitespace --check` clean on a fresh clone.
- `( cd frontend && npx tsc --noEmit )` passes.
- Manually: from the landing (no open project), import a project file — a spinner overlay reading "Importing project…" shows during upload+parse and clears once the workspace opens.