### PR TITLE
fix(reextraction): stop same-name unit from another document bleeding into a row

### DIFF
--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -2178,17 +2178,28 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
         if row_name and row_name in extracted_by_row_name:
             candidates = extracted_by_row_name[row_name]
-            if len(candidates) == 1:
-                return candidates[0]
-            for paper in papers:
-                paper_stem = (
-                    paper.split("_")[0].lower()
-                    if "_" in paper
-                    else paper.rsplit(".", 1)[0].lower()
-                )
+            # Prefer a candidate whose source document matches this row's own, so
+            # a same-name unit extracted from a *different* document is never
+            # merged in. row_dedup_key separates rows by (name, source) and the
+            # exact-key match above already handles the in-scope row; reaching
+            # here means this row's (name, source) was not re-extracted this run,
+            # so a blind same-name match would pull another document's values in.
+            row_stems = {
+                (p.split("_")[0].lower() if "_" in p else p.rsplit(".", 1)[0].lower())
+                for p in papers
+            }
+            if row_src:
+                row_stems.add(row_src.lower())
+            if row_stems:
                 for cand in candidates:
-                    if _resolve_source_document(cand).lower() == paper_stem:
+                    if _resolve_source_document(cand).lower() in row_stems:
                         return cand
+                # Known source but no candidate matches it: do not guess by name
+                # alone; fall through to the loose / paper-stem matching below.
+            elif len(candidates) == 1:
+                # No source on this row to disambiguate against; the single
+                # same-name candidate is the best available match.
+                return candidates[0]
 
         # OU rediscovery may shorten unit names — match by last name + source document.
         if row_name:

--- a/backend/tests/test_reextraction_match_cross_source.py
+++ b/backend/tests/test_reextraction_match_cross_source.py
@@ -1,0 +1,108 @@
+"""Tests for _match_extracted_row source disambiguation.
+
+Rows are keyed by (row_name, source_document), so the same unit name appearing
+in several documents is stored as separate rows. When a run re-extracts one of
+those rows, the matcher must not merge that extraction into a *different*
+same-name row from another document. See fix: "stop same-name unit from another
+document bleeding into a row".
+"""
+
+from unittest.mock import MagicMock
+
+from app.services.reextraction_service import ReextractionService
+
+
+def _make_service() -> ReextractionService:
+    return ReextractionService(MagicMock(), MagicMock())
+
+
+def _extracted(name: str, source: str, **cols) -> dict:
+    row = {"_row_name": name, "_source_document": source}
+    row.update(cols)
+    return row
+
+
+NAME = "Randolph D. Moss"
+DOC_Y = "AmicaDocY"
+DOC_X = "ImmigrantDocX"
+
+
+def _indexes(extracted_rows):
+    """Build the three lookup structures the matcher consumes."""
+    by_key = {}
+    by_row_name: dict = {}
+    by_paper_stem: dict = {}
+    for row in extracted_rows:
+        src = row["_source_document"]
+        by_key[(row["_row_name"], src)] = row
+        by_row_name.setdefault(row["_row_name"], []).append(row)
+        by_paper_stem.setdefault(src.lower(), []).append(row)
+    return by_key, by_row_name, by_paper_stem
+
+
+def test_exact_key_row_matches_its_own_extraction():
+    svc = _make_service()
+    only = _extracted(NAME, DOC_Y, policy="Biden")
+    by_key, by_row_name, by_paper_stem = _indexes([only])
+
+    match = svc._match_extracted_row(
+        NAME, DOC_Y, [f"{DOC_Y}.pdf"], by_key, by_row_name, by_paper_stem, set()
+    )
+    assert match is only
+
+
+def test_same_name_row_from_other_document_is_not_matched():
+    """The regression guard: only DOC_Y was re-extracted; the DOC_X row with the
+    same unit name must NOT pick up DOC_Y's extraction."""
+    svc = _make_service()
+    only = _extracted(NAME, DOC_Y, policy="Biden")
+    by_key, by_row_name, by_paper_stem = _indexes([only])
+
+    match = svc._match_extracted_row(
+        NAME, DOC_X, [f"{DOC_X}.pdf"], by_key, by_row_name, by_paper_stem, set()
+    )
+    assert match is None
+
+
+def test_row_without_source_falls_back_to_single_same_name_candidate():
+    """A row with no source document to disambiguate on still matches the single
+    same-name extraction (preserved behavior)."""
+    svc = _make_service()
+    only = _extracted(NAME, DOC_Y, policy="Biden")
+    by_key, by_row_name, by_paper_stem = _indexes([only])
+
+    match = svc._match_extracted_row(
+        NAME, "", [], by_key, by_row_name, by_paper_stem, set()
+    )
+    assert match is only
+
+
+def test_row_matched_by_paper_when_source_field_absent():
+    """A row whose source is only known via its papers list still matches the
+    candidate from that same paper."""
+    svc = _make_service()
+    only = _extracted(NAME, DOC_Y, policy="Biden")
+    by_key, by_row_name, by_paper_stem = _indexes([only])
+
+    match = svc._match_extracted_row(
+        NAME, "", [f"{DOC_Y}.pdf"], by_key, by_row_name, by_paper_stem, set()
+    )
+    assert match is only
+
+
+def test_correct_row_still_matches_when_both_documents_reextracted():
+    """When both same-name rows are re-extracted, each row gets its own source's
+    extraction via the exact-key path."""
+    svc = _make_service()
+    ext_y = _extracted(NAME, DOC_Y, policy="Biden")
+    ext_x = _extracted(NAME, DOC_X, policy="Trump")
+    by_key, by_row_name, by_paper_stem = _indexes([ext_y, ext_x])
+
+    match_x = svc._match_extracted_row(
+        NAME, DOC_X, [f"{DOC_X}.pdf"], by_key, by_row_name, by_paper_stem, set()
+    )
+    match_y = svc._match_extracted_row(
+        NAME, DOC_Y, [f"{DOC_Y}.pdf"], by_key, by_row_name, by_paper_stem, set()
+    )
+    assert match_x is ext_x
+    assert match_y is ext_y


### PR DESCRIPTION
## Problem
Rows are keyed by `(row_name, source_document)`, so a unit name recurring across documents is stored as separate rows. `_match_extracted_row`'s exact-name fallback returned a same-name candidate without verifying its source, so a scoped or only_empty run that re-extracts one `(name, source)` row merged that document's values into a *different* same-name row from another document (overwrite in a full run; wrong values into empty cells in an only_empty run). Reachable whenever a unit name recurs (e.g. a judge across cases) and the run is scoped.

## Solution
Prefer a candidate whose source document matches the row's own document/papers; fall back to a blind single-candidate match only when the row has no resolvable source. Rediscovery name-shortening is unaffected — it uses the separate loose-match path, which already checks source.

## Verify
- New test test_reextraction_match_cross_source.py (5 cases incl. the cross-source regression) — passes against _match_extracted_row.
- `git apply --ignore-whitespace --check` on a clean clone: OK
- `python -m py_compile` on code + test: OK