### PR TITLE
Stream Gemini chat responses

### DIFF
--- a/backend/app/services/chat/agent_service.py
+++ b/backend/app/services/chat/agent_service.py
@@ -38,6 +38,24 @@ logger = logging.getLogger(__name__)
 
 MAX_TOOL_ITERATIONS = 10
 
+
+class _StreamedChatResponse:
+    """Aggregate Gemini stream chunks into the shape used by the agent loop."""
+
+    def __init__(
+        self,
+        *,
+        text: str = "",
+        function_calls: Optional[list[Any]] = None,
+        message_emitted: bool = False,
+        stopped: bool = False,
+    ) -> None:
+        self.text = text
+        self.function_calls = function_calls or []
+        self.message_emitted = message_emitted
+        self.stopped = stopped
+
+
 CHAT_SYSTEM_PROMPT = """You are the ScheMatiQ workspace assistant.
 
 Terminology (do not confuse these):
@@ -387,7 +405,9 @@ class ChatAgentService:
                     )
                 )
 
-            response = await self._send_function_response(state, pending, tool_result)
+            response = await self._send_function_response(
+                state, pending, tool_result, outbound_messages
+            )
             loop_result = await self._continue_after_tool(state, response, outbound_messages)
             if loop_result["status"] == "complete":
                 await self._persist_history(state)
@@ -475,6 +495,7 @@ class ChatAgentService:
                 state,
                 pending,
                 {"cancelled": True, "message": reason},
+                outbound_messages,
             )
             loop_result = await self._continue_after_tool(
                 state,
@@ -846,14 +867,106 @@ class ChatAgentService:
         Broadcast failures are swallowed for the same reason.
         """
         outbound_messages.append(message)
+        await self._broadcast_chat_event(state, "chat_message", message)
+        return message
+
+    @staticmethod
+    async def _broadcast_chat_event(
+        state: ChatSessionState,
+        event_type: str,
+        data: dict[str, Any],
+    ) -> None:
+        """Best-effort live delivery; the completed HTTP response is authoritative."""
         try:
             await websocket_manager.broadcast_to_session(
                 state.workspace_session_id,
-                {"type": "chat_message", "data": message},
+                {"type": event_type, "data": data},
             )
         except Exception as exc:
-            logger.debug("Could not stream chat message over WS: %s", exc)
-        return message
+            logger.debug("Could not stream %s over WS: %s", event_type, exc)
+
+    async def _send_chat_message(
+        self,
+        state: ChatSessionState,
+        content: Any,
+        outbound_messages: list[dict[str, Any]],
+    ) -> Any:
+        """Send one Gemini message and live-stream text chunks to the workspace.
+
+        Tool-call chunks are accumulated for the existing manual tool loop. If a
+        provider ever emits text before a function call, discard that provisional
+        UI message so internal tool-planning text is not left in the transcript.
+        The non-streaming fallback keeps tests and older SDK clients compatible.
+        """
+        LLMCallTracker.get_instance().set_stage("chat")
+        state.pending_llm_calls += 1
+
+        send_stream = getattr(state.chat, "send_message_stream", None)
+        if not callable(send_stream):
+            return await state.chat.send_message(content)
+
+        stream = await send_stream(content)
+
+        async def _close_stream() -> None:
+            close = getattr(stream, "aclose", None)
+            if callable(close):
+                await close()
+
+        message_id = str(uuid.uuid4())
+        text_chunks: list[str] = []
+        function_calls: list[Any] = []
+        message_visible = False
+
+        async for chunk in stream:
+            if state.stop_requested:
+                if message_visible:
+                    await self._broadcast_chat_event(
+                        state, "chat_message_discard", {"id": message_id}
+                    )
+                await _close_stream()
+                return _StreamedChatResponse(stopped=True)
+
+            chunk_calls = getattr(chunk, "function_calls", None) or []
+            if chunk_calls:
+                function_calls.extend(chunk_calls)
+                if message_visible:
+                    await self._broadcast_chat_event(
+                        state, "chat_message_discard", {"id": message_id}
+                    )
+                    message_visible = False
+
+            delta = getattr(chunk, "text", None) or ""
+            if delta:
+                text_chunks.append(delta)
+                if not function_calls:
+                    message_visible = True
+                    await self._broadcast_chat_event(
+                        state,
+                        "chat_message_delta",
+                        {"id": message_id, "delta": delta},
+                    )
+
+        if state.stop_requested:
+            if message_visible:
+                await self._broadcast_chat_event(
+                    state, "chat_message_discard", {"id": message_id}
+                )
+            await _close_stream()
+            return _StreamedChatResponse(stopped=True)
+
+        text = "".join(text_chunks).strip()
+        if function_calls:
+            return _StreamedChatResponse(text=text, function_calls=function_calls)
+
+        if text:
+            await self._emit(
+                state,
+                outbound_messages,
+                self._text_message(text, message_id=message_id),
+            )
+            return _StreamedChatResponse(text=text, message_emitted=True)
+
+        return _StreamedChatResponse()
 
     async def _run_loop(
         self,
@@ -861,7 +974,7 @@ class ChatAgentService:
         user_text: str,
         outbound_messages: list[dict[str, Any]],
     ) -> dict[str, Any]:
-        response = await self._send_user_message(state, user_text)
+        response = await self._send_user_message(state, user_text, outbound_messages)
         return await self._continue_after_tool(state, response, outbound_messages)
 
     async def _continue_after_tool(
@@ -876,7 +989,7 @@ class ChatAgentService:
             # function responses, so the SDK chat is balanced. The turn is
             # discarded by the caller (no persist), so an unanswered function
             # call sitting in `response` here is dropped with it.
-            if state.stop_requested:
+            if state.stop_requested or getattr(response, "stopped", False):
                 return {"status": "stopped"}
             function_calls = getattr(response, "function_calls", None) or []
             if function_calls:
@@ -960,7 +1073,9 @@ class ChatAgentService:
                         self._function_response_part(tool_name, tool_result)
                     )
 
-                response = await self._send_function_response_parts(state, response_parts)
+                response = await self._send_function_response_parts(
+                    state, response_parts, outbound_messages
+                )
                 continue
 
             text = (getattr(response, "text", None) or "").strip()
@@ -969,7 +1084,10 @@ class ChatAgentService:
                 # the answer instead of emitting it.
                 if state.stop_requested:
                     return {"status": "stopped"}
-                await self._emit(state, outbound_messages, self._text_message(text))
+                if not getattr(response, "message_emitted", False):
+                    await self._emit(
+                        state, outbound_messages, self._text_message(text)
+                    )
                 return {"status": "complete"}
 
             break
@@ -979,21 +1097,25 @@ class ChatAgentService:
         )
         return {"status": "complete"}
 
-    async def _send_user_message(self, state: ChatSessionState, user_text: str) -> Any:
-        LLMCallTracker.get_instance().set_stage("chat")
-        state.pending_llm_calls += 1
-        return await state.chat.send_message(user_text)
+    async def _send_user_message(
+        self,
+        state: ChatSessionState,
+        user_text: str,
+        outbound_messages: list[dict[str, Any]],
+    ) -> Any:
+        return await self._send_chat_message(state, user_text, outbound_messages)
 
     async def _send_function_response(
         self,
         state: ChatSessionState,
         pending: PendingToolCall,
         tool_result: dict[str, Any],
+        outbound_messages: list[dict[str, Any]],
     ) -> Any:
-        LLMCallTracker.get_instance().set_stage("chat")
-        state.pending_llm_calls += 1
-        return await state.chat.send_message(
-            self._function_response_part(pending.tool_name, tool_result)
+        return await self._send_chat_message(
+            state,
+            self._function_response_part(pending.tool_name, tool_result),
+            outbound_messages,
         )
 
     @staticmethod
@@ -1006,20 +1128,23 @@ class ChatAgentService:
         )
 
     async def _send_function_response_parts(
-        self, state: ChatSessionState, parts: list[Any]
+        self,
+        state: ChatSessionState,
+        parts: list[Any],
+        outbound_messages: list[dict[str, Any]],
     ) -> Any:
         """Send one function response per tool call the model issued this turn.
 
         Gemini expects a response for every function call it emitted; sending all of
         them together lets a batch of tool calls (e.g. several update_cell) all run.
         """
-        LLMCallTracker.get_instance().set_stage("chat")
-        state.pending_llm_calls += 1
-        return await state.chat.send_message(parts)
+        return await self._send_chat_message(state, parts, outbound_messages)
 
-    def _text_message(self, content: str) -> dict[str, Any]:
+    def _text_message(
+        self, content: str, *, message_id: Optional[str] = None
+    ) -> dict[str, Any]:
         return {
-            "id": str(uuid.uuid4()),
+            "id": message_id or str(uuid.uuid4()),
             "role": "assistant",
             "kind": "text",
             "content": content,

--- a/backend/tests/test_chat_streaming.py
+++ b/backend/tests/test_chat_streaming.py
@@ -1,0 +1,121 @@
+"""Focused tests for Gemini text streaming in the workspace chat."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.chat import agent_service as agent_module
+from app.services.chat.agent_service import ChatAgentService
+from app.services.chat.session_store import ChatSessionState
+
+
+class _Chunk:
+    def __init__(self, text: str = "", function_calls=None) -> None:
+        self.text = text
+        self.function_calls = function_calls or []
+
+
+class _StreamingChat:
+    def __init__(self, chunks: list[_Chunk], after_first=None) -> None:
+        self._chunks = chunks
+        self._after_first = after_first
+
+    async def send_message_stream(self, content):
+        async def _iterate():
+            for index, chunk in enumerate(self._chunks):
+                yield chunk
+                if index == 0 and self._after_first:
+                    self._after_first()
+
+        return _iterate()
+
+
+def _state(chat) -> ChatSessionState:
+    return ChatSessionState(
+        client=object(),
+        chat=chat,
+        workspace_session_id="stream-session",
+        session_mode="schematiq",
+    )
+
+
+@pytest.fixture
+def recorded_events(monkeypatch):
+    events: list[dict] = []
+
+    async def _record(session_id: str, message: dict) -> None:
+        assert session_id == "stream-session"
+        events.append(message)
+
+    monkeypatch.setattr(
+        agent_module.websocket_manager,
+        "broadcast_to_session",
+        _record,
+        raising=True,
+    )
+    return events
+
+
+@pytest.mark.asyncio
+async def test_text_chunks_stream_and_finish_with_authoritative_message(recorded_events):
+    service = ChatAgentService()
+    state = _state(_StreamingChat([_Chunk("Hello"), _Chunk(" world")]))
+    outbound: list[dict] = []
+
+    response = await service._send_chat_message(state, "hi", outbound)
+
+    assert response.text == "Hello world"
+    assert response.message_emitted is True
+    assert [event["type"] for event in recorded_events] == [
+        "chat_message_delta",
+        "chat_message_delta",
+        "chat_message",
+    ]
+    message_id = recorded_events[0]["data"]["id"]
+    assert recorded_events[1]["data"]["id"] == message_id
+    assert recorded_events[2]["data"]["id"] == message_id
+    assert outbound == [recorded_events[2]["data"]]
+    assert outbound[0]["content"] == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_late_tool_call_discards_provisional_text(recorded_events):
+    service = ChatAgentService()
+    function_call = SimpleNamespace(name="get_schema", args={})
+    state = _state(
+        _StreamingChat([_Chunk("Let me check."), _Chunk(function_calls=[function_call])])
+    )
+    outbound: list[dict] = []
+
+    response = await service._send_chat_message(state, "show schema", outbound)
+
+    assert response.function_calls == [function_call]
+    assert response.message_emitted is False
+    assert outbound == []
+    assert [event["type"] for event in recorded_events] == [
+        "chat_message_delta",
+        "chat_message_discard",
+    ]
+    assert recorded_events[0]["data"]["id"] == recorded_events[1]["data"]["id"]
+
+
+@pytest.mark.asyncio
+async def test_stop_discards_partial_text(recorded_events):
+    service = ChatAgentService()
+    state = _state(None)
+    state.chat = _StreamingChat(
+        [_Chunk("partial"), _Chunk(" ignored")],
+        after_first=lambda: setattr(state, "stop_requested", True),
+    )
+    outbound: list[dict] = []
+
+    response = await service._send_chat_message(state, "start", outbound)
+
+    assert response.stopped is True
+    assert outbound == []
+    assert [event["type"] for event in recorded_events] == [
+        "chat_message_delta",
+        "chat_message_discard",
+    ]

--- a/frontend/src/pages/Workspace/chat/ChatPanel.tsx
+++ b/frontend/src/pages/Workspace/chat/ChatPanel.tsx
@@ -112,6 +112,9 @@ export function ChatPanel({
   // from the step that was already running, so drop live chat_message events
   // until the next turn starts rather than letting the stopped reply trickle in.
   const suppressStreamRef = useRef(false);
+  // Stable id of the assistant message currently receiving Gemini text chunks.
+  // Stop and tool-call fallback use it to remove a provisional partial reply.
+  const streamingMessageIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     const container = messagesRef.current;
@@ -265,21 +268,49 @@ export function ChatPanel({
     [sessionId, references],
   );
 
-  // Ids are the deduplication key. Assistant and tool messages now arrive over
-  // two channels -- live over the WebSocket as the agent produces them, and
-  // again in the HTTP response at the end of the turn -- so whichever lands
-  // first wins and the other copy is dropped. The HTTP response stays the source
-  // of truth: if the socket is down, nothing is lost.
+  // Ids are the deduplication key. The final HTTP response is authoritative, so
+  // replace a live WebSocket copy with the completed message instead of dropping
+  // it. This also finalizes a message that was assembled from streaming deltas.
   const appendMessages = useCallback((next: WorkspaceMessage[]) => {
     setMessages((current) => {
-      const seen = new Set(current.map((message) => message.id));
-      const fresh = next.filter((message) => {
-        if (seen.has(message.id)) return false;
-        seen.add(message.id);
-        return true;
+      const updated = [...current];
+      const indexById = new Map(updated.map((message, index) => [message.id, index]));
+      next.forEach((message) => {
+        const existingIndex = indexById.get(message.id);
+        if (existingIndex == null) {
+          indexById.set(message.id, updated.length);
+          updated.push(message);
+        } else {
+          updated[existingIndex] = message;
+        }
       });
-      return fresh.length ? [...current, ...fresh] : current;
+      return updated;
     });
+  }, []);
+
+  const appendChatDelta = useCallback((id: string, delta: string) => {
+    if (!id || !delta) return;
+    streamingMessageIdRef.current = id;
+    setMessages((current) => {
+      const existingIndex = current.findIndex((message) => message.id === id);
+      if (existingIndex < 0) {
+        return [...current, { id, role: 'assistant', content: delta }];
+      }
+      const updated = [...current];
+      updated[existingIndex] = {
+        ...updated[existingIndex],
+        content: `${updated[existingIndex].content}${delta}`,
+      };
+      return updated;
+    });
+  }, []);
+
+  const discardStreamedMessage = useCallback((id: string) => {
+    if (!id) return;
+    if (streamingMessageIdRef.current === id) {
+      streamingMessageIdRef.current = null;
+    }
+    setMessages((current) => current.filter((message) => message.id !== id));
   }, []);
 
   // A column fill runs in the background after the chat turn ends, streaming cells
@@ -294,7 +325,18 @@ export function ChatPanel({
         // staying empty until the HTTP response returns. After a Stop we ignore
         // these so the halted turn's reply does not keep landing.
         if (suppressStreamRef.current) return;
-        appendMessages([mapChatTurnMessage(message.data as unknown as ChatTurnMessage)]);
+        const completed = mapChatTurnMessage(message.data as unknown as ChatTurnMessage);
+        appendMessages([completed]);
+        if (streamingMessageIdRef.current === completed.id) {
+          streamingMessageIdRef.current = null;
+        }
+      } else if (message.type === 'chat_message_delta' && message.data) {
+        if (suppressStreamRef.current) return;
+        const data = message.data as unknown as { id?: string; delta?: string };
+        if (data.id && data.delta) appendChatDelta(data.id, data.delta);
+      } else if (message.type === 'chat_message_discard' && message.data) {
+        const data = message.data as unknown as { id?: string };
+        if (data.id) discardStreamedMessage(data.id);
       } else if (message.type === 'reference_fill_started') {
         const data = (message.data ?? {}) as unknown as { column?: string };
         setFillRunning({ column: data.column ?? '' });
@@ -374,7 +416,7 @@ export function ChatPanel({
     };
     webSocketService.addMessageHandler(handler);
     return () => webSocketService.removeMessageHandler(handler);
-  }, [sessionId, appendMessages]);
+  }, [sessionId, appendChatDelta, appendMessages, discardStreamedMessage]);
 
   const applyChatResponse = useCallback((response: Awaited<ReturnType<typeof chatAPI.sendMessage>>) => {
     setChatId(response.chat_id);
@@ -558,6 +600,8 @@ export function ChatPanel({
   // tell the backend to bail and discard the turn. The backend call is
   // best-effort -- the UI is already unblocked regardless of its outcome.
   const handleStop = useCallback(() => {
+    const streamingMessageId = streamingMessageIdRef.current;
+    if (streamingMessageId) discardStreamedMessage(streamingMessageId);
     suppressStreamRef.current = true;
     stop();
     if (sessionId) {
@@ -565,7 +609,7 @@ export function ChatPanel({
         // Best-effort: the turn ends server-side on its own if this misses.
       });
     }
-  }, [sessionId, stop]);
+  }, [discardStreamedMessage, sessionId, stop]);
 
   useEffect(() => {
     if (!onRegisterCancelPending) return;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -358,7 +358,7 @@ export interface ObservationUnitReadyData {
 }
 
 export interface WebSocketMessage {
-  type: 'progress' | 'log' | 'error' | 'completed' | 'connected' | 'disconnected' | 'reconnecting' | 'pong' | 'heartbeat' | 'schema_completed' | 'schema_progress' | 'row_completed' | 'schema_updated' | 'reprocessing_progress' | 'reprocessing_completed' | 'reextraction_started' | 'reextraction_progress' | 'reextraction_completed' | 'reextraction_failed' | 'reextraction_stopped' | 'document_started' | 'cell_extracted' | 'stopped' | 'continue_discovery_progress' | 'continue_discovery_completed' | 'continue_discovery_stopped' | 'incremental_extraction_progress' | 'quota_exceeded' | 'observation_unit_ready' | 'observation_unit_definition_updated' | 'reference_fill_started' | 'reference_fill_completed' | 'chat_message';
+  type: 'progress' | 'log' | 'error' | 'completed' | 'connected' | 'disconnected' | 'reconnecting' | 'pong' | 'heartbeat' | 'schema_completed' | 'schema_progress' | 'row_completed' | 'schema_updated' | 'reprocessing_progress' | 'reprocessing_completed' | 'reextraction_started' | 'reextraction_progress' | 'reextraction_completed' | 'reextraction_failed' | 'reextraction_stopped' | 'document_started' | 'cell_extracted' | 'stopped' | 'continue_discovery_progress' | 'continue_discovery_completed' | 'continue_discovery_stopped' | 'incremental_extraction_progress' | 'quota_exceeded' | 'observation_unit_ready' | 'observation_unit_definition_updated' | 'reference_fill_started' | 'reference_fill_completed' | 'chat_message' | 'chat_message_delta' | 'chat_message_discard';
   timestamp?: string;
   session_id?: string;
   message?: string;


### PR DESCRIPTION
## Problem

Workspace chat waits for Gemini to finish before displaying assistant text.

## Solution

- Stream Gemini text chunks through the existing WebSocket
- Reconcile partial and final messages using a stable message ID
- Discard partial output after Stop or a transition to tool calls
- Preserve the non-streaming fallback and existing tool loop
- Add focused streaming regression tests

## Verify

- git apply --ignore-whitespace --check
- ( cd frontend && npx tsc --noEmit )
- python -m py_compile backend/app/services/chat/agent_service.py backend/tests/test_chat_streaming.py