### PR TITLE
feat(chat): add only_empty option to fill_column_from_reference

### DIFF
--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -509,6 +509,7 @@ class ToolExecutor:
           args.get("column"),
           args.get("reference_id"),
           rows=args.get("rows"),
+          only_empty=args.get("only_empty", False),
       )
 
   async def _handle_explain_cell(
@@ -1050,6 +1051,7 @@ class ToolExecutor:
           session_id,
           columns=args.get("columns"),
           scope=args.get("scope", "edited_only"),
+          only_empty=args.get("only_empty", False),
       )
 
   async def _handle_extract_cells(

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -285,7 +285,10 @@ def _all_tools() -> list[ToolSpec]:
                 "once) and fills each row as it completes. Use this instead of many "
                 "individual update_cell calls when populating a whole column from a "
                 "reference. Pass `rows` to fill only specific rows instead of the "
-                "whole column. Get the reference id from list_reference_sources."
+                "whole column. By default this OVERWRITES cells that already hold a "
+                "value (the reference is treated as authoritative); pass only_empty=true "
+                "to fill just the blank cells and leave existing values untouched. "
+                "Get the reference id from list_reference_sources."
             ),
             parameters={
                 "type": "object",
@@ -304,6 +307,14 @@ def _all_tools() -> list[ToolSpec]:
                         "description": (
                             "Optional observation-unit / row names to fill (as shown by "
                             "preview_data). Omit to fill every row in the column."
+                        ),
+                    },
+                    "only_empty": {
+                        "type": "boolean",
+                        "description": (
+                            "When false (default) the reference value overwrites cells "
+                            "that already hold a value. Set true to fill only cells that "
+                            "are currently empty and never overwrite an existing value."
                         ),
                     },
                 },
@@ -559,7 +570,10 @@ def _all_tools() -> list[ToolSpec]:
                 "when omitted it defaults to the edited/new columns only (scope='edited_only'). "
                 "Does not touch other columns or the observation unit unless scope='all'. Use "
                 "this for a targeted refresh after add_column/edit_column; use `reprocess` to "
-                "refresh the entire table. Does NOT re-include a document that was skipped "
+                "refresh the entire table. By default this OVERWRITES existing values in the "
+                "targeted columns; pass only_empty=true to fill just the blank cells and leave "
+                "existing values untouched (the safe choice when the user says fill/complete "
+                "missing cells rather than redo the column). Does NOT re-include a document that was skipped "
                 "during extraction (skipped documents stay skipped): if the user asks about a "
                 "missing document, call list_skipped_documents first."
             ),
@@ -580,6 +594,14 @@ def _all_tools() -> list[ToolSpec]:
                         "description": (
                             "Fallback when `columns` is omitted: 'edited_only' re-extracts the "
                             "edited/new columns, 'all' re-extracts every column."
+                        ),
+                    },
+                    "only_empty": {
+                        "type": "boolean",
+                        "description": (
+                            "When false (default) every targeted cell is re-extracted and "
+                            "existing values are overwritten. Set true to fill only blank "
+                            "cells and never overwrite a value that is already present."
                         ),
                     },
                 },

--- a/backend/app/services/reference_fill_service.py
+++ b/backend/app/services/reference_fill_service.py
@@ -171,12 +171,15 @@ class ReferenceFillService:
     async def start_fill(
         self, session_id: str, column: str, reference_id: str,
         rows: Optional[list[str]] = None,
+        only_empty: bool = False,
     ) -> dict[str, Any]:
         """Validate the request, then start the fill in the background.
 
         Returns immediately with the operation id and the number of rows to fill.
         When ``rows`` is given, only those observation-unit / row names are filled;
-        otherwise every row in the column is filled.
+        otherwise every row in the column is filled. When ``only_empty`` is set,
+        rows whose cell in ``column`` already holds a value are skipped, so the
+        reference never overwrites values that are already there.
         """
         column = (column or "").strip()
         reference_id = (reference_id or "").strip()
@@ -220,6 +223,23 @@ class ReferenceFillService:
                     "preview_data."
                 )
         rows = loaded_rows
+
+        if only_empty:
+            # Fill only cells that currently hold no value, so the reference does
+            # not overwrite values already present. A cell the model confirmed
+            # empty from the source documents is still a candidate here: the
+            # reference is a separate source that may hold the value.
+            from app.services.reextraction_service import _is_empty_cell_value
+            from app.services.data_utils import get_extraction_column_value
+            rows = [
+                r for r in rows
+                if _is_empty_cell_value(get_extraction_column_value(r, column))
+            ]
+            if not rows:
+                raise ValueError(
+                    f"Every targeted cell in '{column}' already has a value; "
+                    "nothing to fill with only_empty=true."
+                )
 
         column_obj = next(
             (c for c in session.columns if c.name == column), None

--- a/backend/tests/test_chat_executor.py
+++ b/backend/tests/test_chat_executor.py
@@ -200,9 +200,14 @@ async def test_fill_tool_delegates_to_background_service(executor, sample_sessio
 
     captured: dict = {}
 
-    async def fake_start(session_id, column, reference_id, rows=None):
+    async def fake_start(session_id, column, reference_id, rows=None, only_empty=False):
         captured.update(
-            {"session_id": session_id, "column": column, "reference_id": reference_id}
+            {
+                "session_id": session_id,
+                "column": column,
+                "reference_id": reference_id,
+                "only_empty": only_empty,
+            }
         )
         return {"status": "started", "fill_id": "f1", "total": 3}
 
@@ -212,4 +217,9 @@ async def test_fill_tool_delegates_to_background_service(executor, sample_sessio
         {"column": "Year", "reference_id": "r1"},
     )
     assert result["status"] == "started"
-    assert captured == {"session_id": sample_session.id, "column": "Year", "reference_id": "r1"}
+    assert captured == {
+        "session_id": sample_session.id,
+        "column": "Year",
+        "reference_id": "r1",
+        "only_empty": False,
+    }


### PR DESCRIPTION
## Problem
`fill_column_from_reference` calls `update_cell(update_all=True)` for every unit that produced an answer, so it **overwrites cells that already hold a value**. There was no way to fill only the blanks and protect existing (e.g. manually curated) data.

## Solution
Add an `only_empty` parameter (tool + handler + service). Default `false` preserves the current overwrite behavior; `true` filters the target rows to those whose cell in the column is currently empty before starting the fill. Emptiness is base-empty (`_is_empty_cell_value`), so a cell the source documents confirmed empty is still a candidate — the reference is a separate source that may hold the value. If nothing is empty in scope, the call reports that rather than starting a no-op job.

## Verify
- `git apply --ignore-whitespace --check` on a clean clone: OK
- `python -m py_compile` on all three changed files: OK