### PR TITLE
refactor(rediscovery): share preparation between /load/rediscover and chat tool

### DIFF
--- a/backend/app/api/routes/load.py
+++ b/backend/app/api/routes/load.py
@@ -997,91 +997,57 @@ async def rediscover_imported_session(session_id: str, background_tasks: Backgro
     does not make rediscovery possible for a session with no documents behind
     its data.
     """
-    from app.core.config import LLM_CALL_GLOBAL_LIMIT, DEVELOPER_MODE
-    from app.models.schematiq import ScheMatiQConfig
-    from app.services.rediscovery_config import build_rediscovery_backends
-    from schematiq.core.llm_call_tracker import QuotaExceededError
-    # Shared orchestration singletons (see app.services.orchestration): the same
-    # runner/reextraction instances the chat tools and Stop button operate on.
     from app.api.routes.schematiq import QUOTA_EXCEEDED_USER_MESSAGE
     from app.services.orchestration import reextraction_service, schematiq_runner
+    from app.services.rediscovery_service import (
+        prepare_rediscovery,
+        RediscoverySessionNotFound,
+        RediscoveryNotImported,
+        RediscoveryNoObservationUnit,
+        RediscoveryDocumentsUnavailable,
+        RediscoveryQuotaExceeded,
+        RediscoveryPipelineBusy,
+        RediscoveryPrepareFailed,
+    )
 
     try:
-        set_session_context(session_id)
-        session = session_manager.get_session(session_id)
-        if not session:
-            raise HTTPException(status_code=404, detail="Session not found")
-        if not is_imported(session):
-            raise HTTPException(
-                status_code=400,
-                detail=f"Rediscovery via this endpoint is only for imported sessions (type='{session.type}').",
-            )
-        if not session.observation_unit:
-            raise HTTPException(
-                status_code=400,
-                detail="Session has no observation unit configured. Set one before rediscovering.",
-            )
-
-        # Same gate re-extraction uses: rediscovery is only meaningful if the
-        # session's rows actually resolve to real source documents somewhere
-        # (local pending_documents/documents, or the session's cloud dataset).
-        paper_discovery = await reextraction_service.discover_papers(session_id)
-        availability = await reextraction_service.precheck_document_availability(
-            session_id, operation_type="reextraction", paper_discovery=paper_discovery,
+        await prepare_rediscovery(
+            session_id,
+            runner=schematiq_runner,
+            reextraction_service=reextraction_service,
+            require_imported=True,
         )
-        if not availability.get("can_proceed", False):
-            raise HTTPException(
-                status_code=400,
-                detail="No source documents are available for this project. "
-                       "Add the original source documents from the Documents tab, then try again.",
-            )
-
-        if not DEVELOPER_MODE:
-            try:
-                schematiq_runner.check_global_quota(LLM_CALL_GLOBAL_LIMIT)
-            except QuotaExceededError as exc:
-                from app.core.email_alerts import send_quota_exceeded_alert
-                send_quota_exceeded_alert(total_used=exc.used)
-                raise HTTPException(status_code=429, detail=QUOTA_EXCEEDED_USER_MESSAGE)
-
-        # Build a minimal, valid ScheMatiQConfig for this existing session.
-        # Prefer the project's persisted backends (restored on import from a
-        # complete export) so rediscovery uses the ORIGINAL models rather than
-        # RELEASE_CONFIG defaults; fall back to defaults for an older import.
-        # docs_path is left unset: resolve_docs_paths() already auto-detects
-        # session-local pending_documents/documents before falling back to it,
-        # which is exactly where an imported project's bundled files live.
-        schema_backend, value_backend = build_rediscovery_backends(session, session_id)
-        config = ScheMatiQConfig(
-            query=session.schema_query or "",
-            docs_path=None,
-            schema_creation_backend=schema_backend,
-            value_extraction_backend=value_backend,
-            output_path="outputs/rediscovered_output.json",
-        )
-        await schematiq_runner.save_config(session_id, config)
-
-        # Mark this run as an observation-unit rediscovery so prepare_resume
-        # clears prior schema/data artifacts and seeds initial_observation_unit
-        # from session.observation_unit, exactly like the SCHEMATIQ-session flow.
-        session = session_manager.get_session(session_id)
-        session.metadata.pending_observation_unit_rediscovery = True
-        session_manager.update_session(session)
-
-        try:
-            await schematiq_runner.prepare_resume(session_id)
-        except RuntimeError as e:
-            msg = str(e)
-            if "already has an active operation" in msg or "Timed out waiting" in msg:
-                raise HTTPException(
-                    status_code=409,
-                    detail="Pipeline is still stopping. Wait a few seconds and try again.",
-                ) from e
-            raise HTTPException(status_code=500, detail=msg) from e
-
         background_tasks.add_task(schematiq_runner.run_schematiq, session_id)
 
         return {"message": "Schema rediscovery started", "session_id": session_id}
+
+    except RediscoverySessionNotFound:
+        raise HTTPException(status_code=404, detail="Session not found")
+    except RediscoveryNotImported as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Rediscovery via this endpoint is only for imported sessions (type='{e.session_type}').",
+        )
+    except RediscoveryNoObservationUnit:
+        raise HTTPException(
+            status_code=400,
+            detail="Session has no observation unit configured. Set one before rediscovering.",
+        )
+    except RediscoveryDocumentsUnavailable:
+        raise HTTPException(
+            status_code=400,
+            detail="No source documents are available for this project. "
+                   "Add the original source documents from the Documents tab, then try again.",
+        )
+    except RediscoveryQuotaExceeded:
+        raise HTTPException(status_code=429, detail=QUOTA_EXCEEDED_USER_MESSAGE)
+    except RediscoveryPipelineBusy:
+        raise HTTPException(
+            status_code=409,
+            detail="Pipeline is still stopping. Wait a few seconds and try again.",
+        )
+    except RediscoveryPrepareFailed as e:
+        raise HTTPException(status_code=500, detail=e.message)
 
     except CapacityExceededError as e:
         raise HTTPException(status_code=503, detail=str(e))

--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -13,7 +13,7 @@ from app.core.config import DEFAULT_DATA_DIR, DEVELOPER_MODE, LLM_CALL_GLOBAL_LI
 from app.core.logging_utils import set_session_context
 from app.models.modification import ModificationAction
 from app.models.session import ColumnInfo
-from app.services.session_capabilities import has_live_pipeline, is_imported
+from app.services.session_capabilities import has_live_pipeline
 from app.services import concurrency_limiter, session_manager
 from app.services.data_utils import _resolve_source_document, canonicalize_column_name
 from app.services.pipeline.data_query import get_data as query_get_data
@@ -1112,91 +1112,51 @@ class ToolExecutor:
   async def _handle_rediscover(
       self, session_id: str, session_mode: str, args: dict[str, Any]
   ) -> dict[str, Any]:
-      # Full schema + observation-unit rediscovery from chat. Mirrors the proven
-      # POST /load/rediscover sequence (which backs the workspace "Rediscover
-      # schema" button): set pending_observation_unit_rediscovery so
-      # prepare_resume clears prior schema/data and re-seeds the observation
-      # unit, then run the pipeline — which re-evaluates previously-skipped
-      # documents. Differences from the route: gate failures surface as
-      # ValueError (rendered as a tool error), and the run is spawned as an
-      # asyncio task instead of via FastAPI BackgroundTasks.
-      #
-      # Works for both session types. The only mode-specific step is the config:
-      # a SCHEMATIQ session already has a runnable config.json from
-      # /schematiq/configure and must NOT have it overwritten with defaults; an
-      # UPLOAD session has none, so we synthesize one exactly like the route.
-      from app.models.schematiq import ScheMatiQConfig
-      from app.services.rediscovery_config import build_rediscovery_backends
-      from schematiq.core.llm_call_tracker import QuotaExceededError
+      # Full schema + observation-unit rediscovery from chat. The preparation
+      # sequence (observation-unit + document gates, quota check, config
+      # synthesis for imported sessions, pending_observation_unit_rediscovery
+      # flag, prepare_resume) is shared with POST /load/rediscover via
+      # prepare_rediscovery. This handler only translates the typed gate errors
+      # into tool-facing ValueErrors and spawns the run as an asyncio task
+      # (the route uses FastAPI BackgroundTasks). require_imported=False: unlike
+      # the route, the chat tool rediscovers both imported and SCHEMATIQ sessions.
+      from app.services.rediscovery_service import (
+          prepare_rediscovery,
+          RediscoverySessionNotFound,
+          RediscoveryNoObservationUnit,
+          RediscoveryDocumentsUnavailable,
+          RediscoveryQuotaExceeded,
+          RediscoveryPipelineBusy,
+      )
 
-      set_session_context(session_id)
-      session = session_manager.get_session(session_id)
-      if not session:
+      try:
+          await prepare_rediscovery(
+              session_id,
+              runner=schematiq_runner,
+              reextraction_service=reextraction_service,
+              require_imported=False,
+          )
+      except RediscoverySessionNotFound:
           raise ValueError("Session not found.")
-      if not session.observation_unit:
+      except RediscoveryNoObservationUnit:
           raise ValueError(
               "This project has no observation unit configured. Set one "
               "(edit_observation_unit) before rediscovering."
           )
-
-      # Same availability gate reextraction and /load/rediscover use. The tool is
-      # only advertised when the session looks extraction-capable, but that
-      # signal is local-disk only, so re-check the authoritative predicate
-      # (local + cloud) here before starting an expensive run.
-      paper_discovery = await reextraction_service.discover_papers(session_id)
-      availability = await reextraction_service.precheck_document_availability(
-          session_id,
-          operation_type="reextraction",
-          paper_discovery=paper_discovery,
-      )
-      if not availability.get("can_proceed", False):
+      except RediscoveryDocumentsUnavailable:
           raise ValueError(
               "No source documents are available for this project. Open a row and "
               'use "Show source document" to re-attach the original files, then '
               "try again."
           )
-
-      if not DEVELOPER_MODE:
-          try:
-              schematiq_runner.check_global_quota(LLM_CALL_GLOBAL_LIMIT)
-          except QuotaExceededError as exc:
-              from app.core.email_alerts import send_quota_exceeded_alert
-              send_quota_exceeded_alert(total_used=exc.used)
-              raise ValueError(
-                  "The global usage limit has been reached. Please try again later."
-              ) from exc
-
-      if is_imported(session):
-          # Imported session: no runnable config.json exists, so synthesize one.
-          # Prefer the project's persisted backends (restored on import from a
-          # complete export) so rediscovery uses the ORIGINAL models rather than
-          # RELEASE_CONFIG defaults; fall back to defaults for an older import.
-          # docs_path unset — resolve_docs_paths auto-detects the session-local
-          # pending_documents/documents where imported files live.
-          schema_backend, value_backend = build_rediscovery_backends(session, session_id)
-          config = ScheMatiQConfig(
-              query=session.schema_query or "",
-              docs_path=None,
-              schema_creation_backend=schema_backend,
-              value_extraction_backend=value_backend,
-              output_path="outputs/rediscovered_output.json",
+      except RediscoveryQuotaExceeded:
+          raise ValueError(
+              "The global usage limit has been reached. Please try again later."
           )
-          await schematiq_runner.save_config(session_id, config)
-      # else SCHEMATIQ: keep the existing config.json written by /schematiq/configure.
-
-      session = session_manager.get_session(session_id)
-      session.metadata.pending_observation_unit_rediscovery = True
-      session_manager.update_session(session)
-
-      try:
-          await schematiq_runner.prepare_resume(session_id)
-      except RuntimeError as e:
-          msg = str(e)
-          if "already has an active operation" in msg or "Timed out waiting" in msg:
-              raise ValueError(
-                  "The pipeline is still stopping. Wait a few seconds and try again."
-              ) from e
-          raise
+      except RediscoveryPipelineBusy:
+          raise ValueError(
+              "The pipeline is still stopping. Wait a few seconds and try again."
+          )
 
       asyncio.create_task(self._run_schematiq_task(session_id))
       return {

--- a/backend/app/services/rediscovery_service.py
+++ b/backend/app/services/rediscovery_service.py
@@ -1,0 +1,154 @@
+"""Shared preparation for schema + observation-unit rediscovery.
+
+Both the HTTP route ``POST /load/rediscover`` (workspace "Rediscover schema"
+button) and the chat ``rediscover`` tool run the same preparation sequence:
+gate on a configured observation unit and available source documents, check the
+global LLM quota, synthesize a runnable ``config.json`` for imported sessions,
+mark the run as an observation-unit rediscovery, and call ``prepare_resume``.
+That sequence used to be duplicated in both call sites, so a change in one could
+silently drift from the other.
+
+``prepare_rediscovery`` is that single implementation. It is dependency-injected
+(the caller passes its own ``runner`` and ``reextraction_service``), so it is
+correct regardless of whether those services are shared singletons yet, and it
+raises typed :class:`RediscoveryError` subclasses instead of choosing a user
+surface. Each caller translates those into its own error type and message
+(``HTTPException`` for the route, ``ValueError`` for the chat tool) and spawns
+the run in its own way (FastAPI ``BackgroundTasks`` vs ``asyncio.create_task``).
+
+The function stops at ``prepare_resume`` and does NOT start the pipeline or
+release the concurrency slot on failure — callers keep their existing spawn and
+cleanup semantics.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.logging_utils import set_session_context
+from app.services import session_manager
+from app.services.session_capabilities import is_imported
+
+
+class RediscoveryError(Exception):
+    """Base class for rediscovery preparation failures."""
+
+
+class RediscoverySessionNotFound(RediscoveryError):
+    """The session id does not resolve to a session."""
+
+
+class RediscoveryNotImported(RediscoveryError):
+    """require_imported was set but the session is not an imported session."""
+
+    def __init__(self, session_type: Any) -> None:
+        super().__init__(f"Session is not an imported session (type='{session_type}').")
+        self.session_type = session_type
+
+
+class RediscoveryNoObservationUnit(RediscoveryError):
+    """No observation unit is configured for the session."""
+
+
+class RediscoveryDocumentsUnavailable(RediscoveryError):
+    """No source documents resolve for the session, so rediscovery is a no-op."""
+
+
+class RediscoveryQuotaExceeded(RediscoveryError):
+    """The global LLM usage quota has been reached."""
+
+    def __init__(self, used: int) -> None:
+        super().__init__("The global LLM usage quota has been reached.")
+        self.used = used
+
+
+class RediscoveryPipelineBusy(RediscoveryError):
+    """prepare_resume could not acquire the slot because a run is still stopping."""
+
+
+class RediscoveryPrepareFailed(RediscoveryError):
+    """prepare_resume failed with a non-transient RuntimeError."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+async def prepare_rediscovery(
+    session_id: str,
+    *,
+    runner: Any,
+    reextraction_service: Any,
+    require_imported: bool,
+) -> None:
+    """Run the shared rediscovery preparation up to and including prepare_resume.
+
+    On success the caller may spawn ``runner.run_schematiq(session_id)``. On any
+    gate failure a :class:`RediscoveryError` subclass is raised; unrelated
+    exceptions (e.g. from ``discover_papers``) propagate unchanged so callers'
+    outer handlers see them exactly as before.
+    """
+    from app.core.config import DEVELOPER_MODE, LLM_CALL_GLOBAL_LIMIT
+    from app.models.schematiq import ScheMatiQConfig
+    from app.services.rediscovery_config import build_rediscovery_backends
+    from schematiq.core.llm_call_tracker import QuotaExceededError
+
+    set_session_context(session_id)
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise RediscoverySessionNotFound()
+    if require_imported and not is_imported(session):
+        raise RediscoveryNotImported(session.type)
+    if not session.observation_unit:
+        raise RediscoveryNoObservationUnit()
+
+    # Same gate re-extraction uses: rediscovery is only meaningful if the
+    # session's rows actually resolve to real source documents somewhere
+    # (local pending_documents/documents, or the session's cloud dataset).
+    paper_discovery = await reextraction_service.discover_papers(session_id)
+    availability = await reextraction_service.precheck_document_availability(
+        session_id, operation_type="reextraction", paper_discovery=paper_discovery,
+    )
+    if not availability.get("can_proceed", False):
+        raise RediscoveryDocumentsUnavailable()
+
+    if not DEVELOPER_MODE:
+        try:
+            runner.check_global_quota(LLM_CALL_GLOBAL_LIMIT)
+        except QuotaExceededError as exc:
+            from app.core.email_alerts import send_quota_exceeded_alert
+            send_quota_exceeded_alert(total_used=exc.used)
+            raise RediscoveryQuotaExceeded(exc.used) from exc
+
+    # Imported session: no runnable config.json exists, so synthesize one.
+    # Prefer the project's persisted backends (restored on import from a complete
+    # export) so rediscovery uses the ORIGINAL models rather than RELEASE_CONFIG
+    # defaults; fall back to defaults for an older import. docs_path is left
+    # unset: resolve_docs_paths() auto-detects the session-local
+    # pending_documents/documents where imported files live. A SCHEMATIQ session
+    # already has a config.json from /schematiq/configure and keeps it.
+    if is_imported(session):
+        schema_backend, value_backend = build_rediscovery_backends(session, session_id)
+        config = ScheMatiQConfig(
+            query=session.schema_query or "",
+            docs_path=None,
+            schema_creation_backend=schema_backend,
+            value_extraction_backend=value_backend,
+            output_path="outputs/rediscovered_output.json",
+        )
+        await runner.save_config(session_id, config)
+
+    # Mark this run as an observation-unit rediscovery so prepare_resume clears
+    # prior schema/data artifacts and seeds initial_observation_unit from
+    # session.observation_unit.
+    session = session_manager.get_session(session_id)
+    session.metadata.pending_observation_unit_rediscovery = True
+    session_manager.update_session(session)
+
+    try:
+        await runner.prepare_resume(session_id)
+    except RuntimeError as e:
+        msg = str(e)
+        if "already has an active operation" in msg or "Timed out waiting" in msg:
+            raise RediscoveryPipelineBusy(msg) from e
+        raise RediscoveryPrepareFailed(msg) from e


### PR DESCRIPTION
## Problem
The rediscovery preparation sequence — observation-unit + source-document gates, global LLM quota check (+ alert), `config.json` synthesis for imported sessions, the `pending_observation_unit_rediscovery` flag, and `prepare_resume` — was implemented **twice**: in `POST /load/rediscover` (workspace "Rediscover schema" button) and in the chat `rediscover` tool (`_handle_rediscover`), whose own comment described itself as mirroring the route. Duplicated logic can silently drift.

## Solution
Extract the sequence into `app/services/rediscovery_service.py::prepare_rediscovery`, a single implementation that is **dependency-injected** (the caller passes its own `runner`/`reextraction_service`, which since #492 are the shared orchestration singletons) and raises typed `RediscoveryError` subclasses instead of choosing a user surface. The route translates them into `HTTPException` (`require_imported=True`); the chat tool into `ValueError` (`require_imported=False`, since chat rediscovers both imported and SCHEMATIQ sessions). Each caller keeps its own spawn (FastAPI `BackgroundTasks` vs `asyncio.create_task`), return shape, and outer error handling. User-facing message strings stay per-caller (they differ intentionally).

## Behaviour preservation
- `CapacityExceededError` and `QuotaExceededError` extend `Exception`, not `RuntimeError`, so the shared `except RuntimeError` around `prepare_resume` does not swallow them: the route's 503 (capacity) and 429 (quota, with alert) are unchanged.
- A non-transient `prepare_resume` failure raises `RediscoveryPrepareFailed` → route 500 **without** releasing the concurrency slot, matching the original inner-try mapping.
- The 'already has an active operation' / 'Timed out waiting' case maps to 409 (route) / a 'still stopping' ValueError (chat).
- Gate ordering preserved: route checks imported→observation-unit; chat checks observation-unit.

## Verify
- `git apply --ignore-whitespace --check` clean on current main
- `python -m py_compile` on the three touched files; `pyflakes` clean
- `python -c "import app.main"` (no circular import)
- Manual: rediscover an imported project and a SCHEMATIQ project from both the workspace button and the chat tool; confirm identical gating (no observation unit / no documents / quota) and that runs start and can be stopped.