### PR TITLE
fix(reextraction): hydrate data files before only_empty narrowing scan

### DIFF
--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -1035,6 +1035,33 @@ class ReextractionService(WebSocketBroadcasterMixin):
             )
         return normalized
 
+    async def _hydrate_reextraction_data_files(self, session_id: str) -> None:
+        """Pull the data files the only_empty scan reads down to local disk.
+
+        ``_scan_only_empty_scope`` reads ``extracted_data.jsonl`` / ``data.jsonl``
+        straight off local disk via ``_resolve_reextraction_data_files``. On a
+        fresh worker -- e.g. after a Railway redeploy wipes the container, or a
+        worker that did not run the original extraction -- those files live only
+        in Supabase, so the scan reads nothing, returns ``readable=False``,
+        silently skips the only_empty narrowing, and runs a full (expensive)
+        extraction whose 'nothing to fill' gates never fire. Hydrating first
+        makes the scan see the current cell values. Best-effort: a candidate
+        with no storage mapping or an absent object is left as-is, as before.
+        """
+        from app.services.data_utils import (
+            ensure_session_data_file_local,
+            session_data_file_candidates,
+        )
+
+        for path in session_data_file_candidates(session_id):
+            try:
+                await ensure_session_data_file_local(session_id, path)
+            except Exception as exc:  # storage hiccup -> fall back to local view
+                logger.debug(
+                    "reextraction hydrate skipped for %s (session %s): %s",
+                    path, session_id, exc,
+                )
+
     def _resolve_reextraction_data_files(self, session_id: str) -> List[Path]:
         """Data files to read current cell values from, newest source first."""
         files: List[Path] = []
@@ -1291,6 +1318,10 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
         only_empty_targets: Optional[Dict[str, Dict[str, Dict[str, Any]]]] = None
         if only_empty:
+            # The scan below reads cell values off local disk; on a fresh worker
+            # they may live only in storage. Hydrate first so the narrowing is
+            # computed from real data instead of silently skipped (readable=False).
+            await self._hydrate_reextraction_data_files(session_id)
             scan = self._scan_only_empty_scope(
                 session_id, resolved, scoped_documents, scoped_rows,
                 retry_confirmed_empty=retry_confirmed_empty,

--- a/backend/tests/test_reextraction_only_empty_hydration.py
+++ b/backend/tests/test_reextraction_only_empty_hydration.py
@@ -1,0 +1,101 @@
+"""The only_empty narrowing scan must hydrate data files from storage first.
+
+_resolve_reextraction_data_files / _build_only_empty_targets read
+extracted_data.jsonl off local disk. On a fresh worker (post-redeploy, or a
+worker that did not run the original extraction) the file lives only in Supabase.
+Without hydration the scan finds nothing, silently skips only_empty narrowing,
+and runs a full extraction. These tests pin that _hydrate_reextraction_data_files
+pulls the file down so the scan sees the current cell values.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.reextraction_service import ReextractionService
+
+
+class InMemoryStorage:
+    def __init__(self, files: dict[str, bytes] | None = None):
+        self.files = dict(files or {})
+
+    async def download_file(self, bucket: str, path: str) -> bytes | None:
+        return self.files.get(f"{bucket}/{path}")
+
+    async def file_exists(self, bucket: str, path: str) -> bool:
+        return f"{bucket}/{path}" in self.files
+
+
+def _make_service() -> ReextractionService:
+    return ReextractionService(websocket_manager=MagicMock(), session_manager=MagicMock())
+
+
+def _jsonl(rows: list[dict]) -> bytes:
+    return "".join(json.dumps(r, ensure_ascii=False) + "\n" for r in rows).encode()
+
+
+@pytest.fixture
+def isolated_dirs(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "schematiq_work").mkdir(parents=True)
+    (tmp_path / "data").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_hydrates_extracted_data_from_storage_when_local_absent(isolated_dirs, monkeypatch):
+    tmp = isolated_dirs
+    session_id = "sess-hydrate-1"
+    rows = [{"_row_name": "Row A", "_papers": ["p1"], "col1": {"answer": "x", "excerpts": []}}]
+    storage = InMemoryStorage({f"data/{session_id}/extracted_data.jsonl": _jsonl(rows)})
+    monkeypatch.setattr("app.storage.get_storage", lambda: storage, raising=False)
+
+    local = tmp / "schematiq_work" / session_id / "extracted_data.jsonl"
+    assert not local.exists()  # fresh worker: nothing on disk
+
+    svc = _make_service()
+    await svc._hydrate_reextraction_data_files(session_id)
+
+    assert local.exists(), "extracted_data.jsonl was not hydrated from storage"
+    # And the sync scan resolver now finds it, so only_empty narrowing can run.
+    resolved = svc._resolve_reextraction_data_files(session_id)
+    assert local.resolve() in [p.resolve() for p in resolved]
+
+
+@pytest.mark.asyncio
+async def test_hydration_is_noop_when_local_file_present(isolated_dirs, monkeypatch):
+    tmp = isolated_dirs
+    session_id = "sess-hydrate-2"
+    local = tmp / "schematiq_work" / session_id / "extracted_data.jsonl"
+    local.parent.mkdir(parents=True, exist_ok=True)
+    local.write_bytes(_jsonl([{"_row_name": "Row A", "col1": {"answer": "local", "excerpts": []}}]))
+
+    # Storage has different content; hydration must NOT overwrite the local copy.
+    storage = InMemoryStorage(
+        {f"data/{session_id}/extracted_data.jsonl": _jsonl([{"_row_name": "Row A", "col1": {"answer": "remote", "excerpts": []}}])}
+    )
+    monkeypatch.setattr("app.storage.get_storage", lambda: storage, raising=False)
+
+    svc = _make_service()
+    await svc._hydrate_reextraction_data_files(session_id)
+
+    with open(local, encoding="utf-8") as f:
+        row = json.loads(f.readline())
+    assert row["col1"]["answer"] == "local"
+
+
+@pytest.mark.asyncio
+async def test_hydration_survives_storage_error(isolated_dirs, monkeypatch):
+    session_id = "sess-hydrate-3"
+
+    class BoomStorage:
+        async def download_file(self, bucket, path):
+            raise RuntimeError("storage down")
+
+    monkeypatch.setattr("app.storage.get_storage", lambda: BoomStorage(), raising=False)
+
+    svc = _make_service()
+    # Must not raise: a storage hiccup falls back to the local (empty) view.
+    await svc._hydrate_reextraction_data_files(session_id)


### PR DESCRIPTION
## Problem
The only_empty narrowing scan (`_find_empty_target_cells` / `_build_only_empty_targets`) reads `extracted_data.jsonl` / `data.jsonl` off local disk via `_resolve_reextraction_data_files`. `start_gated_reextraction` does not hydrate those files first (`capture_and_save_baseline` only touches the session schema; `discover_papers` only touches documents). On a fresh worker — after a Railway redeploy wipes the container, or a worker that did not run the original extraction — the files live only in Supabase, so the scan finds nothing, silently skips the narrowing, and runs a full extraction. Results stay correct (the merge guard still prevents overwriting filled cells) but the model is re-billed on already-filled columns and the 'nothing to fill' gates never fire.

## Solution
Add `_hydrate_reextraction_data_files`, which hydrates the three candidate paths (the ones `_resolve_reextraction_data_files` checks) via the existing `ensure_session_data_file_local`, and call it once at the top of the only_empty block before the scan. `storage_path_for_data_file` already maps `extracted_data.jsonl`. Best-effort: a storage error falls back to the local view, and an already-local file is left untouched (never overwritten from storage).

## Verify
- `python -m py_compile` on reextraction_service.py
- `pytest tests/test_reextraction_only_empty_hydration.py` — 3 pass (hydrate-when-absent, no-op-when-present, survive-storage-error); the hydrate test fails on pre-fix code (negative-checked)
- `pytest` reextraction + gating suites — 23 pass