### PR TITLE
fix(workspace): Find highlight no longer vanishes on re-render

### DIFF
--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -74,6 +74,7 @@ export function SpreadsheetSurface({
   cellFormats,
   formatVersion,
   hotTableRef,
+  searchTermRef,
   onSelectionChange,
   onGroundingHighlight,
   onGroundingScrollRequest,
@@ -103,6 +104,11 @@ export function SpreadsheetSurface({
   cellFormats: CellFormatMap;
   formatVersion: number;
   hotTableRef: MutableRefObject<HotTableClass | null>;
+  // Active "Find in table" term, owned by the workspace (which drives the
+  // search). The grid re-applies it on every view render so the highlight
+  // survives unrelated re-renders (see beforeViewRender wiring below). `null`
+  // when no search is active.
+  searchTermRef?: MutableRefObject<string | null>;
   onSelectionChange: (selection: SheetSelection) => void;
   // Reports all grounding excerpts of the newly selected data cell (or null when
   // the cell has no grounding), so the source panel can highlight them.
@@ -740,6 +746,34 @@ export function SpreadsheetSurface({
     filterInitInstanceRef.current = hot;
     markFilterSettingsInitOnly(hot);
   });
+
+  // Keep the "Find in table" highlight alive across re-renders.
+  //
+  // The Search plugin marks matches with transient `isSearchResult` cell meta
+  // that a plain render preserves, but a @handsontable/react re-render (which
+  // re-pushes the full settings through updateSettings) rebuilds it, so the
+  // yellow highlight silently vanished on the next unrelated re-render
+  // (selection, toast, background refresh poll) even though the query itself
+  // was never cleared. Re-applying the active query in `beforeViewRender` -- so
+  // the meta is set again before the cells paint -- restores it in the same
+  // render with no extra render() call (and thus no risk of a render loop). The
+  // reentrancy guard covers any nested render the plugin might trigger, and the
+  // work is skipped entirely when no search is active.
+  const reapplyingSearchRef = useRef(false);
+  const reapplySearchHighlight = useCallback(() => {
+    if (reapplyingSearchRef.current) return;
+    const term = searchTermRef?.current;
+    if (!term) return;
+    const hot = hotTableRef.current?.hotInstance;
+    if (!hot) return;
+    try {
+      const search = hot.getPlugin('search');
+      if (!search?.isEnabled?.()) return;
+      reapplyingSearchRef.current = true;
+      search.query(term);
+    } catch { /* instance may be mid-teardown */ }
+    finally { reapplyingSearchRef.current = false; }
+  }, [hotTableRef, searchTermRef]);
 
   // Renderer for the active grouping column: plain text plus a count badge on
   // the group's first row. With cells merged, only the top row of a group is
@@ -1720,6 +1754,9 @@ export function SpreadsheetSurface({
         // scroll position, so the compensation above lands on final values.
         afterScrollHorizontally={syncHeaderOverlayScroll}
         afterScrollVertically={syncHeaderOverlayScroll}
+        // Re-mark search matches before each paint so a wrapper re-render that
+        // rebuilt the cell meta does not drop the active Find highlight.
+        beforeViewRender={reapplySearchHighlight}
         afterViewRender={syncHeaderOverlayScroll}
         afterColumnSort={applyGroupMerges}
         afterFilter={applyGroupMerges}

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -137,6 +137,11 @@ function Workspace() {
   const { toast } = useToast();
   const importInputRef = useRef<HTMLInputElement | null>(null);
   const hotTableRef = useRef<HotTableClass | null>(null);
+  // Active "Find in table" term. Held in a ref (not state) because it only
+  // needs to be read by the grid's beforeViewRender hook to re-apply the
+  // highlight after re-renders -- it never needs to trigger a React render
+  // itself. `null` when no search is active.
+  const activeSearchTermRef = useRef<string | null>(null);
   const [activeSheet, setActiveSheet] = useState<SheetId>('data');
   const [sessionMode, setSessionMode] = useState<WorkspaceSessionMode>(requestedMode);
   const [projectDialogOpen, setProjectDialogOpen] = useState(!sessionId);
@@ -1040,9 +1045,18 @@ function Workspace() {
 
   const searchPage = useCallback(() => {
     const term = window.prompt('Find in table')?.trim();
-    if (!term) return;
     const hot = hotTableRef.current?.hotInstance;
     if (!hot) return;
+    // Empty / cancelled prompt clears any active search. The grid now re-applies
+    // the active term on every render, so without a clear path an old highlight
+    // would persist until the sheet remounts.
+    if (!term) {
+      activeSearchTermRef.current = null;
+      hot.getPlugin('search').query('');
+      hot.render();
+      return;
+    }
+    activeSearchTermRef.current = term;
     const results = hot.getPlugin('search').query(term);
     hot.render();
     if (results.length === 0) {
@@ -1229,6 +1243,7 @@ function Workspace() {
         cellFormats={cellFormats}
         formatVersion={formatVersion}
         hotTableRef={hotTableRef}
+        searchTermRef={activeSearchTermRef}
         onSelectionChange={updateSheetSelection}
         onGroundingHighlight={handleGroundingHighlight}
         onGroundingScrollRequest={() => setGroundingScrollNonce((n) => n + 1)}


### PR DESCRIPTION
## Problem
Find in table (Search plugin) marks matches with transient isSearchResult cell meta. A @handsontable/react re-render re-pushes the full settings through updateSettings, which rebuilds that meta, so the highlight silently disappeared on the next unrelated re-render (selection, toast, background refresh poll) even though the query was never cleared. Verified: not caused by the data re-push, and not fixable via init-only (search re-push is not the trigger; the render rebuilds the meta).

## Solution
Persist the active term (activeSearchTermRef in Workspace) and re-apply query() in the grid's beforeViewRender so the meta is re-marked before cells paint -- same render, no extra render() call, no loop (reentrancy-guarded, skipped when no search is active). Add a clear path: an empty/cancelled Find prompt now clears the search so the highlight can't become permanently sticky.

## Verify
- Repro (React18 + handsontable@17.0.1 + @handsontable/react@16.2.0, jsdom): before fix, highlight 2 -> 0 after re-render; after fix it stays 2 across successive re-renders and clears to 0 on empty Find; no render loop.
- ( cd frontend && npx tsc --noEmit ) -> clean
- git apply --ignore-whitespace --check on fresh main (b4a597c) -> OK