### PR TITLE
refactor(services): unify stateful orchestration singletons across chat and routes

### DIFF
--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -1001,10 +1001,10 @@ async def rediscover_imported_session(session_id: str, background_tasks: Backgro
     from app.models.schematiq import ScheMatiQConfig
     from app.services.rediscovery_config import build_rediscovery_backends
     from schematiq.core.llm_call_tracker import QuotaExceededError
-    # Both are module-level singletons constructed in routes/schematiq.py, shared
-    # across the app the same way app.main imports schematiq_runner from there.
-    from app.api.routes.schematiq import schematiq_runner, QUOTA_EXCEEDED_USER_MESSAGE
-    from app.api.routes.schema import reextraction_service
+    # Shared orchestration singletons (see app.services.orchestration): the same
+    # runner/reextraction instances the chat tools and Stop button operate on.
+    from app.api.routes.schematiq import QUOTA_EXCEEDED_USER_MESSAGE
+    from app.services.orchestration import reextraction_service, schematiq_runner
 
     try:
         set_session_context(session_id)

--- a/backend/app/api/routes/schema.py
+++ b/backend/app/api/routes/schema.py
@@ -15,10 +15,8 @@ from app.core.config import DEFAULT_DATA_DIR
 from app.models.session import ColumnInfo
 from app.models.modification import ModificationAction
 from app.services.schema_manager import SchemaManager
-from app.services.reextraction_service import ReextractionService
-from app.services.continue_discovery_service import ContinueDiscoveryService
 from app.services.data_editor import DataEditor
-from app.services import session_manager, websocket_manager, concurrency_limiter, data_collection_service
+from app.services import session_manager, websocket_manager, concurrency_limiter
 from app.core.exceptions import CapacityExceededError
 from app.core.logging_utils import set_session_context
 
@@ -28,18 +26,10 @@ router = APIRouter(tags=["schema"])
 # Create schema manager instance
 schema_manager = SchemaManager(websocket_manager, session_manager)
 
-# Create reextraction service instance
-from app.services import pubmed_enrichment_service, uniprot_enrichment_service
-reextraction_service = ReextractionService(websocket_manager, session_manager,
-                                           data_collection_service=data_collection_service,
-                                           pubmed_enrichment_service=pubmed_enrichment_service,
-                                           uniprot_enrichment_service=uniprot_enrichment_service)
-
-# Create continue discovery service instance
-continue_discovery_service = ContinueDiscoveryService(websocket_manager, session_manager,
-                                                      data_collection_service=data_collection_service,
-                                                      pubmed_enrichment_service=pubmed_enrichment_service,
-                                                      uniprot_enrichment_service=uniprot_enrichment_service)
+# Shared reextraction + continue-discovery singletons (see
+# app.services.orchestration): the same instances the chat tools and the
+# /load/rediscover route operate on, so stop/resume see the in-flight task.
+from app.services.orchestration import continue_discovery_service, reextraction_service
 
 # Create data editor instance
 data_editor = DataEditor()

--- a/backend/app/api/routes/schematiq.py
+++ b/backend/app/api/routes/schematiq.py
@@ -17,10 +17,9 @@ from fastapi.responses import StreamingResponse
 from app.models.session import VisualizationSession, SessionType, SessionStatus, SessionMetadata, FilterSortRequest
 from app.services.session_capabilities import has_live_pipeline
 from app.models.schematiq import ScheMatiQConfig, ScheMatiQStatus, CostEstimate, CostEstimateRequest, PhaseEstimate, DocumentStats
-from app.services.schematiq_runner import ScheMatiQRunner
 from app.services.pipeline.data_query import session_data_read_failed
 from app.services.data_editor import DataEditor
-from app.services import websocket_manager, session_manager, concurrency_limiter, data_collection_service
+from app.services import session_manager, concurrency_limiter
 from app.core.exceptions import CapacityExceededError
 from app.utils.csv_helpers import format_excerpt_for_csv
 from app.services.file_parser import format_column_header
@@ -29,12 +28,10 @@ from schematiq.core.cost_estimator import estimate_from_config
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
-# Create shared ScheMatiQ runner instance with shared managers
-from app.services import pubmed_enrichment_service, uniprot_enrichment_service
-schematiq_runner = ScheMatiQRunner(websocket_manager=websocket_manager, session_manager=session_manager,
-                         data_collection_service=data_collection_service,
-                         pubmed_enrichment_service=pubmed_enrichment_service,
-                         uniprot_enrichment_service=uniprot_enrichment_service)
+# Shared ScheMatiQ runner singleton (see app.services.orchestration). The chat
+# tools, the /load/rediscover route and app.main all bind this same instance, so
+# a run started from any entry point can be stopped and resumed from any other.
+from app.services.orchestration import schematiq_runner
 # Create data editor instance
 data_editor = DataEditor()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -196,7 +196,7 @@ async def get_llm_usage():
     ``used``/``remaining`` honor the optional rolling window
     (LLM_CALL_LIMIT_WINDOW_DAYS); ``lifetime_total`` is always cumulative.
     """
-    from app.api.routes.schematiq import schematiq_runner
+    from app.services.orchestration import schematiq_runner
     from app.services import concurrency_limiter
 
     report = schematiq_runner.get_usage_report()

--- a/backend/app/services/chat/deps.py
+++ b/backend/app/services/chat/deps.py
@@ -14,40 +14,18 @@ from app.services import (
     session_manager,
     websocket_manager,
 )
-from app.services.continue_discovery_service import ContinueDiscoveryService
 from app.services.data_editor import DataEditor
 from app.services.observation_unit_manager import ObservationUnitManager
-from app.services.reextraction_service import ReextractionService
 from app.services.schema_manager import SchemaManager
-from app.services.schematiq_runner import ScheMatiQRunner
-from app.services import pubmed_enrichment_service, uniprot_enrichment_service
-
-from app.services import data_collection_service
+from app.services.orchestration import (
+    continue_discovery_service,
+    reextraction_service,
+    schematiq_runner,
+)
 
 schema_manager = SchemaManager(websocket_manager, session_manager)
-reextraction_service = ReextractionService(
-    websocket_manager,
-    session_manager,
-    data_collection_service=data_collection_service,
-    pubmed_enrichment_service=pubmed_enrichment_service,
-    uniprot_enrichment_service=uniprot_enrichment_service,
-)
-continue_discovery_service = ContinueDiscoveryService(
-    websocket_manager,
-    session_manager,
-    data_collection_service=data_collection_service,
-    pubmed_enrichment_service=pubmed_enrichment_service,
-    uniprot_enrichment_service=uniprot_enrichment_service,
-)
 observation_unit_manager = ObservationUnitManager(websocket_manager, session_manager)
 data_editor = DataEditor()
-schematiq_runner = ScheMatiQRunner(
-    websocket_manager=websocket_manager,
-    session_manager=session_manager,
-    data_collection_service=data_collection_service,
-    pubmed_enrichment_service=pubmed_enrichment_service,
-    uniprot_enrichment_service=uniprot_enrichment_service,
-)
 
 from app.services.reference_fill_service import ReferenceFillService
 

--- a/backend/app/services/continue_discovery_service.py
+++ b/backend/app/services/continue_discovery_service.py
@@ -1401,7 +1401,7 @@ class ContinueDiscoveryService(WebSocketBroadcasterMixin):
                 llm_calls_after = LLMCallTracker.get_instance().get_counts().get("continue_discovery", 0)
                 delta = max(0, llm_calls_after - llm_calls_before)
                 if delta > 0:
-                    from app.services.chat.deps import schematiq_runner
+                    from app.services.orchestration import schematiq_runner
                     record_id = f"continue_discovery-{operation.session_id[:8]}-{int(datetime.now().timestamp())}"
                     await asyncio.to_thread(
                         schematiq_runner.record_external_usage, record_id, {"continue_discovery": delta}

--- a/backend/app/services/orchestration.py
+++ b/backend/app/services/orchestration.py
@@ -1,0 +1,69 @@
+"""Process-wide singletons for stateful orchestration services.
+
+``ScheMatiQRunner``, ``ReextractionService`` and ``ContinueDiscoveryService``
+each hold in-process, per-session operation registries — the running asyncio
+tasks and their stop flags (``running_sessions``/``stop_flags`` on the runner;
+``active_operations``/``stop_flags``/``_extraction_tasks`` on reextraction;
+``active_operations``/``stop_flags``/``_tasks`` on continue-discovery). Any code
+that *starts* a run and any code that *stops* or *resumes* it must operate on the
+same instance, or the stop/resume never sees the in-flight task and silently
+no-ops.
+
+Historically the HTTP routes (``routes/schematiq.py``, ``routes/schema.py``) and
+the workspace chat (``services/chat/deps.py``) each constructed their own copies.
+A run started from chat therefore could not be stopped by the route's Stop button
+(and vice versa), and ``prepare_resume``'s instance-local ``is_running`` check
+diverged from the shared ``concurrency_limiter``, forcing the fragile
+"slot held without running task" branch. This module makes the three services
+true singletons: every entry point imports the instances from here.
+
+Import contract: this module MUST NOT be imported from ``app.services.__init__``.
+The service classes below do ``from app.services import concurrency_limiter`` at
+module load, so importing this module during package initialisation would hit a
+partially-initialised ``app.services``. It is only safe to import once the
+package has finished initialising — i.e. from route modules / ``chat.deps`` at
+their own load time.
+"""
+
+from __future__ import annotations
+
+from app.services import (
+    data_collection_service,
+    pubmed_enrichment_service,
+    session_manager,
+    uniprot_enrichment_service,
+    websocket_manager,
+)
+from app.services.continue_discovery_service import ContinueDiscoveryService
+from app.services.reextraction_service import ReextractionService
+from app.services.schematiq_runner import ScheMatiQRunner
+
+schematiq_runner = ScheMatiQRunner(
+    websocket_manager=websocket_manager,
+    session_manager=session_manager,
+    data_collection_service=data_collection_service,
+    pubmed_enrichment_service=pubmed_enrichment_service,
+    uniprot_enrichment_service=uniprot_enrichment_service,
+)
+
+reextraction_service = ReextractionService(
+    websocket_manager,
+    session_manager,
+    data_collection_service=data_collection_service,
+    pubmed_enrichment_service=pubmed_enrichment_service,
+    uniprot_enrichment_service=uniprot_enrichment_service,
+)
+
+continue_discovery_service = ContinueDiscoveryService(
+    websocket_manager,
+    session_manager,
+    data_collection_service=data_collection_service,
+    pubmed_enrichment_service=pubmed_enrichment_service,
+    uniprot_enrichment_service=uniprot_enrichment_service,
+)
+
+__all__ = [
+    "schematiq_runner",
+    "reextraction_service",
+    "continue_discovery_service",
+]

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -1999,7 +1999,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 llm_calls_after = LLMCallTracker.get_instance().get_counts().get("reextraction", 0)
                 delta = max(0, llm_calls_after - llm_calls_before)
                 if delta > 0:
-                    from app.services.chat.deps import schematiq_runner
+                    from app.services.orchestration import schematiq_runner
                     record_id = f"reextraction-{operation.session_id[:8]}-{int(datetime.now().timestamp())}"
                     await asyncio.to_thread(
                         schematiq_runner.record_external_usage, record_id, {"reextraction": delta}


### PR DESCRIPTION
## Problem
`ScheMatiQRunner`, `ReextractionService` and `ContinueDiscoveryService` each hold in-process per-session operation registries: running asyncio tasks and stop flags (`running_sessions`/`stop_flags`; `active_operations`/`_extraction_tasks`/`_tasks`). The HTTP routes (`routes/schematiq.py`, `routes/schema.py`) and the workspace chat (`services/chat/deps.py`) each constructed **separate** instances, and reextraction/continue-discovery reached into `chat.deps` for the runner while `/schematiq/run|stop|resume` used the route runner.

Consequences (verified from code):
- The Stop button (`POST /schematiq/stop`) targets the route runner; a run started by the chat `run_schematiq`/`rediscover` tool registers its task on the chat runner, so `stop_execution` finds nothing and silently no-ops.
- `prepare_resume`'s instance-local `is_running` diverges from the shared `concurrency_limiter`, forcing the fragile 'slot held without running task' branch that force-releases the shared slot while the other instance's task is still running.

## Solution
Add `app/services/orchestration.py` as the single home for the three stateful singletons, built on the existing low-level shared singletons in `app.services`. Rewire all entry points (`routes/schematiq.py`, `routes/schema.py`, `chat/deps.py`, `main.py`, `load.py`, and the internal usage-recording imports in reextraction/continue-discovery) to import from it. Stateless services (SchemaManager, ObservationUnitManager, DataEditor) are intentionally left as-is; the `/load/rediscover` vs chat `rediscover` duplication is a separate concern for a follow-up PR. Import contract: `orchestration` is never imported from `services/__init__`, so the classes' `from app.services import concurrency_limiter` never hits a partially-initialised package.

## Verify
- `git apply --ignore-whitespace --check` clean on current main
- `python -m py_compile` on all 8 touched files
- `python -c "import app.main"` (no circular import)
- Manual: start a run from chat, hit the workspace Stop button -> run actually stops; start from the run button, stop from chat -> stops.