### PR TITLE
fix(workspace): column value filter no longer wiped on re-render

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -673,8 +673,8 @@ export function SpreadsheetSurface({
     registerFormatShortcuts(hot);
   });
 
-  const markFilterSettingsInitOnly = useCallback(() => {
-    const hot = hotTableRef.current?.hotInstance;
+  const markFilterSettingsInitOnly = useCallback((instance?: HotTableClass['hotInstance']) => {
+    const hot = instance ?? hotTableRef.current?.hotInstance;
     if (!hot) return;
     try {
       const settings = hot.getSettings() as { _initOnlySettings?: string[] };
@@ -692,6 +692,26 @@ export function SpreadsheetSurface({
       }
     } catch { /* instance may be mid-teardown */ }
   }, [hotTableRef]);
+
+  // Drive `markFilterSettingsInitOnly` from an effect rather than `afterInit`.
+  // `afterInit` fires from inside Handsontable's constructor, before
+  // @handsontable/react has assigned the instance onto the ref, so the
+  // afterInit call read `hotTableRef.current?.hotInstance` as undefined and
+  // silently no-opped -- leaving `filters`/`dropdownMenu`/`contextMenu` OUT of
+  // `_initOnlySettings`. The wrapper then re-pushed `filters` through
+  // updateSettings on the next unrelated re-render, re-initializing the filters
+  // plugin and wiping the active filter, so a filter set from the dropdown
+  // appeared to do nothing. This is the same ref-timing gotcha already handled
+  // for `registerFormatShortcuts` above; the identity guard makes it a no-op
+  // except on the first render after a new grid instance appears (the grid
+  // remounts on sheet/view `key` changes, resetting `_initOnlySettings`).
+  const filterInitInstanceRef = useRef<HotTableClass['hotInstance'] | null>(null);
+  useEffect(() => {
+    const hot = hotTableRef.current?.hotInstance;
+    if (!hot || filterInitInstanceRef.current === hot) return;
+    filterInitInstanceRef.current = hot;
+    markFilterSettingsInitOnly(hot);
+  });
 
   // Renderer for the active grouping column: plain text plus a count badge on
   // the group's first row. With cells merged, only the top row of a group is
@@ -1663,7 +1683,9 @@ export function SpreadsheetSurface({
         afterInit={() => {
           syncHotTableDimensions();
           applyGroupMerges();
-          markFilterSettingsInitOnly();
+          // markFilterSettingsInitOnly is driven by a post-mount effect instead:
+          // at afterInit the wrapper has not yet assigned the instance onto the
+          // ref, so calling it here would read undefined and silently no-op.
           syncHeaderOverlayScroll();
         }}
         // Runs after Handsontable has drawn and (mis)clamped the header overlay's


### PR DESCRIPTION
## Problem
Filtering a column by value stopped applying: unchecking values in the header dropdown and clicking OK did nothing (rows not trimmed). Reproduced in a screen recording on the Ruling Direction column.

Root cause (verified from code + runtime repro): markFilterSettingsInitOnly reads hotTableRef.current?.hotInstance but is called only from afterInit. In @handsontable/react@16.2.0 the instance is not yet assigned to the ref when afterInit fires, so the call no-ops. filters/dropdownMenu/contextMenu are therefore never added to _initOnlySettings, and the wrapper re-pushes filters via updateSettings on the next unrelated re-render, re-initializing the Filters plugin and discarding the active filter. Same ref-timing gotcha already fixed for registerFormatShortcuts.

## Solution
Drive markFilterSettingsInitOnly from a post-mount effect (per-instance identity guard), mirroring registerFormatShortcuts; make it accept an optional instance; remove the ineffective afterInit call.

## Verify
- Repro (React18 + handsontable@17.0.1 + @handsontable/react@16.2.0, jsdom): before fix, filter (4->2 rows) is wiped back to 4 on re-render; after fix it persists (stays 2). _initOnlySettings gains filters/dropdownMenu/contextMenu.
- ( cd frontend && npx tsc --noEmit ) -> clean
- git apply --ignore-whitespace --check on fresh main -> OK