### PR TITLE
fix(reextraction): correct progress counting and skip I/O for scoped re-extraction

### DIFF
--- a/backend/app/services/reextraction_service.py
+++ b/backend/app/services/reextraction_service.py
@@ -1823,9 +1823,12 @@ class ReextractionService(WebSocketBroadcasterMixin):
             # Capture event loop before entering thread pool
             loop = asyncio.get_running_loop()
 
-            def on_document_started(paper_title: str):
-                """Fired once per source document file — drives the 'X of Y docs' counter."""
-                doc_index[0] += 1
+            def on_document_started(paper_title: str, unit_count: int = 1):
+                """Fired once per document entering extraction — drives the 'X of Y'
+                counter. ``unit_count`` lets a document that maps to several known
+                observation units advance the counter by more than 1, matching
+                total_documents once it's been expressed in units below."""
+                doc_index[0] += unit_count
                 operation.processed_documents = doc_index[0]
                 try:
                     asyncio.run_coroutine_threadsafe(

--- a/backend/app/services/upload_document_processor.py
+++ b/backend/app/services/upload_document_processor.py
@@ -57,9 +57,14 @@ class UploadDocumentProcessor(WebSocketBroadcasterMixin):
         """
         doc_index = [0]  # counts source files, incremented by on_document_started
 
-        def on_document_started(paper_title: str):
-            """Called once per source document file before extraction begins."""
-            doc_index[0] += 1
+        def on_document_started(paper_title: str, unit_count: int = 1):
+            """Called once per source document file before extraction begins.
+
+            This flow never passes known_units, so unit_count is always 1 here;
+            the parameter exists because the library calls every on_document_started
+            callback with (paper_title, unit_count).
+            """
+            doc_index[0] += unit_count
             try:
                 asyncio.run_coroutine_threadsafe(
                     self.websocket_manager.broadcast_to_session(session_id, {

--- a/schematiq-lib/schematiq/value_extraction/core/table_builder.py
+++ b/schematiq-lib/schematiq/value_extraction/core/table_builder.py
@@ -13,7 +13,7 @@ from schematiq.core.schema import Schema
 from schematiq.core.llm_backends import LLMInterface
 from schematiq.core.results import SkippedDocument
 from schematiq.core.config import config as lib_config
-from schematiq.value_extraction.config.messages import skipped_summary, DEFAULT_SKIP_REASON
+from schematiq.value_extraction.config.messages import skipped_summary, DEFAULT_SKIP_REASON, NO_KNOWN_UNITS
 
 from .paper_processor import (
     PaperProcessor,
@@ -38,7 +38,7 @@ class TableBuilder:
                  on_unit_row_written: Optional[OnUnitRowWrittenCallback] = None,
                  should_stop: Optional[ShouldStopCallback] = None,
                  on_warning: Optional[OnWarningCallback] = None,
-                 on_document_started: Optional[Callable[[str], None]] = None,
+                 on_document_started: Optional[Callable[[str, int], None]] = None,
                  write_skip_rationale_artifact: Optional[bool] = None,
                  reference_context: Optional[str] = None):
         self.llm = llm
@@ -435,21 +435,41 @@ class TableBuilder:
             if paper in processed_papers:
                 continue
 
+            paper_title = paper.stem
+            source_dir = doc_to_source.get(paper, paper.parent)
+
+            # Scoped re-extraction marks a document with known_units=[] when none
+            # of its observation units are in scope for this run. Skip it here,
+            # before touching the file or firing progress callbacks -- reading
+            # the full text and reporting "processing" for a document we are
+            # about to discard wastes I/O and misleads progress/log output.
+            if known_units is not None and paper_title in known_units and not known_units[paper_title]:
+                self._skipped_documents.append(
+                    SkippedDocument(document=paper_title, reason=NO_KNOWN_UNITS)
+                )
+                print(f"⏭️  Skipping {paper_title}: not in scope for this run")
+                processed_papers.add(paper)
+                continue
+
             try:
                 paper_text = paper.read_text(encoding="utf-8", errors="ignore")
-                paper_title = paper.stem
-                source_dir = doc_to_source.get(paper, paper.parent)
+                paper_known_units = known_units.get(paper_title) if known_units else None
 
                 if self.on_document_started:
                     try:
-                        self.on_document_started(paper_title)
+                        # Advance the progress counter by the number of observation
+                        # units this document actually contributes, not by 1 file --
+                        # a document can hold more than one known unit, and the
+                        # caller expresses total_documents in units once known_units
+                        # is in play (see reextraction_service._run_reextraction).
+                        unit_count_hint = len(paper_known_units) if paper_known_units else 1
+                        self.on_document_started(paper_title, unit_count_hint)
                     except Exception:
                         pass
 
                 print(f"🔍 Processing {paper_title} for observation units ({observation_unit.name})...")
 
                 # Extract values with observation units (may return multiple rows)
-                paper_known_units = known_units.get(paper_title) if known_units else None
                 paper_unit_targets = unit_targets_by_paper.get(paper_title) if unit_targets_by_paper else None
                 extraction_result = self.paper_processor.extract_values_for_paper_with_units(
                     paper_title=paper_title,

--- a/schematiq-lib/schematiq/value_extraction/main.py
+++ b/schematiq-lib/schematiq/value_extraction/main.py
@@ -38,7 +38,7 @@ def build_table_jsonl(
     on_warning: Optional[OnWarningCallback] = None,
     known_units: Optional[Dict[str, List[str]]] = None,
     unit_targets_by_paper: Optional[Dict[str, Dict[str, Any]]] = None,
-    on_document_started: Optional[Callable[[str], None]] = None,
+    on_document_started: Optional[Callable[[str, int], None]] = None,
     write_skip_rationale_artifact: Optional[bool] = None,
     reference_context: Optional[str] = None,
 ) -> Dict[str, Any]:


### PR DESCRIPTION
## Problem
Scoped re-extraction (used by "Fill empty cells") marks documents outside the requested scope with `known_units=[]`. `table_builder.py` still read each such document's full text from disk and fired `on_document_started` (advancing the doc-progress counter) *before* checking that list, immediately followed by an unconditional "🔍 Processing ... for observation units" log line that implies work is happening when the document is about to be skipped.

Separately, `total_documents` is overwritten to the observation-unit count once `known_units` is known (a document can hold more than one), but `on_document_started` always advanced the counter by exactly 1 per physical file — so a multi-unit document under-counted against the total, and force-skipped documents over-counted, producing a mismatched progress display.

## Solution
- `table_builder.py`: check `known_units` for the current paper *before* reading its text or invoking any callback. Force-skipped documents are recorded via `SkippedDocument` and skipped immediately, with no file read and no misleading log line.
- `on_document_started` now takes an optional `unit_count` (default 1) and `table_builder.py` passes `len(paper_known_units)` for documents in scope, so the counter tracks units, not files.
- Updated both real callback implementations (`reextraction_service.py`, `upload_document_processor.py`) and the `main.py` type hint to the new 2-arg signature.

## Verify
```
git apply --ignore-whitespace --check <patch>   # on a clean clone
python -m py_compile backend/app/services/reextraction_service.py backend/app/services/upload_document_processor.py schematiq-lib/schematiq/value_extraction/core/table_builder.py schematiq-lib/schematiq/value_extraction/main.py
```
No frontend files touched, so tsc wasn't run for this PR.

Manual check: run "Fill empty cells" on 2 cells and confirm out-of-scope documents log "⏭️ Skipping ..." (not "🔍 Processing ..."), with no file read for them, and document_index never exceeds total_documents during the run.