### PR TITLE
fix(reextraction): force-skip on-disk documents absent from scope metadata

### DIFF
--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -1553,6 +1553,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
         documents: Optional[List[str]],
         rows: Optional[List[str]],
         all_paper_stems: set,
+        on_disk_stems: Optional[set] = None,
     ) -> Dict[str, List[str]]:
         """Restrict a run to specific documents and/or rows via ``known_units``.
 
@@ -1565,6 +1566,17 @@ class ReextractionService(WebSocketBroadcasterMixin):
             ``rows`` so only the requested units are extracted;
           - a target document that has no known units (previously skipped) is
             dropped from the map so the library re-discovers its units.
+
+        ``on_disk_stems`` is the set of document stems actually present in the
+        session's document directories (what the library will walk). It must be
+        included so on-disk files that are absent from the row/skip metadata --
+        e.g. a collision-renamed ``<name>_N`` duplicate (see unique_dest_path)
+        or any orphan file -- are force-skipped to ``[]`` rather than left absent
+        and re-discovered. Without it, a scoped run still runs full unit
+        discovery + extraction on every such file, ballooning a targeted fill
+        into unrequested units. Only affects scoped runs (this method is called
+        only when documents/rows are given), where skipping non-targets is the
+        intent.
         """
         if not documents and not rows:
             return known_units
@@ -1574,7 +1586,12 @@ class ReextractionService(WebSocketBroadcasterMixin):
         targets = explicit if documents else set(all_paper_stems) | set(known_units.keys())
         row_filter = set(rows) if rows else None
         scoped: Dict[str, List[str]] = {}
-        universe = set(all_paper_stems) | set(known_units.keys()) | targets
+        universe = (
+            set(all_paper_stems)
+            | set(known_units.keys())
+            | targets
+            | (on_disk_stems or set())
+        )
         for stem in universe:
             if stem not in targets:
                 scoped[stem] = []  # force-skip every non-target document
@@ -1828,8 +1845,22 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     all_stems = self._project_document_stems(
                         operation.paper_discovery or {}, session
                     )
+                    # Stems the library will actually walk. Passed so on-disk
+                    # files absent from the row/skip metadata (e.g. a
+                    # collision-renamed <name>_N duplicate) are force-skipped
+                    # instead of triggering unit discovery on a scoped run.
+                    on_disk_stems = {
+                        p.stem
+                        for d in docs_directories
+                        for p in d.iterdir()
+                        if p.is_file() and not p.name.startswith(".")
+                    }
                     known_units = self._scope_known_units(
-                        known_units, operation.documents, operation.rows, all_stems
+                        known_units,
+                        operation.documents,
+                        operation.rows,
+                        all_stems,
+                        on_disk_stems,
                     )
                     logger.info(
                         "Scoped re-extraction (documents=%s, rows=%s); %d paper(s) skipped",


### PR DESCRIPTION
## Problem
A scoped re-extraction (via the chat `extract_cells` tool, or the workspace re-extract path) restricts work through `known_units`: `[]` = skip for free, a name list = extract those units, absent = run unit discovery. `_scope_known_units` builds its universe from row/skip **metadata** only (`all_paper_stems | known_units.keys()`). On-disk documents with no metadata entry -- notably collision-renamed `<name>_N` duplicates created by `unique_dest_path` -- are therefore **absent** from the map, so the library runs full observation-unit discovery + value extraction on them. A targeted fill of a few rows balloons into re-identifying and extracting units that were never requested (and burns LLM quota).

Observed: a rows-scoped `extract_cells` for 4 named units walked all on-disk documents and ran discovery on `Chung...SDNY_1`, `Mercato...SDNY_1`, `NewJersey...CA1_1`, etc., producing units outside the requested scope.

## Solution
Enumerate the document stems actually present in the session's document directories (what the library walks) and pass them into `_scope_known_units`. Any on-disk stem that is not a scope target is force-skipped to `[]`. Only affects scoped runs (the method is called only when documents/rows are given), where skipping non-targets is the intent; unscoped/rediscovery paths are untouched.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone: OK
- `python -m py_compile backend/app/services/reextraction_service.py`: OK
- Isolated logic test on the observed scenario: orphan `_N` stems go from absent (discovery) to `[]` (skipped); requested targets keep their units.