### PR TITLE
fix(reextraction): correct progress counting and skip I/O for scoped re-extraction

### DIFF
--- a/backend/app/api/routes/schema.py
+++ b/backend/app/api/routes/schema.py
@@ -42,6 +42,7 @@ class ColumnEditRequest(BaseModel):
     definition: Optional[str] = None
     rationale: Optional[str] = None
     allowed_values: Optional[List[str]] = None  # Closed set of valid values
+    extraction_strategy: Optional[str] = None  # document | web | document_then_web
     reprocess: bool = True
 
 class ColumnAddRequest(BaseModel):
@@ -51,6 +52,7 @@ class ColumnAddRequest(BaseModel):
     allowed_values: Optional[List[str]] = None  # Closed set of valid values
     documents_path: Optional[str] = None
     data_type: str = "text"
+    extraction_strategy: str = "document"  # document | web | document_then_web
     llm_config: Optional[Dict[str, Any]] = None  # User-provided LLM config with API key
 
 class ColumnMergeRequest(BaseModel):
@@ -133,6 +135,10 @@ async def edit_column(
                 if edit_request.allowed_values is not None:
                     # Empty list means clear allowed_values, otherwise set the list
                     col.allowed_values = edit_request.allowed_values if edit_request.allowed_values else None
+                if edit_request.extraction_strategy is not None:
+                    if edit_request.extraction_strategy not in ("document", "web", "document_then_web"):
+                        raise HTTPException(status_code=400, detail="extraction_strategy must be document, web, or document_then_web")
+                    col.extraction_strategy = edit_request.extraction_strategy
                 column_found = True
                 break
 
@@ -149,6 +155,7 @@ async def edit_column(
                 "definition_changed": edit_request.definition is not None,
                 "rationale_changed": edit_request.rationale is not None,
                 "allowed_values_changed": edit_request.allowed_values is not None,
+                "extraction_strategy_changed": edit_request.extraction_strategy is not None,
             }
         )
         session.modification_history.append(modification)
@@ -316,6 +323,9 @@ async def add_column(
             if col.name == canonical_name:
                 raise HTTPException(status_code=400, detail=f"Column '{canonical_name}' already exists")
         
+        if add_request.extraction_strategy not in ("document", "web", "document_then_web"):
+            raise HTTPException(status_code=400, detail="extraction_strategy must be document, web, or document_then_web")
+
         # Create new column
         new_column = ColumnInfo(
             name=canonical_name,
@@ -323,7 +333,8 @@ async def add_column(
             definition=add_request.definition,
             rationale=add_request.rationale or "",
             data_type=add_request.data_type,
-            allowed_values=add_request.allowed_values if add_request.allowed_values else None
+            allowed_values=add_request.allowed_values if add_request.allowed_values else None,
+            extraction_strategy=add_request.extraction_strategy
         )
         
         session.columns.append(new_column)

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -26,6 +26,9 @@ class SessionStatus(str, Enum):
     PROCESSING_DOCUMENTS = "processing_documents"  # Processing documents with ScheMatiQ pipeline
     OBSERVATION_UNIT_REVIEW = "observation_unit_review"  # Paused for user to review observation unit
 
+
+ColumnExtractionStrategy = Literal["document", "web", "document_then_web"]
+
 class ObservationUnitInfo(BaseModel):
     """
     Defines what constitutes a single row (observation unit) in the extracted table.
@@ -80,6 +83,7 @@ class ColumnInfo(BaseModel):
     allowed_values: Optional[List[str]] = None  # Closed set of valid values for categorical columns
     auto_expand_threshold: Optional[int] = 2  # Auto-add new value if seen in N+ docs (None/0 = disabled)
     pending_values: Optional[List[PendingValue]] = None  # Values pending approval
+    extraction_strategy: ColumnExtractionStrategy = "document"
 
 
 class ColumnBaseline(BaseModel):
@@ -88,6 +92,7 @@ class ColumnBaseline(BaseModel):
     definition: str = ""
     rationale: str = ""
     allowed_values: Optional[List[str]] = None
+    extraction_strategy: ColumnExtractionStrategy = "document"
     checksum: str = ""  # MD5 hash of definition + rationale + allowed_values
 
 

--- a/backend/app/services/chat/tool_executor.py
+++ b/backend/app/services/chat/tool_executor.py
@@ -38,6 +38,16 @@ logger = logging.getLogger(__name__)
 # Max characters of a reference document returned by read_reference_source. Kept
 # below the tool-result truncation budget so the body is never dropped wholesale.
 READ_REFERENCE_CHAT_BUDGET = 6000
+VALID_EXTRACTION_STRATEGIES = {"document", "web", "document_then_web"}
+
+
+def _extraction_strategy(args: dict[str, Any], default: str = "document") -> str:
+    strategy = args.get("extraction_strategy", default)
+    if strategy not in VALID_EXTRACTION_STRATEGIES:
+        raise ValueError(
+            "extraction_strategy must be document, web, or document_then_web"
+        )
+    return strategy
 
 
 class ToolExecutor:
@@ -627,6 +637,7 @@ class ToolExecutor:
           raise ValueError("Session not found")
       definition = args["definition"]
       rationale = args.get("rationale", "") or ""
+      extraction_strategy = _extraction_strategy(args)
       name, display_name = canonicalize_column_name(args["name"])
       if not name:
           raise ValueError("Column name cannot be empty")
@@ -634,14 +645,22 @@ class ToolExecutor:
           if col.name == name:
               raise ValueError(f"Column '{name}' already exists")
       new_column = ColumnInfo(
-          name=name, display_name=display_name, definition=definition, rationale=rationale
+          name=name,
+          display_name=display_name,
+          definition=definition,
+          rationale=rationale,
+          extraction_strategy=extraction_strategy,
       )
       session.columns.append(new_column)
       session.modification_history.append(
           ModificationAction(
               action_type="column_added",
               column_name=name,
-              details={"definition": definition, "rationale": rationale},
+              details={
+                  "definition": definition,
+                  "rationale": rationale,
+                  "extraction_strategy": extraction_strategy,
+              },
           )
       )
       session.metadata.last_modified = datetime.now()
@@ -669,6 +688,9 @@ class ToolExecutor:
       old_name = args["old_name"]
       definition = args.get("definition")
       rationale = args.get("rationale")
+      extraction_strategy = (
+          _extraction_strategy(args) if "extraction_strategy" in args else None
+      )
       new_name: Optional[str] = None
       new_display_name: Optional[str] = None
       if args.get("new_name"):
@@ -690,13 +712,21 @@ class ToolExecutor:
                   col.definition = definition
               if rationale is not None:
                   col.rationale = rationale
+              if extraction_strategy is not None:
+                  col.extraction_strategy = extraction_strategy
               column_found = True
               break
       if not column_found:
           raise ValueError(f"Column '{old_name}' not found")
-      if new_name is None and definition is None and rationale is None:
+      if (
+          new_name is None
+          and definition is None
+          and rationale is None
+          and extraction_strategy is None
+      ):
           raise ValueError(
-              "Nothing to update: provide new_name, definition, and/or rationale."
+              "Nothing to update: provide new_name, definition, rationale, "
+              "and/or extraction_strategy."
           )
       session.modification_history.append(
           ModificationAction(
@@ -707,6 +737,7 @@ class ToolExecutor:
                   "new_name": new_name,
                   "definition_changed": definition is not None,
                   "rationale_changed": rationale is not None,
+                  "extraction_strategy_changed": extraction_strategy is not None,
               },
           )
       )
@@ -742,6 +773,8 @@ class ToolExecutor:
           changed.append("definition")
       if rationale is not None:
           changed.append("rationale")
+      if extraction_strategy is not None:
+          changed.append("extraction_strategy")
       changed_label = ", ".join(changed) if changed else "no fields"
       return {
           "status": "success",

--- a/backend/app/services/chat/tool_registry.py
+++ b/backend/app/services/chat/tool_registry.py
@@ -338,6 +338,15 @@ def _all_tools() -> list[ToolSpec]:
                             "(optional)."
                         ),
                     },
+                    "extraction_strategy": {
+                        "type": "string",
+                        "enum": ["document", "web", "document_then_web"],
+                        "description": (
+                            "Where values come from: document (default), web (always use "
+                            "grounded web search), or document_then_web (use the source "
+                            "document first and search the web only when it has no value)."
+                        ),
+                    },
                 },
                 "required": ["name", "definition"],
             },
@@ -349,7 +358,8 @@ def _all_tools() -> list[ToolSpec]:
             description=(
                 "Rename or update a SCHEMA COLUMN (data table field): its name, definition "
                 "(what the column captures), and/or rationale (why the column matters / how to "
-                "extract it). Does not change the observation unit definition — use "
+                "extract it), including whether values come from documents or grounded web "
+                "search. Does not change the observation unit definition — use "
                 "edit_observation_unit for that. Call get_schema first for the exact column "
                 "name and to confirm WHICH column the user means before editing; never edit "
                 "multiple columns unless the user explicitly asked for all of them. Does not "
@@ -366,6 +376,15 @@ def _all_tools() -> list[ToolSpec]:
                         "description": (
                             "Updated rationale: why this column matters for the query / guidance "
                             "for extraction (optional). Pass an empty string to clear it."
+                        ),
+                    },
+                    "extraction_strategy": {
+                        "type": "string",
+                        "enum": ["document", "web", "document_then_web"],
+                        "description": (
+                            "Where values come from: document (default), web (always use "
+                            "grounded web search), or document_then_web (use the source "
+                            "document first and search the web only when it has no value)."
                         ),
                     },
                 },

--- a/backend/app/services/orchestration.py
+++ b/backend/app/services/orchestration.py
@@ -37,6 +37,9 @@ from app.services import (
 from app.services.continue_discovery_service import ContinueDiscoveryService
 from app.services.reextraction_service import ReextractionService
 from app.services.schematiq_runner import ScheMatiQRunner
+from app.services.web_enrichment_service import WebEnrichmentService
+
+web_enrichment_service = WebEnrichmentService(session_manager=session_manager)
 
 schematiq_runner = ScheMatiQRunner(
     websocket_manager=websocket_manager,
@@ -52,6 +55,7 @@ reextraction_service = ReextractionService(
     data_collection_service=data_collection_service,
     pubmed_enrichment_service=pubmed_enrichment_service,
     uniprot_enrichment_service=uniprot_enrichment_service,
+    web_enrichment_service=web_enrichment_service,
 )
 
 continue_discovery_service = ContinueDiscoveryService(

--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -6,7 +6,6 @@ Handles schema change detection, paper discovery, and selective re-extraction.
 import json
 import os
 import asyncio
-import hashlib
 import threading
 import uuid
 import logging
@@ -19,6 +18,11 @@ from app.models.session import (
 )
 from app.services.websocket_manager import WebSocketManager
 from app.services.session_manager import SessionManager
+from app.services.schema_baseline import (
+    build_column_baseline,
+    build_schema_baseline,
+    calculate_column_checksum,
+)
 from app.services.websocket_mixin import WebSocketBroadcasterMixin
 from app.services.atomic_jsonl import write_jsonl_atomic
 from app.services import schematiq_thread_pool, concurrency_limiter, llm_call_tracker_lock
@@ -174,7 +178,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
 
     def __init__(self, websocket_manager: WebSocketManager, session_manager: SessionManager,
                  data_collection_service=None, pubmed_enrichment_service=None,
-                 uniprot_enrichment_service=None):
+                 uniprot_enrichment_service=None, web_enrichment_service=None):
         super().__init__(websocket_manager)
         self.session_manager = session_manager
         self.active_operations: Dict[str, ReextractionOperation] = {}
@@ -184,6 +188,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
         self._data_collection_service = data_collection_service
         self._pubmed_enrichment_service = pubmed_enrichment_service
         self._uniprot_enrichment_service = uniprot_enrichment_service
+        self._web_enrichment_service = web_enrichment_service
         self._incremental_merge_locks: Dict[str, asyncio.Lock] = {}
 
     @staticmethod
@@ -308,31 +313,9 @@ class ReextractionService(WebSocketBroadcasterMixin):
         from app.services.data_utils import is_local_path
         return is_local_path(path)
 
-    @staticmethod
-    def calculate_column_checksum(column: ColumnInfo) -> str:
-        """Calculate a checksum for change detection."""
-        content = f"{column.definition or ''}{column.rationale or ''}"
-        if column.allowed_values:
-            content += "|".join(sorted(column.allowed_values))
-        return hashlib.md5(content.encode()).hexdigest()
-
     def capture_baseline(self, session: VisualizationSession) -> SchemaBaseline:
         """Capture the current schema state as a baseline."""
-        columns_dict = {}
-        for col in session.columns:
-            if col.name and not col.name.lower().endswith('_excerpt'):
-                columns_dict[col.name] = ColumnBaseline(
-                    name=col.name,
-                    definition=col.definition or "",
-                    rationale=col.rationale or "",
-                    allowed_values=col.allowed_values,
-                    checksum=self.calculate_column_checksum(col)
-                )
-
-        return SchemaBaseline(
-            columns=columns_dict,
-            captured_at=datetime.now()
-        )
+        return build_schema_baseline(session.columns)
 
     async def capture_and_save_baseline(self, session_id: str) -> None:
         """Capture baseline and save to session."""
@@ -395,7 +378,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
             else:
                 # Check for changes
                 baseline = baseline_columns[col.name]
-                current_checksum = self.calculate_column_checksum(col)
+                current_checksum = calculate_column_checksum(col)
                 # Detect rename: baseline entry was moved to new key but name field still has old name
                 was_renamed = col.name != baseline.name
 
@@ -430,13 +413,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 # do NOT recapture the whole baseline, or we'd erase real edits.
                 for col_name in stale_cols:
                     col = next(c for c in session.columns if c.name == col_name)
-                    session.schema_baseline.columns[col_name] = ColumnBaseline(
-                        name=col.name,
-                        definition=col.definition or "",
-                        rationale=col.rationale or "",
-                        allowed_values=col.allowed_values,
-                        checksum=self.calculate_column_checksum(col),
-                    )
+                    session.schema_baseline.columns[col_name] = build_column_baseline(col)
                 self.session_manager.update_session(session)
                 # Inline re-detection: remove the now-patched stale columns from
                 # the result so they are no longer reported as new or changed,
@@ -463,6 +440,9 @@ class ReextractionService(WebSocketBroadcasterMixin):
         if current_values != baseline_values:
             return "allowed_values"
 
+        if current.extraction_strategy != baseline.extraction_strategy:
+            return "extraction_strategy"
+
         return "unknown"
 
     def _get_change_old_value(self, change_type: str, baseline: ColumnBaseline) -> Optional[str]:
@@ -472,6 +452,8 @@ class ReextractionService(WebSocketBroadcasterMixin):
             return baseline.rationale
         elif change_type == "allowed_values":
             return ", ".join(baseline.allowed_values or [])
+        elif change_type == "extraction_strategy":
+            return baseline.extraction_strategy
         return None
 
     def _get_change_new_value(self, change_type: str, current: ColumnInfo) -> Optional[str]:
@@ -481,6 +463,8 @@ class ReextractionService(WebSocketBroadcasterMixin):
             return current.rationale
         elif change_type == "allowed_values":
             return ", ".join(current.allowed_values or [])
+        elif change_type == "extraction_strategy":
+            return current.extraction_strategy
         return None
 
     # ==================== Paper Discovery ====================
@@ -1282,6 +1266,12 @@ class ReextractionService(WebSocketBroadcasterMixin):
         resolved = await self.resolve_reextraction_columns(session_id, columns, scope)
 
         session = self.session_manager.get_session(session_id)
+        selected_columns = [
+            col for col in (session.columns if session else []) if col.name in resolved
+        ]
+        requires_documents = any(
+            col.extraction_strategy != "web" for col in selected_columns
+        )
         renamed_from = (
             self._collect_renamed_from_history(session, resolved) if session else {}
         )
@@ -1379,9 +1369,9 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 # rows to compare against and are re-discovered from scratch.
                 if scan.empty_columns:
                     resolved = [c for c in resolved if c in scan.empty_columns]
-                if scoped_documents is None:
+                if scoped_documents is None and requires_documents:
                     scoped_documents = sorted(scan.docs_with_empties)
-                else:
+                elif scoped_documents is not None:
                     scoped_documents = [
                         d for d in scoped_documents
                         if d in scan.docs_with_empties or d in skipped_scope
@@ -1394,39 +1384,36 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 # extraction in the lib.
                 only_empty_targets = scan.plan
 
-        availability = await self.precheck_document_availability(
-            session_id,
-            operation_type="reextraction",
-            paper_discovery=paper_discovery,
-        )
-        if scoped_documents:
-            # Document-scoped run (e.g. extract_cells on a single skipped file):
-            # gate only on the requested documents, not the whole project, so a
-            # targeted re-extraction is not blocked by unrelated documents that
-            # happen to be unreachable. A skipped document re-attached via "Show
-            # source document" lands on disk and is picked up here.
-            scoped_avail = self._scoped_documents_availability(
-                session_id, scoped_documents, availability
+        if requires_documents:
+            availability = await self.precheck_document_availability(
+                session_id,
+                operation_type="reextraction",
+                paper_discovery=paper_discovery,
             )
-            scoped_missing = scoped_avail["missing"]
-            if scoped_missing:
-                raise ValueError(
-                    f"{len(scoped_missing)} source document(s) are unavailable: "
-                    f"{', '.join(scoped_missing)}. Open a row from one of them and "
-                    "use \"Show source document\" to re-attach the file, then try "
-                    "again."
+            if scoped_documents:
+                # Gate only the document scope needed by document/hybrid columns.
+                scoped_avail = self._scoped_documents_availability(
+                    session_id, scoped_documents, availability
                 )
-        elif not availability.get("can_proceed", False):
-            missing = availability.get("missing_documents") or []
-            if missing:
+                scoped_missing = scoped_avail["missing"]
+                if scoped_missing:
+                    raise ValueError(
+                        f"{len(scoped_missing)} source document(s) are unavailable: "
+                        f"{', '.join(scoped_missing)}. Open a row from one of them and "
+                        "use \"Show source document\" to re-attach the file, then try "
+                        "again."
+                    )
+            elif not availability.get("can_proceed", False):
+                missing = availability.get("missing_documents") or []
+                if missing:
+                    raise ValueError(
+                        f"{len(missing)} source document(s) are unavailable. "
+                        "Add them from the Documents tab, then try again."
+                    )
                 raise ValueError(
-                    f"{len(missing)} source document(s) are unavailable. "
-                    "Add them from the Documents tab, then try again."
+                    "No source documents available. Add the original source "
+                    "documents from the Documents tab, then try again."
                 )
-            raise ValueError(
-                "No source documents available. Add the original source "
-                "documents from the Documents tab, then try again."
-            )
 
         return await self.start_reextraction(
             session_id,
@@ -1475,10 +1462,20 @@ class ReextractionService(WebSocketBroadcasterMixin):
         if invalid_columns:
             raise ValueError(f"Invalid columns: {invalid_columns}")
 
+        selected_columns = [col for col in session.columns if col.name in columns]
+        requires_documents = any(
+            col.extraction_strategy != "web" for col in selected_columns
+        )
+        has_web_columns = any(
+            col.extraction_strategy != "document" for col in selected_columns
+        )
+        if has_web_columns and self._web_enrichment_service is None:
+            raise RuntimeError("Web enrichment service is not configured")
+
         # Validate observation_unit (required by value extraction pipeline)
         # Must check before spawning background task to avoid race condition
         # where the error fires before the WebSocket connects.
-        if not session.observation_unit:
+        if requires_documents and not session.observation_unit:
             inferred_unit_name = None
             data_dir = Path(DEFAULT_DATA_DIR) / session_id
             schematiq_dir = Path(DEFAULT_SCHEMATIQ_WORK_DIR) / session_id
@@ -1539,6 +1536,10 @@ class ReextractionService(WebSocketBroadcasterMixin):
             llm = self._get_llm_from_session(session_id)
         except Exception as e:
             raise ValueError(f"LLM configuration error: {e}")
+        if has_web_columns and not callable(getattr(llm, "generate_grounded", None)):
+            raise ValueError(
+                "Web-sourced columns require a Gemini model with Google Search grounding."
+            )
 
         # Create operation
         operation_id = str(uuid.uuid4())[:8]
@@ -1744,6 +1745,18 @@ class ReextractionService(WebSocketBroadcasterMixin):
             if not session:
                 raise ValueError(f"Session {operation.session_id} not found")
 
+            target_columns = [
+                col for col in session.columns if col.name in operation.columns
+            ]
+            document_columns = [
+                col for col in target_columns if col.extraction_strategy != "web"
+            ]
+            web_columns = [
+                col for col in target_columns
+                if col.extraction_strategy != "document"
+            ]
+            document_column_names = [col.name for col in document_columns]
+
             data_dir = Path(DEFAULT_DATA_DIR) / operation.session_id
             schematiq_dir = Path(DEFAULT_SCHEMATIQ_WORK_DIR) / operation.session_id
             session_dir = data_dir  # Keep for schema/output file paths
@@ -1766,7 +1779,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 paper_discovery = await self.discover_papers(operation.session_id)
             logger.debug(f"Paper discovery result - available: {len(paper_discovery.get('available_papers', []))}, cloud: {len(paper_discovery.get('cloud_papers', {}))}, missing: {len(paper_discovery.get('missing_papers', []))}")
 
-            if paper_discovery.get("cloud_papers"):
+            if document_columns and paper_discovery.get("cloud_papers"):
                 logger.debug(f"Downloading {len(paper_discovery['cloud_papers'])} cloud papers...")
                 downloaded = await self.download_cloud_papers(
                     operation.session_id,
@@ -1775,12 +1788,6 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 logger.debug(f"Downloaded {len(downloaded)} papers from cloud storage for re-extraction")
             else:
                 logger.debug("No cloud papers to download")
-
-            # Get target columns
-            target_columns = [
-                col for col in session.columns
-                if col.name in operation.columns
-            ]
 
             # Build schema for extraction
             schema_data = {
@@ -1792,7 +1799,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                         "explanation": col.rationale or f"Information for {col.name}",
                         "allowed_values": col.allowed_values
                     }
-                    for col in target_columns
+                    for col in document_columns
                 ]
             }
 
@@ -1805,14 +1812,16 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 if session.observation_unit.example_names:
                     schema_data["observation_unit"]["example_names"] = session.observation_unit.example_names
 
-            # Save schema file
+            # Save a document-extraction schema only for document/hybrid columns.
             schema_file = session_dir / f"reextract_schema_{operation_id}.json"
-            with open(schema_file, 'w') as f:
-                json.dump(schema_data, f, indent=2)
+            if document_columns:
+                with open(schema_file, 'w') as f:
+                    json.dump(schema_data, f, indent=2)
 
-            # Setup LLM and retriever (use cached retriever for performance)
+            # The same configured Gemini instance serves document extraction and
+            # the physically separate grounded web path.
             llm = self._get_llm_from_session(operation.session_id)
-            retriever = self.get_cached_retriever()
+            retriever = self.get_cached_retriever() if document_columns else None
 
             output_file = session_dir / f"reextract_output_{operation_id}.jsonl"
 
@@ -1836,7 +1845,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                                 "document_name": paper_title,
                                 "document_index": doc_index[0],
                                 "total_documents": operation.total_documents,
-                                "columns": operation.columns,
+                                "columns": document_column_names,
                             }
                         ),
                         loop
@@ -1850,7 +1859,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                     future = asyncio.run_coroutine_threadsafe(
                         self._merge_incremental_unit_row(
                             operation.session_id,
-                            operation.columns,
+                            document_column_names,
                             dict(unit_row),
                             operation,
                             renamed_from=operation.renamed_from,
@@ -1910,17 +1919,17 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 [str(d) for d in docs_directories],
                 len(docs_directories),
             )
-            if operation.total_documents > 0 and not docs_directories:
+            if document_columns and operation.total_documents > 0 and not docs_directories:
                 raise RuntimeError(
                     "No document directories found on disk for this session. "
                     "Re-upload documents on the Data tab and try again."
                 )
 
-            rediscover_observation_units = bool(
+            rediscover_observation_units = bool(document_columns) and bool(
                 session.metadata.pending_observation_unit_rediscovery
             )
 
-            if docs_directories:
+            if document_columns and docs_directories:
                 logger.debug("Starting build_table_jsonl extraction...")
 
                 known_units = self._build_known_units_for_reextraction(
@@ -1979,6 +1988,27 @@ class ReextractionService(WebSocketBroadcasterMixin):
                 # Load reference context before entering the sync extraction thread.
                 reference_context = await build_reference_context(session)
 
+                document_targets = operation.only_empty_targets
+                if document_targets is not None and web_columns:
+                    allowed = set(document_column_names)
+                    document_targets = {
+                        paper: {
+                            unit: {
+                                "targets": [
+                                    name for name in plan.get("targets", [])
+                                    if name in allowed
+                                ],
+                                "filled": {
+                                    name: value
+                                    for name, value in plan.get("filled", {}).items()
+                                    if name in allowed
+                                },
+                            }
+                            for unit, plan in units.items()
+                        }
+                        for paper, units in document_targets.items()
+                    }
+
                 def run_extraction():
                     return build_table_jsonl(
                         schema_path=schema_file,
@@ -1995,7 +2025,7 @@ class ReextractionService(WebSocketBroadcasterMixin):
                         on_document_started=on_document_started,
                         should_stop=should_stop,  # Allow graceful stop
                         known_units=known_units if known_units else None,
-                        unit_targets_by_paper=operation.only_empty_targets,
+                        unit_targets_by_paper=document_targets,
                         write_skip_rationale_artifact=session.write_artifacts,
                         reference_context=reference_context,
                     )
@@ -2005,17 +2035,39 @@ class ReextractionService(WebSocketBroadcasterMixin):
             else:
                 logger.debug("No document directories exist, skipping extraction")
 
-            # Merge results with existing data
-            logger.debug("Merging re-extracted data...")
-            await self._merge_reextracted_data(
-                operation.session_id,
-                operation.columns,
-                output_file,
-                renamed_from=operation.renamed_from,
-                initial_matched_keys=operation.incrementally_merged_keys,
-                only_empty=operation.only_empty,
-                retry_confirmed_empty=operation.retry_confirmed_empty,
-            )
+            if document_columns:
+                logger.debug("Merging document re-extraction data...")
+                await self._merge_reextracted_data(
+                    operation.session_id,
+                    document_column_names,
+                    output_file,
+                    renamed_from=operation.renamed_from,
+                    initial_matched_keys=operation.incrementally_merged_keys,
+                    only_empty=operation.only_empty,
+                    retry_confirmed_empty=operation.retry_confirmed_empty,
+                )
+
+            if web_columns:
+                async def on_web_cell(row_name: str, column_name: str, value: Any):
+                    await self.broadcast_cell_extracted(
+                        operation.session_id,
+                        {
+                            "row_name": row_name,
+                            "column": column_name,
+                            "value": value,
+                        },
+                    )
+
+                await self._web_enrichment_service.enrich_columns(
+                    operation.session_id,
+                    web_columns,
+                    llm,
+                    documents=operation.documents,
+                    rows=operation.rows,
+                    only_empty=operation.only_empty,
+                    should_stop=lambda: self.is_stop_requested(operation_id),
+                    on_cell=on_web_cell,
+                )
 
             # Update baseline after successful extraction
             await self.capture_and_save_baseline(operation.session_id)

--- a/backend/app/services/schema_baseline.py
+++ b/backend/app/services/schema_baseline.py
@@ -1,0 +1,45 @@
+"""Shared schema-baseline construction and checksum helpers."""
+
+import hashlib
+from datetime import datetime
+from typing import Iterable
+
+from app.models.session import ColumnBaseline, ColumnInfo, SchemaBaseline
+
+
+def calculate_column_checksum(column: ColumnInfo) -> str:
+    """Return the stable checksum used for schema-change detection.
+
+    The default document strategy deliberately keeps the legacy checksum so
+    persisted baselines do not make every existing column look edited.
+    """
+    content = f"{column.definition or ''}{column.rationale or ''}"
+    if column.extraction_strategy != "document":
+        content += f"|strategy:{column.extraction_strategy}"
+    if column.allowed_values:
+        content += "|".join(sorted(column.allowed_values))
+    return hashlib.md5(content.encode()).hexdigest()
+
+
+def build_column_baseline(column: ColumnInfo) -> ColumnBaseline:
+    """Create the persisted baseline representation of one column."""
+    return ColumnBaseline(
+        name=column.name,
+        definition=column.definition or "",
+        rationale=column.rationale or "",
+        allowed_values=column.allowed_values,
+        extraction_strategy=column.extraction_strategy,
+        checksum=calculate_column_checksum(column),
+    )
+
+
+def build_schema_baseline(columns: Iterable[ColumnInfo]) -> SchemaBaseline:
+    """Create a baseline for all real data columns in a schema."""
+    return SchemaBaseline(
+        columns={
+            column.name: build_column_baseline(column)
+            for column in columns
+            if column.name and not column.name.lower().endswith("_excerpt")
+        },
+        captured_at=datetime.now(),
+    )

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -1,13 +1,13 @@
 """Session management service."""
 
-import hashlib
 import logging
 import threading
 from typing import Dict, Optional
 from datetime import datetime
 
-from app.models.session import VisualizationSession, SessionStatus, ColumnBaseline, SchemaBaseline
+from app.models.session import VisualizationSession, SessionStatus
 from app.models.modification import CreationMetadata
+from app.services.schema_baseline import build_schema_baseline
 from app.storage import get_storage, StorageInterface
 
 logger = logging.getLogger(__name__)
@@ -122,30 +122,14 @@ class SessionManager:
         if not session:
             return False
 
-        columns_dict = {}
-        for col in session.columns:
-            if col.name and not col.name.lower().endswith('_excerpt'):
-                # Calculate checksum from definition + rationale + allowed_values
-                content = f"{col.definition or ''}{col.rationale or ''}"
-                if col.allowed_values:
-                    content += "|".join(sorted(col.allowed_values))
-                checksum = hashlib.md5(content.encode()).hexdigest()
-
-                columns_dict[col.name] = ColumnBaseline(
-                    name=col.name,
-                    definition=col.definition or "",
-                    rationale=col.rationale or "",
-                    allowed_values=col.allowed_values,
-                    checksum=checksum
-                )
-
-        session.schema_baseline = SchemaBaseline(
-            columns=columns_dict,
-            captured_at=datetime.now()
-        )
+        session.schema_baseline = build_schema_baseline(session.columns)
 
         self.update_session(session)
-        logger.debug(f"Captured schema baseline for session {session_id} with {len(columns_dict)} columns")
+        logger.debug(
+            "Captured schema baseline for session %s with %d columns",
+            session_id,
+            len(session.schema_baseline.columns),
+        )
         return True
 
     def finalize_creation(self, session_id: str, llm_model: str = "", llm_provider: str = "") -> bool:

--- a/backend/app/services/web_enrichment_service.py
+++ b/backend/app/services/web_enrichment_service.py
@@ -1,0 +1,343 @@
+"""Grounded web enrichment for columns that explicitly opt into web access."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Tuple
+
+from app.models.session import ColumnInfo
+from app.services.atomic_jsonl import write_jsonl_atomic
+from app.services.data_utils import (
+    _resolve_source_document,
+    extract_papers,
+    persist_session_data_file,
+    resolve_session_data_files,
+    row_name_of,
+)
+from app.services.session_manager import SessionManager
+from schematiq.value_extraction.config.prompts import (
+    SYSTEM_PROMPT_WEB_VALUE,
+    USER_PROMPT_WEB_VALUE,
+)
+from schematiq.value_extraction.core.json_parser import JSONResponseParser
+
+logger = logging.getLogger(__name__)
+
+CellCallback = Callable[[str, str, Any], Optional[Awaitable[None]]]
+
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.IGNORECASE | re.DOTALL)
+_IDENTIFYING_KEY_PARTS = (
+    "court",
+    "case",
+    "docket",
+    "jurisdiction",
+    "document",
+    "citation",
+)
+_CACHE_KEY_PARTS = ("court", "jurisdiction")
+
+
+def _cell_container(row: Dict[str, Any]) -> Dict[str, Any]:
+    data = row.get("data")
+    return data if isinstance(data, dict) else row
+
+
+def _answer(value: Any) -> Any:
+    if isinstance(value, dict) and "answer" in value:
+        return value.get("answer")
+    return value
+
+
+def _is_empty(value: Any) -> bool:
+    value = _answer(value)
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    return False
+
+
+def _text(value: Any) -> str:
+    value = _answer(value)
+    if value is None:
+        return ""
+    if isinstance(value, (str, int, float, bool)):
+        return str(value).strip()
+    return ""
+
+
+def _matches_scope(
+    row: Dict[str, Any],
+    documents: Optional[Iterable[str]],
+    rows: Optional[Iterable[str]],
+) -> bool:
+    if rows is not None and row_name_of(row) not in set(rows):
+        return False
+    if documents is None:
+        return True
+    wanted = {Path(str(value)).stem.lower() for value in documents}
+    source = Path(_resolve_source_document(row) or "").stem.lower()
+    papers = {
+        Path(str(value)).stem.lower()
+        for value in extract_papers(row)
+    }
+    return source in wanted or bool(papers & wanted)
+
+
+def _identifying_context(row: Dict[str, Any], excluded: Iterable[str]) -> str:
+    container = _cell_container(row)
+    excluded_names = {name.lower() for name in excluded}
+    parts: List[str] = []
+
+    source = _resolve_source_document(row)
+    if source:
+        parts.append(f"source_document={source}")
+
+    for key, value in container.items():
+        key_lower = str(key).lower()
+        if key_lower in excluded_names or key_lower.startswith("_"):
+            continue
+        if not any(part in key_lower for part in _IDENTIFYING_KEY_PARTS):
+            continue
+        rendered = _text(value)
+        if rendered:
+            parts.append(f"{key}={rendered[:240]}")
+        if len(parts) >= 6:
+            break
+    return "; ".join(parts)[:1000] or "No additional identifying context available"
+
+
+def _entity_cache_context(row: Dict[str, Any]) -> str:
+    """Stable disambiguator that still caches one entity across many cases."""
+    container = _cell_container(row)
+    parts = []
+    for key, value in container.items():
+        key_lower = str(key).lower()
+        if any(part in key_lower for part in _CACHE_KEY_PARTS):
+            rendered = _text(value)
+            if rendered:
+                parts.append(f"{key_lower}={rendered.lower()}")
+    if parts:
+        return "|".join(sorted(parts))
+
+    # Without a stable court/jurisdiction identifier, prefer correctness over
+    # cross-document cache hits: a namesake in another case must not reuse this
+    # entity's answer.
+    source = _resolve_source_document(row)
+    if source:
+        parts.append(f"source={Path(source).stem.lower()}")
+    for key, value in container.items():
+        key_lower = str(key).lower()
+        if "case" in key_lower or "docket" in key_lower:
+            rendered = _text(value)
+            if rendered:
+                parts.append(f"{key_lower}={rendered.lower()}")
+    return "|".join(sorted(parts))
+
+
+def _parse_grounded_value(text: str) -> Any:
+    candidate = text.strip()
+    match = _JSON_FENCE_RE.search(candidate)
+    if match:
+        candidate = match.group(1).strip()
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError:
+        start = candidate.find("{")
+        end = candidate.rfind("}")
+        if start < 0 or end <= start:
+            return None
+        try:
+            parsed = json.loads(candidate[start : end + 1])
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed.get("value")
+
+
+def _source_excerpts(sources: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    excerpts = []
+    for source in sources[:5]:
+        url = str(source.get("url") or "").strip()
+        if not url:
+            continue
+        title = str(source.get("title") or "Web source").strip()
+        excerpts.append({"text": f"{title}: {url}", "source": title})
+    return excerpts
+
+
+class WebEnrichmentService:
+    """Resolve opted-in cells with Gemini Google Search grounding."""
+
+    def __init__(self, session_manager: SessionManager):
+        self._session_manager = session_manager
+        self._parser = JSONResponseParser()
+
+    async def enrich_columns(
+        self,
+        session_id: str,
+        columns: List[ColumnInfo],
+        llm: Any,
+        *,
+        documents: Optional[List[str]] = None,
+        rows: Optional[List[str]] = None,
+        only_empty: bool = False,
+        should_stop: Optional[Callable[[], bool]] = None,
+        on_cell: Optional[CellCallback] = None,
+    ) -> Dict[str, int]:
+        """Enrich selected rows in-place and persist every changed data file.
+
+        ``document_then_web`` always fills only gaps left by document extraction.
+        ``web`` overwrites on a normal re-extraction and respects ``only_empty``
+        for targeted gap-fill requests.
+        """
+        data_files = await resolve_session_data_files(session_id)
+        if not data_files:
+            raise ValueError("No table rows are available for web enrichment.")
+
+        cache: Dict[Tuple[str, str, str], Optional[Dict[str, Any]]] = {}
+        stats = {"lookups": 0, "cache_hits": 0, "updated_cells": 0}
+        requested_names = [column.name for column in columns]
+        row_scope = set(rows) if rows is not None else None
+
+        for data_file in data_files:
+            file_rows = self._load_rows(data_file)
+            changed = False
+            for row in file_rows:
+                if should_stop and should_stop():
+                    if changed:
+                        write_jsonl_atomic(data_file, file_rows, ensure_ascii=False)
+                        await persist_session_data_file(session_id, data_file)
+                    return stats
+                if not _matches_scope(row, documents, row_scope):
+                    continue
+                entity_name = row_name_of(row)
+                if not entity_name:
+                    continue
+
+                container = _cell_container(row)
+                context = _identifying_context(row, requested_names)
+                cache_context = _entity_cache_context(row)
+                for column in columns:
+                    existing = container.get(column.name)
+                    fill_gaps_only = (
+                        only_empty
+                        or column.extraction_strategy == "document_then_web"
+                    )
+                    if fill_gaps_only and not _is_empty(existing):
+                        continue
+
+                    cache_key = (
+                        column.name,
+                        entity_name.strip().lower(),
+                        cache_context,
+                    )
+                    if cache_key in cache:
+                        cell = cache[cache_key]
+                        stats["cache_hits"] += 1
+                    else:
+                        stats["lookups"] += 1
+                        cell = await self._resolve_cell(
+                            llm, entity_name, context, column
+                        )
+                        cache[cache_key] = cell
+
+                    # A failed or ungrounded lookup never destroys an existing value.
+                    if cell is None:
+                        continue
+                    container[column.name] = dict(cell)
+                    status = row.get("_cell_status")
+                    if not isinstance(status, dict):
+                        status = {}
+                        row["_cell_status"] = status
+                    status[column.name] = "external_source"
+                    changed = True
+                    stats["updated_cells"] += 1
+
+                    if on_cell:
+                        result = on_cell(entity_name, column.name, dict(cell))
+                        if inspect.isawaitable(result):
+                            await result
+
+            if changed:
+                write_jsonl_atomic(data_file, file_rows, ensure_ascii=False)
+                await persist_session_data_file(session_id, data_file)
+
+        logger.info(
+            "[web-enrichment] session=%s lookups=%d cache_hits=%d updated_cells=%d",
+            session_id[:8],
+            stats["lookups"],
+            stats["cache_hits"],
+            stats["updated_cells"],
+        )
+        return stats
+
+    async def _resolve_cell(
+        self,
+        llm: Any,
+        entity_name: str,
+        context: str,
+        column: ColumnInfo,
+    ) -> Optional[Dict[str, Any]]:
+        allowed_values = (
+            json.dumps(column.allowed_values, ensure_ascii=False)
+            if column.allowed_values
+            else "none"
+        )
+        user_prompt = USER_PROMPT_WEB_VALUE.format(
+            entity_name=entity_name,
+            entity_context=context,
+            column_name=column.name,
+            column_definition=column.definition or f"Data field: {column.name}",
+            column_rationale=column.rationale or "none",
+            allowed_values=allowed_values,
+        )
+        text, sources = await asyncio.to_thread(
+            llm.generate_grounded,
+            [
+                {"role": "system", "content": SYSTEM_PROMPT_WEB_VALUE},
+                {"role": "user", "content": user_prompt},
+            ],
+            max_output_tokens=256,
+            # Do not pass response_schema here: Gemini 3.1 Flash-Lite supports
+            # each feature separately but currently rejects structured output
+            # combined with built-in tools. The strict JSON prompt is parsed below.
+        )
+        excerpts = _source_excerpts(sources)
+        if not excerpts:
+            return None
+
+        value = _parse_grounded_value(text)
+        if value is None or isinstance(value, (dict, list)):
+            return None
+        parsed = {
+            column.name: {
+                "answer": str(value).strip(),
+                "excerpts": [],
+            }
+        }
+        normalized, _unmatched = self._parser.postprocess(
+            parsed,
+            [column.name],
+            {column.name: column.allowed_values or []},
+        )
+        cell = normalized.get(column.name)
+        if not cell or _is_empty(cell):
+            return None
+        cell["excerpts"] = excerpts
+        return cell
+
+    @staticmethod
+    def _load_rows(path: Path) -> List[Dict[str, Any]]:
+        rows = []
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if line.strip():
+                    rows.append(json.loads(line))
+        return rows

--- a/backend/app/services/web_enrichment_service.py
+++ b/backend/app/services/web_enrichment_service.py
@@ -202,7 +202,7 @@ class WebEnrichmentService:
             raise ValueError("No table rows are available for web enrichment.")
 
         cache: Dict[Tuple[str, str, str], Optional[Dict[str, Any]]] = {}
-        stats = {"lookups": 0, "cache_hits": 0, "updated_cells": 0}
+        stats = {"lookups": 0, "cache_hits": 0, "updated_cells": 0, "model_knowledge_cells": 0}
         requested_names = [column.name for column in columns]
         row_scope = set(rows) if rows is not None else None
 
@@ -251,12 +251,17 @@ class WebEnrichmentService:
                     # A failed or ungrounded lookup never destroys an existing value.
                     if cell is None:
                         continue
-                    container[column.name] = dict(cell)
+                    cell_copy = dict(cell)
+                    container[column.name] = cell_copy
                     status = row.get("_cell_status")
                     if not isinstance(status, dict):
                         status = {}
                         row["_cell_status"] = status
-                    status[column.name] = "external_source"
+                    if cell_copy.get("_unverified"):
+                        status[column.name] = "model_knowledge"
+                        stats["model_knowledge_cells"] += 1
+                    else:
+                        status[column.name] = "external_source"
                     changed = True
                     stats["updated_cells"] += 1
 
@@ -270,11 +275,12 @@ class WebEnrichmentService:
                 await persist_session_data_file(session_id, data_file)
 
         logger.info(
-            "[web-enrichment] session=%s lookups=%d cache_hits=%d updated_cells=%d",
+            "[web-enrichment] session=%s lookups=%d cache_hits=%d updated_cells=%d unverified=%d",
             session_id[:8],
             stats["lookups"],
             stats["cache_hits"],
             stats["updated_cells"],
+            stats["model_knowledge_cells"],
         )
         return stats
 
@@ -310,9 +316,10 @@ class WebEnrichmentService:
             # combined with built-in tools. The strict JSON prompt is parsed below.
         )
         excerpts = _source_excerpts(sources)
-        if not excerpts:
-            return None
 
+        # A missing web source no longer discards the answer. The model's value
+        # is kept but flagged as unverified, so the UI can label it as "not from
+        # the document and not web-verified" (see _unverified below).
         value = _parse_grounded_value(text)
         if value is None or isinstance(value, (dict, list)):
             return None
@@ -330,7 +337,18 @@ class WebEnrichmentService:
         cell = normalized.get(column.name)
         if not cell or _is_empty(cell):
             return None
-        cell["excerpts"] = excerpts
+        if excerpts:
+            cell["excerpts"] = excerpts
+        else:
+            cell["excerpts"] = [{
+                "text": (
+                    "This value was provided by the model from its own knowledge. "
+                    "It was not found in the source documents and was not verified "
+                    "against a web source."
+                ),
+                "source": "Model knowledge (unverified)",
+            }]
+            cell["_unverified"] = True
         return cell
 
     @staticmethod

--- a/backend/tests/test_web_sourced_columns.py
+++ b/backend/tests/test_web_sourced_columns.py
@@ -1,0 +1,127 @@
+"""Focused tests for opt-in, grounded web column enrichment."""
+
+import hashlib
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from app.models.session import ColumnInfo
+import app.services.web_enrichment_service as web_module
+from app.services.reextraction_service import ReextractionService
+from app.services.schema_baseline import (
+    build_schema_baseline,
+    calculate_column_checksum,
+)
+from app.services.web_enrichment_service import WebEnrichmentService
+from schematiq.core.llm_backends import GeminiLLM
+
+
+def test_orchestration_wires_web_enrichment_to_reextraction():
+    from app.services import orchestration
+
+    assert (
+        orchestration.reextraction_service._web_enrichment_service
+        is orchestration.web_enrichment_service
+    )
+
+
+def test_column_strategy_is_backward_compatible_and_changes_checksum():
+    document = ColumnInfo(name="party", definition="Appointing party")
+    web = ColumnInfo(
+        name="party",
+        definition="Appointing party",
+        extraction_strategy="web",
+    )
+
+    legacy = hashlib.md5("Appointing party".encode()).hexdigest()
+    assert document.extraction_strategy == "document"
+    assert calculate_column_checksum(document) == legacy
+    assert calculate_column_checksum(web) != legacy
+
+    baseline = build_schema_baseline(
+        [document, ColumnInfo(name="party_excerpt", definition="Source excerpt")]
+    )
+    assert list(baseline.columns) == ["party"]
+    assert baseline.columns["party"].checksum == legacy
+
+
+def test_grounding_source_extraction_deduplicates_urls():
+    chunks = [
+        SimpleNamespace(web=SimpleNamespace(uri="https://example.com/a", title="A")),
+        SimpleNamespace(web=SimpleNamespace(uri="https://example.com/a", title="Again")),
+        SimpleNamespace(web=SimpleNamespace(uri="https://example.com/b", title="B")),
+    ]
+    candidate = SimpleNamespace(
+        grounding_metadata=SimpleNamespace(grounding_chunks=chunks)
+    )
+
+    assert GeminiLLM._extract_grounding_sources(candidate) == [
+        {"url": "https://example.com/a", "title": "A"},
+        {"url": "https://example.com/b", "title": "B"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_web_enrichment_caches_entity_and_writes_url_provenance(
+    tmp_path, monkeypatch
+):
+    data_file = tmp_path / "data.jsonl"
+    rows = [
+        {
+            "row_name": "Jane Doe",
+            "court": "Example Circuit",
+            "case": "Case One",
+            "data": {"party": None},
+        },
+        {
+            "row_name": "Jane Doe",
+            "court": "Example Circuit",
+            "case": "Case Two",
+            "data": {"party": None},
+        },
+    ]
+    data_file.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
+
+    async def resolve_files(_session_id):
+        return [data_file]
+
+    async def persist(_session_id, _path):
+        return None
+
+    monkeypatch.setattr(web_module, "resolve_session_data_files", resolve_files)
+    monkeypatch.setattr(web_module, "persist_session_data_file", persist)
+
+    class FakeLLM:
+        def __init__(self):
+            self.calls = 0
+
+        def generate_grounded(self, _prompt, **_kwargs):
+            self.calls += 1
+            return (
+                '{"value": "democratic"}',
+                [{"url": "https://example.com/source", "title": "Example"}],
+            )
+
+    llm = FakeLLM()
+    service = WebEnrichmentService(session_manager=SimpleNamespace())
+    column = ColumnInfo(
+        name="party",
+        definition="Appointing party",
+        allowed_values=["Democratic", "Republican"],
+        extraction_strategy="web",
+    )
+
+    stats = await service.enrich_columns("session", [column], llm)
+
+    saved = [json.loads(line) for line in data_file.read_text().splitlines()]
+    assert llm.calls == 1
+    assert stats == {"lookups": 1, "cache_hits": 1, "updated_cells": 2}
+    assert [row["data"]["party"]["answer"] for row in saved] == [
+        "Democratic",
+        "Democratic",
+    ]
+    assert all(row["_cell_status"]["party"] == "external_source" for row in saved)
+    assert "https://example.com/source" in saved[0]["data"]["party"]["excerpts"][0]["text"]

--- a/backend/tests/test_web_sourced_columns.py
+++ b/backend/tests/test_web_sourced_columns.py
@@ -118,10 +118,62 @@ async def test_web_enrichment_caches_entity_and_writes_url_provenance(
 
     saved = [json.loads(line) for line in data_file.read_text().splitlines()]
     assert llm.calls == 1
-    assert stats == {"lookups": 1, "cache_hits": 1, "updated_cells": 2}
+    assert stats == {"lookups": 1, "cache_hits": 1, "updated_cells": 2, "model_knowledge_cells": 0}
     assert [row["data"]["party"]["answer"] for row in saved] == [
         "Democratic",
         "Democratic",
     ]
     assert all(row["_cell_status"]["party"] == "external_source" for row in saved)
     assert "https://example.com/source" in saved[0]["data"]["party"]["excerpts"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_web_enrichment_keeps_ungrounded_value_flagged_unverified(
+    tmp_path, monkeypatch
+):
+    """When Google Search returns no sources, the model's value is still kept
+    but marked unverified (status=model_knowledge, cell._unverified=True)."""
+    data_file = tmp_path / "data.jsonl"
+    rows = [
+        {
+            "row_name": "Some Judge",
+            "court": "Example Circuit",
+            "case": "Case One",
+            "data": {"party": None},
+        }
+    ]
+    data_file.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
+
+    async def resolve_files(_session_id):
+        return [data_file]
+
+    async def persist(_session_id, _path):
+        return None
+
+    monkeypatch.setattr(web_module, "resolve_session_data_files", resolve_files)
+    monkeypatch.setattr(web_module, "persist_session_data_file", persist)
+
+    class UngroundedLLM:
+        def generate_grounded(self, _prompt, **_kwargs):
+            # A correct value but NO web sources (what flash-lite does for
+            # facts it answers from memory without searching).
+            return '{"value": "Republican"}', []
+
+    service = WebEnrichmentService(session_manager=SimpleNamespace())
+    column = ColumnInfo(
+        name="party",
+        definition="Appointing party",
+        allowed_values=["Democratic", "Republican"],
+        extraction_strategy="web",
+    )
+
+    stats = await service.enrich_columns("session", [column], UngroundedLLM())
+
+    saved = [json.loads(line) for line in data_file.read_text().splitlines()]
+    assert stats["updated_cells"] == 1
+    assert stats["model_knowledge_cells"] == 1
+    assert saved[0]["data"]["party"]["answer"] == "Republican"
+    assert saved[0]["data"]["party"]["_unverified"] is True
+    assert saved[0]["_cell_status"]["party"] == "model_knowledge"

--- a/frontend/src/components/DataTable/DataTable.tsx
+++ b/frontend/src/components/DataTable/DataTable.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
-import { Search, GripVertical, Loader2, AlertCircle, ExternalLink } from 'lucide-react';
+import { Search, GripVertical, Loader2, AlertCircle, ExternalLink, Globe } from 'lucide-react';
 import { useQuery } from 'react-query';
 import {
   DndContext,
@@ -94,6 +94,7 @@ interface ColumnInfoProp {
   display_name?: string;
   definition?: string;
   allowed_values?: string[];
+  extraction_strategy?: 'document' | 'web' | 'document_then_web';
 }
 
 interface DataTableProps {
@@ -250,24 +251,44 @@ const SortableHeaderCell: React.FC<SortableHeaderCellProps> = ({
 // Column header with optional definition tooltip.
 // `displayName` is the user's original typed label (preserved when it differs
 // from the sanitized canonical column key); fall back to formatting the key.
-const ColumnHeaderLabel: React.FC<{ column: string; displayName?: string; definition?: string }> = ({ column, displayName, definition }) => {
+const ColumnHeaderLabel: React.FC<{ column: string; displayName?: string; definition?: string; extractionStrategy?: 'document' | 'web' | 'document_then_web' }> = ({ column, displayName, definition, extractionStrategy }) => {
   const text = displayName || formatColumnName(column);
   const label = column.startsWith('_') && column !== '_unit_name'
     ? <Badge variant="outline">{text}</Badge>
     : text;
 
-  if (!definition) return <>{label}</>;
+  const webIcon = (extractionStrategy === 'web' || extractionStrategy === 'document_then_web')
+    ? (
+      <Tooltip delayDuration={300}>
+        <TooltipTrigger asChild>
+          <Globe className="inline-block h-3 w-3 ml-1 text-blue-500 align-baseline" />
+        </TooltipTrigger>
+        <TooltipContent side="bottom" align="start" className="max-w-xs px-3 py-2">
+          <p className="text-[13px] font-normal leading-snug">
+            {extractionStrategy === 'web'
+              ? 'Filled from web search.'
+              : 'Filled from the document, then web search for empty cells.'}
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    )
+    : null;
+
+  if (!definition) return <>{label}{webIcon}</>;
 
   return (
-    <Tooltip delayDuration={300}>
-      <TooltipTrigger asChild>
-        <span className="cursor-help underline decoration-dashed decoration-muted-foreground/40 underline-offset-4">{label}</span>
-      </TooltipTrigger>
-      <TooltipContent side="bottom" align="start" className="max-w-xs px-3 py-2">
-        <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70 mb-1.5">Definition</p>
-        <p className="text-[13px] font-normal leading-snug">{definition}</p>
-      </TooltipContent>
-    </Tooltip>
+    <>
+      <Tooltip delayDuration={300}>
+        <TooltipTrigger asChild>
+          <span className="cursor-help underline decoration-dashed decoration-muted-foreground/40 underline-offset-4">{label}</span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" align="start" className="max-w-xs px-3 py-2">
+          <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70 mb-1.5">Definition</p>
+          <p className="text-[13px] font-normal leading-snug">{definition}</p>
+        </TooltipContent>
+      </Tooltip>
+      {webIcon}
+    </>
   );
 };
 
@@ -1338,6 +1359,7 @@ const DataTable: React.FC<DataTableProps> = ({
                             column={frozenColumn}
                             displayName={columnInfo?.find(c => c.name === frozenColumn)?.display_name}
                             definition={columnInfo?.find(c => c.name === frozenColumn)?.definition}
+                            extractionStrategy={columnInfo?.find(c => c.name === frozenColumn)?.extraction_strategy}
                           />
                         </div>
                       </div>
@@ -1370,6 +1392,7 @@ const DataTable: React.FC<DataTableProps> = ({
                           column={column}
                           displayName={columnInfo?.find(c => c.name === column)?.display_name}
                           definition={columnInfo?.find(c => c.name === column)?.definition}
+                          extractionStrategy={columnInfo?.find(c => c.name === column)?.extraction_strategy}
                         />
                       </SortableHeaderCell>
                     ))}

--- a/frontend/src/components/DataTable/DataTable.tsx
+++ b/frontend/src/components/DataTable/DataTable.tsx
@@ -158,6 +158,7 @@ const CELL_STATUS_STYLES: Record<CellStatus, string> = {
   enriched: 'border-l-2 border-l-blue-400 bg-blue-50/40 dark:bg-blue-950/20',
   inferred: 'border-l-2 border-l-amber-400 bg-amber-50/40 dark:bg-amber-950/20',
   external_source: 'border-l-2 border-l-purple-400 bg-purple-50/40 dark:bg-purple-950/20',
+  model_knowledge: 'border-l-2 border-l-orange-400 bg-orange-50/40 dark:bg-orange-950/20',
   schematiq_original: '',
   schematiq_expanded: 'border-l-2 border-l-emerald-400 bg-emerald-50/40 dark:bg-emerald-950/20',
 };
@@ -1279,7 +1280,8 @@ const DataTable: React.FC<DataTableProps> = ({
         {(presentCellStatuses.has('novel_nes') ||
           presentCellStatuses.has('enriched') ||
           presentCellStatuses.has('inferred') ||
-          presentCellStatuses.has('external_source')) && (
+          presentCellStatuses.has('external_source') ||
+          presentCellStatuses.has('model_knowledge')) && (
           <div className="flex items-center gap-4 mb-3 text-xs text-muted-foreground">
             <span className="font-medium text-foreground/70">Cell provenance:</span>
             {presentCellStatuses.has('novel_nes') && (
@@ -1304,6 +1306,12 @@ const DataTable: React.FC<DataTableProps> = ({
               <span className="flex items-center gap-1.5">
                 <span className="inline-block w-2.5 h-2.5 rounded-sm bg-purple-400" />
                 External
+              </span>
+            )}
+            {presentCellStatuses.has('model_knowledge') && (
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-2.5 h-2.5 rounded-sm bg-orange-400" />
+                Model (unverified)
               </span>
             )}
           </div>

--- a/frontend/src/components/DataTable/UnitGroupedTable.tsx
+++ b/frontend/src/components/DataTable/UnitGroupedTable.tsx
@@ -94,6 +94,7 @@ const CELL_STATUS_STYLES: Record<CellStatus, string> = {
   enriched: 'border-l-2 border-l-blue-400 bg-blue-50/40 dark:bg-blue-950/20',
   inferred: 'border-l-2 border-l-amber-400 bg-amber-50/40 dark:bg-amber-950/20',
   external_source: 'border-l-2 border-l-purple-400 bg-purple-50/40 dark:bg-purple-950/20',
+  model_knowledge: 'border-l-2 border-l-orange-400 bg-orange-50/40 dark:bg-orange-950/20',
   schematiq_original: '',
   schematiq_expanded: 'border-l-2 border-l-emerald-400 bg-emerald-50/40 dark:bg-emerald-950/20',
 };
@@ -749,7 +750,8 @@ export const UnitGroupedTable: React.FC<UnitGroupedTableProps> = ({
         {(presentCellStatuses.has('novel_nes') ||
           presentCellStatuses.has('enriched') ||
           presentCellStatuses.has('inferred') ||
-          presentCellStatuses.has('external_source')) && (
+          presentCellStatuses.has('external_source') ||
+          presentCellStatuses.has('model_knowledge')) && (
           <div className="flex items-center gap-4 mb-3 text-xs text-muted-foreground">
             <span className="font-medium text-foreground/70">Cell provenance:</span>
             {presentCellStatuses.has('novel_nes') && (
@@ -774,6 +776,12 @@ export const UnitGroupedTable: React.FC<UnitGroupedTableProps> = ({
               <span className="flex items-center gap-1.5">
                 <span className="inline-block w-2.5 h-2.5 rounded-sm bg-purple-400" />
                 External
+              </span>
+            )}
+            {presentCellStatuses.has('model_knowledge') && (
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block w-2.5 h-2.5 rounded-sm bg-orange-400" />
+                Model (unverified)
               </span>
             )}
           </div>

--- a/frontend/src/components/SchemaEditor/ColumnDialog.tsx
+++ b/frontend/src/components/SchemaEditor/ColumnDialog.tsx
@@ -72,7 +72,8 @@ const ColumnDialog: React.FC<ColumnDialogProps> = ({
     rationale: '',
     new_name: '',
     allowed_values: [] as string[],
-    auto_expand_threshold: 2
+    auto_expand_threshold: 2,
+    extraction_strategy: 'document' as 'document' | 'web' | 'document_then_web'
   });
   const [newAllowedValue, setNewAllowedValue] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -89,7 +90,8 @@ const ColumnDialog: React.FC<ColumnDialogProps> = ({
           rationale: column.rationale || '',
           new_name: column.name,
           allowed_values: column.allowed_values || [],
-          auto_expand_threshold: column.auto_expand_threshold ?? 2
+          auto_expand_threshold: column.auto_expand_threshold ?? 2,
+          extraction_strategy: (column.extraction_strategy as 'document' | 'web' | 'document_then_web') || 'document'
         });
         // Auto-expand constraints section if column has allowed values
         setConstraintsOpen(!!(column.allowed_values && column.allowed_values.length > 0));
@@ -100,7 +102,8 @@ const ColumnDialog: React.FC<ColumnDialogProps> = ({
           rationale: '',
           new_name: '',
           allowed_values: [],
-          auto_expand_threshold: 2
+          auto_expand_threshold: 2,
+          extraction_strategy: 'document'
         });
         setConstraintsOpen(false);
       }
@@ -159,6 +162,7 @@ const ColumnDialog: React.FC<ColumnDialogProps> = ({
           definition: formData.definition.trim(),
           rationale: formData.rationale.trim() || undefined,
           allowed_values: formData.allowed_values.length > 0 ? formData.allowed_values : undefined,
+          extraction_strategy: formData.extraction_strategy,
         };
 
         // Include LLM config if API key is available
@@ -184,6 +188,7 @@ const ColumnDialog: React.FC<ColumnDialogProps> = ({
           rationale: formData.rationale.trim() || undefined,
           new_name: formData.new_name.trim() !== formData.name ? formData.new_name.trim() : undefined,
           allowed_values: formData.allowed_values,  // Send even if empty to allow clearing
+          extraction_strategy: formData.extraction_strategy,
           reprocess: false,  // Don't reprocess documents for metadata-only edits
         };
 
@@ -348,6 +353,31 @@ const ColumnDialog: React.FC<ColumnDialogProps> = ({
               disabled={loading}
               aria-required="false"
             />
+          </div>
+
+          {/* Value Source (extraction strategy) */}
+          <div className="space-y-2">
+            <Label htmlFor="extraction_strategy">Value Source</Label>
+            <Select
+              value={formData.extraction_strategy}
+              onValueChange={(value) => setFormData(prev => ({ ...prev, extraction_strategy: value as 'document' | 'web' | 'document_then_web' }))}
+            >
+              <SelectTrigger id="extraction_strategy">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="document">Document only (default)</SelectItem>
+                <SelectItem value="web">Web search</SelectItem>
+                <SelectItem value="document_then_web">Document, then web for gaps</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              {formData.extraction_strategy === 'document'
+                ? 'Values are extracted only from the attached documents.'
+                : formData.extraction_strategy === 'web'
+                ? 'Values are found with grounded web search. Requires a Gemini model.'
+                : 'The document is tried first; the web fills only cells the document leaves empty.'}
+            </p>
           </div>
 
           {/* Cluster Selection (only for add mode) */}

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -511,6 +511,23 @@ export function SpreadsheetSurface({
     });
   }, [data.rows]);
 
+  // Per-cell "unverified" flags: values that came from the model's own
+  // knowledge (web-sourced columns where no web source backed the answer),
+  // not from the document. Same physical-row indexing as dataGrounding above.
+  const dataUnverified = useMemo(() => {
+    return data.rows.map((row) => {
+      const perColumn: Record<string, boolean> = {};
+      const rowData = row.data || {};
+      for (const key of Object.keys(rowData)) {
+        const value = rowData[key] as { _unverified?: boolean } | undefined;
+        if (value && typeof value === 'object' && value._unverified) {
+          perColumn[key] = true;
+        }
+      }
+      return perColumn;
+    });
+  }, [data.rows]);
+
   const [groundingModal, setGroundingModal] = useState<{
     title: string;
     content: { answer: string; excerpts: CellGrounding['excerpts'] };
@@ -997,8 +1014,11 @@ export function SpreadsheetSurface({
     if (activeSheet === 'data' && column && dataConfirmedEmpty[row]?.[column.key]) {
       props.className = [props.className, 'cell-confirmed-empty'].filter(Boolean).join(' ');
     }
+    if (activeSheet === 'data' && column && dataUnverified[row]?.[column.key]) {
+      props.className = [props.className, 'cell-unverified'].filter(Boolean).join(' ');
+    }
     return props;
-  }, [activeSheet, cellFormats, dataConfirmedEmpty, dataGrounding, sheet]);
+  }, [activeSheet, cellFormats, dataConfirmedEmpty, dataGrounding, dataUnverified, sheet]);
 
   const prevFormatVersionRef = useRef(formatVersion);
 

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -74,6 +74,7 @@ export function SpreadsheetSurface({
   cellFormats,
   formatVersion,
   hotTableRef,
+  searchTermRef,
   onSelectionChange,
   onGroundingHighlight,
   onGroundingScrollRequest,
@@ -103,6 +104,11 @@ export function SpreadsheetSurface({
   cellFormats: CellFormatMap;
   formatVersion: number;
   hotTableRef: MutableRefObject<HotTableClass | null>;
+  // Active "Find in table" term, owned by the workspace (which drives the
+  // search). The grid re-applies it on every view render so the highlight
+  // survives unrelated re-renders, and clears it on Escape (see below). `null`
+  // when no search is active.
+  searchTermRef?: MutableRefObject<string | null>;
   onSelectionChange: (selection: SheetSelection) => void;
   // Reports all grounding excerpts of the newly selected data cell (or null when
   // the cell has no grounding), so the source panel can highlight them.
@@ -685,8 +691,30 @@ export function SpreadsheetSurface({
         stopPropagation: true,
         group: 'schematiq:formatting',
       });
+      // Escape clears the active "Find in table" search + its highlight, the way
+      // browsers and spreadsheets do. `runOnlyIf` gates it on there being an
+      // active search, so when nothing is being searched Escape keeps whatever
+      // default grid behaviour it would otherwise have. Lives in the 'grid'
+      // context, so it does not fire while a cell editor is open (Escape there
+      // still cancels the edit).
+      context.addShortcut({
+        keys: [['escape']],
+        callback: () => {
+          const active = hotTableRef.current?.hotInstance;
+          if (!active) return;
+          try {
+            if (searchTermRef) searchTermRef.current = null;
+            active.getPlugin('search').query('');
+            active.render();
+          } catch { /* instance may be mid-teardown */ }
+        },
+        runOnlyIf: () => Boolean(searchTermRef?.current),
+        preventDefault: true,
+        stopPropagation: true,
+        group: 'schematiq:search',
+      });
     } catch { /* instance may be mid-teardown or context unavailable */ }
-  }, [hotTableRef]);
+  }, [hotTableRef, searchTermRef]);
 
   // Runs after every render, but the identity guard makes it a no-op except on
   // the first render after a new grid instance appears. Deliberately without a
@@ -740,6 +768,34 @@ export function SpreadsheetSurface({
     filterInitInstanceRef.current = hot;
     markFilterSettingsInitOnly(hot);
   });
+
+  // Keep the "Find in table" highlight alive across re-renders.
+  //
+  // The Search plugin marks matches with transient `isSearchResult` cell meta
+  // that a plain render preserves, but a @handsontable/react re-render (which
+  // re-pushes the full settings through updateSettings) rebuilds it, so the
+  // yellow highlight silently vanished on the next unrelated re-render
+  // (selection, toast, background refresh poll) even though the query itself
+  // was never cleared. Re-applying the active query in `beforeViewRender` -- so
+  // the meta is set again before the cells paint -- restores it in the same
+  // render with no extra render() call (and thus no risk of a render loop). The
+  // reentrancy guard covers any nested render the plugin might trigger, and the
+  // work is skipped entirely when no search is active.
+  const reapplyingSearchRef = useRef(false);
+  const reapplySearchHighlight = useCallback(() => {
+    if (reapplyingSearchRef.current) return;
+    const term = searchTermRef?.current;
+    if (!term) return;
+    const hot = hotTableRef.current?.hotInstance;
+    if (!hot) return;
+    try {
+      const search = hot.getPlugin('search');
+      if (!search?.isEnabled?.()) return;
+      reapplyingSearchRef.current = true;
+      search.query(term);
+    } catch { /* instance may be mid-teardown */ }
+    finally { reapplyingSearchRef.current = false; }
+  }, [hotTableRef, searchTermRef]);
 
   // Renderer for the active grouping column: plain text plus a count badge on
   // the group's first row. With cells merged, only the top row of a group is
@@ -1720,6 +1776,9 @@ export function SpreadsheetSurface({
         // scroll position, so the compensation above lands on final values.
         afterScrollHorizontally={syncHeaderOverlayScroll}
         afterScrollVertically={syncHeaderOverlayScroll}
+        // Re-mark search matches before each paint so a wrapper re-render that
+        // rebuilt the cell meta does not drop the active Find highlight.
+        beforeViewRender={reapplySearchHighlight}
         afterViewRender={syncHeaderOverlayScroll}
         afterColumnSort={applyGroupMerges}
         afterFilter={applyGroupMerges}

--- a/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
+++ b/frontend/src/pages/Workspace/SpreadsheetSurface.tsx
@@ -876,6 +876,7 @@ export function SpreadsheetSurface({
       rationale: column.rationale || '',
       allowed_values: Array.isArray(column.allowed_values) ? column.allowed_values.join(', ') : '',
       auto_expand_threshold: column.auto_expand_threshold ?? '',
+      extraction_strategy: column.extraction_strategy || 'document',
     }));
   }, [schemaColumns]);
 
@@ -921,6 +922,14 @@ export function SpreadsheetSurface({
             width: 150,
             headerTooltip: SCHEMA_COLUMN_HEADER_TOOLTIPS.auto_expand_threshold,
           },
+          {
+            key: 'extraction_strategy',
+            label: 'source',
+            width: 170,
+            type: 'dropdown',
+            source: ['document', 'web', 'document_then_web'],
+            headerTooltip: SCHEMA_COLUMN_HEADER_TOOLTIPS.extraction_strategy,
+          },
         ],
       };
     }
@@ -956,12 +965,16 @@ export function SpreadsheetSurface({
         ...dataColumnNames.map((name) => {
           // Mirror the legacy DataTable header behaviour: the data column's
           // header explains itself with the schema definition on hover.
-          const definition = schemaColumns.find((c) => c.name === name)?.definition?.trim();
+          const schemaCol = schemaColumns.find((c) => c.name === name);
+          const definition = schemaCol?.definition?.trim();
+          const isWeb = schemaCol?.extraction_strategy === 'web' || schemaCol?.extraction_strategy === 'document_then_web';
           return {
             key: name,
-            label: columnDisplayLabel(name),
+            label: isWeb ? `${columnDisplayLabel(name)} \u{1F310}` : columnDisplayLabel(name),
             width: 190,
-            headerTooltip: definition || undefined,
+            headerTooltip: isWeb
+              ? `${definition ? definition + ' \u2014 ' : ''}Filled from web search.`
+              : (definition || undefined),
           };
         }),
       ],
@@ -1236,7 +1249,7 @@ export function SpreadsheetSurface({
 
       if (activeSheet === 'schema') {
         const existing = schemaColumns[rowIndex];
-        const editable = ['name', 'definition', 'rationale', 'allowed_values', 'auto_expand_threshold'];
+        const editable = ['name', 'definition', 'rationale', 'allowed_values', 'auto_expand_threshold', 'extraction_strategy'];
         if (!editable.includes(key)) continue;
 
         if (!existing && key === 'name' && String(newValue || '').trim()) {
@@ -1253,6 +1266,7 @@ export function SpreadsheetSurface({
             hot ? String(hot.getDataAtRowProp(rowIndex, field) ?? '') : '';
           const pendingRationale = readRowCell('rationale').trim();
           const pendingAllowedValues = parseAllowedValues(readRowCell('allowed_values'));
+          const pendingStrategy = readRowCell('extraction_strategy').trim();
 
           schemaAPI.addColumn(sessionId, {
             name: String(newValue).trim(),
@@ -1261,6 +1275,10 @@ export function SpreadsheetSurface({
             allowed_values:
               pendingAllowedValues && pendingAllowedValues.length > 0
                 ? pendingAllowedValues
+                : undefined,
+            extraction_strategy:
+              pendingStrategy === 'web' || pendingStrategy === 'document_then_web'
+                ? pendingStrategy
                 : undefined,
           })
             .then(() => {
@@ -1307,6 +1325,9 @@ export function SpreadsheetSurface({
           // Emptying the cell intentionally clears allowed_values; send [] so the
           // backend distinguishes "cleared" from "unchanged" (undefined is dropped by axios).
           request.allowed_values = parseAllowedValues(newValue) ?? [];
+        }
+        if (key === 'extraction_strategy') {
+          request.extraction_strategy = String(newValue || 'document');
         }
 
         const affectedColumn = key === 'name' ? String(newValue || '').trim() : existing.name;
@@ -1739,6 +1760,8 @@ export function SpreadsheetSurface({
           readOnly: column.readOnly,
           width: column.width,
           ...(column.renderer ? { renderer: column.renderer } : {}),
+          ...(column.type ? { type: column.type } : {}),
+          ...(column.source ? { source: column.source } : {}),
         }))}
         colHeaders={sheet.columns.map(formatSheetColHeader)}
         rowHeaders

--- a/frontend/src/pages/Workspace/Workspace.css
+++ b/frontend/src/pages/Workspace/Workspace.css
@@ -1088,6 +1088,25 @@
   pointer-events: none;
 }
 
+/* Web-sourced value that came from the model's own knowledge, not the document
+   and not a verified web source. Amber tint + corner label so it is clearly
+   distinguishable from document-extracted and truly web-grounded cells. */
+.workspace-hot .handsontable td.cell-unverified {
+  position: relative;
+  background-color: rgba(251, 191, 36, 0.10);
+}
+
+.workspace-hot .handsontable td.cell-unverified::after {
+  content: 'unverified';
+  position: absolute;
+  top: 1px;
+  right: 3px;
+  font-size: 9px;
+  line-height: 1;
+  color: #b45309;
+  pointer-events: none;
+}
+
 .workspace-hot .handsontable td.workspace-cell-font-inter {
   font-family: Inter, system-ui, sans-serif;
 }

--- a/frontend/src/pages/Workspace/constants.ts
+++ b/frontend/src/pages/Workspace/constants.ts
@@ -19,6 +19,8 @@ export const SCHEMA_COLUMN_HEADER_TOOLTIPS = {
     'Optional limits: categories (yes/no), numbers, ranges, or one saved date style per column. Leave empty for plain text.',
   auto_expand_threshold:
     'Automatically add new values to allowed_values when they appear in at least this many documents. Set to -1 to disable auto-expansion.',
+  extraction_strategy:
+    'Where values come from: document (only the attached documents), web (grounded web search), or document_then_web (documents first, web only for cells left empty).',
 } as const;
 
 export const SCHEMA_COLUMN_HEADER_INFO_ICON =

--- a/frontend/src/pages/Workspace/index.tsx
+++ b/frontend/src/pages/Workspace/index.tsx
@@ -137,6 +137,11 @@ function Workspace() {
   const { toast } = useToast();
   const importInputRef = useRef<HTMLInputElement | null>(null);
   const hotTableRef = useRef<HotTableClass | null>(null);
+  // Active "Find in table" term. Held in a ref (not state) because it is only
+  // read by the grid's beforeViewRender hook (to re-apply the highlight after
+  // re-renders) and cleared by the grid's Escape shortcut -- it never needs to
+  // trigger a React render itself. `null` when no search is active.
+  const activeSearchTermRef = useRef<string | null>(null);
   const [activeSheet, setActiveSheet] = useState<SheetId>('data');
   const [sessionMode, setSessionMode] = useState<WorkspaceSessionMode>(requestedMode);
   const [projectDialogOpen, setProjectDialogOpen] = useState(!sessionId);
@@ -1043,6 +1048,7 @@ function Workspace() {
     if (!term) return;
     const hot = hotTableRef.current?.hotInstance;
     if (!hot) return;
+    activeSearchTermRef.current = term;
     const results = hot.getPlugin('search').query(term);
     hot.render();
     if (results.length === 0) {
@@ -1229,6 +1235,7 @@ function Workspace() {
         cellFormats={cellFormats}
         formatVersion={formatVersion}
         hotTableRef={hotTableRef}
+        searchTermRef={activeSearchTermRef}
         onSelectionChange={updateSheetSelection}
         onGroundingHighlight={handleGroundingHighlight}
         onGroundingScrollRequest={() => setGroundingScrollNonce((n) => n + 1)}

--- a/frontend/src/pages/Workspace/types.ts
+++ b/frontend/src/pages/Workspace/types.ts
@@ -57,6 +57,10 @@ export type SheetColumn = {
   width?: number;
   readOnly?: boolean;
   headerTooltip?: string;
+  // Optional Handsontable cell type + fixed options (e.g. a dropdown whose
+  // source list constrains the value). Passed through to the grid settings.
+  type?: string;
+  source?: string[];
   // Optional Handsontable cell renderer (used for the observation-unit `field`
   // column, where the meaningful concepts live in the rows rather than the
   // headers). Typed loosely to avoid importing Handsontable's renderer types.

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -158,7 +158,7 @@ export interface VisualizationSession {
   observation_unit?: ObservationUnitInfo;  // What constitutes a single row
 }
 
-export type CellStatus = 'no_change' | 'novel_nes' | 'enriched' | 'inferred' | 'external_source' | 'schematiq_original' | 'schematiq_expanded';
+export type CellStatus = 'no_change' | 'novel_nes' | 'enriched' | 'inferred' | 'external_source' | 'model_knowledge' | 'schematiq_original' | 'schematiq_expanded';
 
 export interface DataRow {
   row_name?: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -498,6 +498,7 @@ export interface EditColumnRequest {
   rationale?: string;
   new_name?: string; // For renaming
   allowed_values?: string[]; // Closed set of valid values
+  extraction_strategy?: 'document' | 'web' | 'document_then_web'; // Where values come from
   reprocess?: boolean; // Whether to reprocess documents (default: true on backend, set false for metadata-only edits)
 }
 
@@ -507,6 +508,7 @@ export interface AddColumnRequest {
   rationale?: string;
   document_paths?: string[]; // Specific documents to process
   allowed_values?: string[]; // Closed set of valid values
+  extraction_strategy?: 'document' | 'web' | 'document_then_web'; // Where values come from
   llm_config?: {
     provider: string;
     model: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -64,6 +64,7 @@ export interface ColumnInfo {
   allowed_values?: string[];  // Closed set of valid values for categorical columns
   auto_expand_threshold?: number;  // Auto-add new value if seen in N+ docs (-1 = disabled)
   pending_values?: PendingValue[];  // Values pending approval
+  extraction_strategy?: 'document' | 'web' | 'document_then_web';
 }
 
 // Schema evolution tracking types
@@ -658,7 +659,7 @@ export interface SchemaEditingState {
 // Re-extraction types
 export interface ColumnChangeDetail {
   column_name: string;
-  change_type: 'definition' | 'rationale' | 'allowed_values' | 'new' | 'renamed';
+  change_type: 'definition' | 'rationale' | 'allowed_values' | 'extraction_strategy' | 'new' | 'renamed';
   old_value?: string;
   new_value?: string;
   row_count_affected: number;

--- a/schematiq-lib/schematiq/core/llm_backends.py
+++ b/schematiq-lib/schematiq/core/llm_backends.py
@@ -11,7 +11,7 @@ import os
 import time
 import random
 from abc import ABC, abstractmethod
-from typing import List, Dict, Any, Union, Optional
+from typing import List, Dict, Any, Union, Optional, Tuple
 import re
 
 import httpx
@@ -948,6 +948,120 @@ class GeminiLLM(LLMInterface):
                     break
 
         # Re-raise the last exception (GeminiLLM.generate)
+        raise last_exception
+
+    @staticmethod
+    def _extract_grounding_sources(candidate: Any) -> List[Dict[str, str]]:
+        """Return de-duplicated web sources from Gemini grounding metadata."""
+        metadata = getattr(candidate, "grounding_metadata", None)
+        chunks = getattr(metadata, "grounding_chunks", None) or []
+        sources: List[Dict[str, str]] = []
+        seen = set()
+        for chunk in chunks:
+            web = getattr(chunk, "web", None)
+            uri = getattr(web, "uri", None) if web is not None else None
+            if not uri or uri in seen:
+                continue
+            seen.add(uri)
+            sources.append({
+                "url": str(uri),
+                "title": str(getattr(web, "title", None) or uri),
+            })
+        return sources
+
+    def generate_grounded(
+        self,
+        prompt: Union[str, List[Dict[str, str]]],
+        **kwargs,
+    ) -> Tuple[str, List[Dict[str, str]]]:
+        """Generate with Google Search enabled and return text plus web sources.
+
+        This is deliberately separate from :meth:`generate`: ordinary document
+        extraction never receives a search tool, so its document-only guarantee
+        is enforced structurally rather than by prompt wording.
+        """
+        prompt_len = sum(
+            len(message.get("content", ""))
+            for message in (
+                prompt if isinstance(prompt, list) else [{"content": prompt}]
+            )
+        )
+        system_instruction = None
+        if isinstance(prompt, list):
+            system_parts = [m["content"] for m in prompt if m["role"] == "system"]
+            user_parts = [m["content"] for m in prompt if m["role"] != "system"]
+            if system_parts:
+                system_instruction = "\n\n".join(system_parts)
+            prompt_text = "\n\n".join(user_parts)
+        else:
+            prompt_text = prompt
+
+        if self.system_prefix:
+            system_instruction = (
+                f"{self.system_prefix}\n\n{system_instruction}"
+                if system_instruction
+                else self.system_prefix
+            )
+
+        config_kwargs = {
+            "max_output_tokens": kwargs.get("max_output_tokens", self.max_output_tokens),
+            "temperature": kwargs.get("temperature", self.temperature),
+            "safety_settings": self.safety_settings,
+            "tools": [self.types.Tool(google_search=self.types.GoogleSearch())],
+        }
+        if system_instruction:
+            config_kwargs["system_instruction"] = system_instruction
+        if kwargs.get("response_schema") is not None:
+            config_kwargs["response_mime_type"] = "application/json"
+            config_kwargs["response_schema"] = kwargs["response_schema"]
+        self._apply_thinking_config(config_kwargs, kwargs.get("thinking_budget"))
+        config = self.types.GenerateContentConfig(**config_kwargs)
+
+        max_retries = 3
+        last_exception = None
+        start_time = time.time()
+        for attempt in range(max_retries + 1):
+            try:
+                response = self._client.models.generate_content(
+                    model=self.model,
+                    contents=prompt_text,
+                    config=config,
+                )
+                if not response.candidates:
+                    return "", []
+                candidate = response.candidates[0]
+                if not candidate.content or not candidate.content.parts:
+                    return "", []
+
+                content = response.text.strip()
+                sources = self._extract_grounding_sources(candidate)
+                LLMCallTracker.get_instance().increment(
+                    model=self.model,
+                    prompt_length=prompt_len,
+                    completion_length=len(content),
+                )
+                return content, sources
+            except Exception as exc:
+                last_exception = exc
+                error_str = str(exc)
+                logger.exception(
+                    "Grounded Gemini call failed after %.1fs (model=%s, prompt_chars=%d)",
+                    time.time() - start_time,
+                    self.model,
+                    len(prompt_text),
+                )
+                if _is_invalid_api_key_error(exc):
+                    raise
+                if _is_rate_limit_error(exc) and attempt < max_retries:
+                    time.sleep(_extract_wait_time(exc))
+                    continue
+                if _is_retryable_server_error(exc) and attempt < max_retries:
+                    time.sleep(10 + random.randint(5, 15))
+                    continue
+                if "Invalid operation" in error_str and "finish_reason" in error_str:
+                    return "", []
+                break
+
         raise last_exception
 
     # ── Context Caching ──────────────────────────────────────────────

--- a/schematiq-lib/schematiq/value_extraction/config/prompts.py
+++ b/schematiq-lib/schematiq/value_extraction/config/prompts.py
@@ -437,3 +437,34 @@ For unit "GPT-4 on MMLU":
   }}
 }}
 """.strip()
+
+# ============================================================================
+# WEB-GROUNDED SINGLE-CELL EXTRACTION
+# ============================================================================
+
+SYSTEM_PROMPT_WEB_VALUE = """
+You are resolving one table cell from public web sources.
+
+Use Google Search to verify the value for the exact entity described by the
+entity name and identifying context. Do not answer from memory. If the entity
+is ambiguous, the sources conflict, or no reliable source supports the value,
+return null.
+
+Return only one JSON object with this shape and no markdown:
+{"value": <string or null>}
+""".strip()
+
+
+USER_PROMPT_WEB_VALUE = """
+Entity: {entity_name}
+Identifying context: {entity_context}
+
+Column: {column_name}
+Definition: {column_definition}
+Extraction guidance: {column_rationale}
+Allowed values / format constraint: {allowed_values}
+
+Find and verify the value for this entity. When allowed values are listed,
+return the matching value spelling. Return null when the fact cannot be
+verified for this exact entity.
+""".strip()


### PR DESCRIPTION
## Problem
Scoped re-extraction (used by "Fill empty cells") marks documents outside the requested scope with `known_units=[]`. `table_builder.py` still read each such document's full text from disk and fired `on_document_started` (advancing the doc-progress counter) *before* checking that list, immediately followed by an unconditional "🔍 Processing ... for observation units" log line that implies work is happening when the document is about to be skipped.

Separately, `total_documents` is overwritten to the observation-unit count once `known_units` is known (a document can hold more than one), but `on_document_started` always advanced the counter by exactly 1 per physical file — so a multi-unit document under-counted against the total, and force-skipped documents over-counted, producing a mismatched progress display (e.g. document_index exceeding total_documents).

## Solution
- `table_builder.py`: check `known_units` for the current paper *before* reading its text or invoking any callback. Force-skipped documents (`known_units[paper_title] == []`) are recorded via `SkippedDocument` and skipped immediately, with no file read and no misleading log line.
- `on_document_started` now takes an optional `unit_count` (default 1) and `table_builder.py` passes `len(paper_known_units)` for documents in scope, so the counter tracks units, not files, matching `total_documents`.
- Updated both real callback implementations (`reextraction_service.py`, `upload_document_processor.py`) and the `main.py` type hint to the new 2-arg signature.

## Verify
```
git apply --ignore-whitespace --check <patch>   # on a clean clone
python -m py_compile backend/app/services/reextraction_service.py backend/app/services/upload_document_processor.py schematiq-lib/schematiq/value_extraction/core/table_builder.py schematiq-lib/schematiq/value_extraction/main.py
```
No frontend files touched by this patch, so `tsc --noEmit" wasn't run for this PR.

Manual check: run "Fill empty cells" on 2 cells in a table with several other rows/documents already filled, and confirm the log no longer prints "🔍 Processing ... for observation units" for out-of-scope documents (only "⏭️ Skipping ..."), and that the reported document_index never exceeds total_documents during the run.