### PR TITLE
fix(value-extraction): preserve _confirmed_empty marker through row merge

### DIFF
--- a/schematiq-lib/schematiq/value_extraction/core/row_manager.py
+++ b/schematiq-lib/schematiq/value_extraction/core/row_manager.py
@@ -91,6 +91,11 @@ class RowDataManager:
             if col_name not in merged:
                 if new_answer:  # Only add if there's actually an answer
                     merged[col_name] = new_col_data.copy()
+                elif new_col_data.get('_confirmed_empty'):
+                    # Model explicitly confirmed this cell is empty. Keep it (with
+                    # the marker) so only_empty re-runs treat it as resolved instead
+                    # of re-billing the model on the same gap every run.
+                    merged[col_name] = new_col_data.copy()
                 continue
                 
             existing_col_data = merged[col_name]
@@ -125,9 +130,18 @@ class RowDataManager:
                     unique_excerpts.append(excerpt)
                     seen.add(excerpt_clean)
             
-            merged[col_name] = {
+            merged_cell = {
                 'answer': merged_answer,
                 'excerpts': unique_excerpts
             }
+            # Preserve the model's confirmed-empty marker only while the cell
+            # stays empty. A non-empty merged answer means it is now filled, so
+            # the marker is intentionally dropped.
+            if not merged_answer and (
+                existing_col_data.get('_confirmed_empty')
+                or new_col_data.get('_confirmed_empty')
+            ):
+                merged_cell['_confirmed_empty'] = True
+            merged[col_name] = merged_cell
         
         return merged

--- a/schematiq-lib/tests/test_row_manager_confirmed_empty.py
+++ b/schematiq-lib/tests/test_row_manager_confirmed_empty.py
@@ -1,0 +1,74 @@
+"""Regression tests for _confirmed_empty preservation in RowManager.merge_row_data.
+
+A cell the LLM explicitly confirmed empty is stored as
+``{"answer": "", "excerpts": [], "_confirmed_empty": True}``. That marker lets
+only_empty re-extraction runs treat the cell as resolved (via ``_is_fillable_gap``)
+instead of re-billing the model on the same gap every run. merge_row_data used to
+reconstruct merged cells with only ``answer``/``excerpts`` and to drop empty new
+cells entirely, silently losing the marker. These tests pin the preservation.
+"""
+
+from schematiq.value_extraction.core.row_manager import RowDataManager
+
+
+def _confirmed_empty_cell():
+    return {"answer": "", "excerpts": [], "_confirmed_empty": True}
+
+
+def test_new_confirmed_empty_column_is_preserved():
+    rm = RowDataManager()
+    existing = {"_row_name": "Unit A", "_papers": ["paper1"]}
+    new = {"_row_name": "Unit A", "col": _confirmed_empty_cell()}
+
+    merged = rm.merge_row_data(existing, new, "paper2")
+
+    assert "col" in merged, "confirmed-empty cell was dropped on first write"
+    assert merged["col"].get("_confirmed_empty") is True
+
+
+def test_plain_empty_new_column_is_still_omitted():
+    # Only *confirmed* empties are preserved; a blank-without-marker cell keeps
+    # the prior behaviour of being omitted so it stays a fillable gap.
+    rm = RowDataManager()
+    existing = {"_row_name": "Unit A", "_papers": ["paper1"]}
+    new = {"_row_name": "Unit A", "col": {"answer": "", "excerpts": []}}
+
+    merged = rm.merge_row_data(existing, new, "paper2")
+
+    assert "col" not in merged
+
+
+def test_confirmed_empty_survives_merge_when_both_empty():
+    rm = RowDataManager()
+    existing = {"_row_name": "Unit A", "_papers": ["paper1"], "col": _confirmed_empty_cell()}
+    new = {"_row_name": "Unit A", "col": _confirmed_empty_cell()}
+
+    merged = rm.merge_row_data(existing, new, "paper2")
+
+    assert merged["col"].get("_confirmed_empty") is True
+    assert merged["col"]["answer"] == ""
+
+
+def test_real_answer_clears_confirmed_empty_marker():
+    # When a later paper supplies a real value, the cell is now filled and the
+    # marker must NOT linger (otherwise only_empty would wrongly skip a real cell).
+    rm = RowDataManager()
+    existing = {"_row_name": "Unit A", "_papers": ["paper1"], "col": _confirmed_empty_cell()}
+    new = {"_row_name": "Unit A", "col": {"answer": "42", "excerpts": ["found it"]}}
+
+    merged = rm.merge_row_data(existing, new, "paper2")
+
+    assert merged["col"]["answer"] == "42"
+    assert "_confirmed_empty" not in merged["col"]
+
+
+def test_existing_real_answer_is_not_overwritten_by_confirmed_empty():
+    # A confirmed-empty new cell must not wipe an existing real value.
+    rm = RowDataManager()
+    existing = {"_row_name": "Unit A", "_papers": ["paper1"], "col": {"answer": "keep me", "excerpts": []}}
+    new = {"_row_name": "Unit A", "col": _confirmed_empty_cell()}
+
+    merged = rm.merge_row_data(existing, new, "paper2")
+
+    assert merged["col"]["answer"] == "keep me"
+    assert "_confirmed_empty" not in merged["col"]


### PR DESCRIPTION
## Problem
When the LLM confirms a cell has no value, postprocess stores it as `{answer: '', excerpts: [], _confirmed_empty: true}`. `_is_fillable_gap` uses that marker so only_empty re-extraction treats the cell as resolved and does not re-bill the model on it. But `RowDataManager.merge_row_data` (used when a unit spans multiple papers, and on the legacy `build_table_jsonl` path) reconstructed merged cells with only `answer`/`excerpts` and dropped empty new cells entirely — silently losing the marker, so those cells reverted to looking like fresh gaps on every subsequent run.

## Solution
Preserve `_confirmed_empty` on merge while the cell stays empty (a non-empty merged answer clears it, since the cell is now filled), and keep confirmed-empty new cells instead of omitting them. Plain empty cells with no marker are still omitted, so genuine gaps remain fillable.

## Verify
- `python -m py_compile` on row_manager.py
- `pytest schematiq-lib/tests/test_row_manager_confirmed_empty.py` — 5 pass; the 2 preservation tests fail on the pre-fix code (negative-checked).